### PR TITLE
feat: Phase 4 — self-improving skill system

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,6 +27,9 @@ TELEGRAM_ALLOWED_USER_IDS=
 LIFE_CONTEXT_PATH=docs/LIFE_CONTEXT.md
 OWNER_NAME=Your Name
 
+# Owner's timezone (IANA name — https://en.wikipedia.org/wiki/List_of_tz_database_time_zones)
+TIMEZONE=America/Los_Angeles
+
 # Query depth (default: true — every message does full proactive fetch)
 # Set to false to re-enable light/heavy classification and skip fetches on greetings/chit-chat
 ALWAYS_HEAVY=true

--- a/agent/briefs.py
+++ b/agent/briefs.py
@@ -1,3 +1,9 @@
+"""Commitment extraction for live conversation turns.
+
+BriefFormatter has been removed — morning brief, weekly review, and commitment
+check are now generated via pepper.chat() guided by skill files in skills/.
+"""
+
 import re
 import json
 import structlog
@@ -30,7 +36,6 @@ class CommitmentExtractor:
         if not self.has_commitment_language(text):
             return []
         if not self._llm:
-            # Fallback: return raw matches
             return [{"text": text, "type": "promise", "detected_at": datetime.utcnow().isoformat()}]
         try:
             result = await self._llm.chat(
@@ -48,7 +53,6 @@ class CommitmentExtractor:
                 model=f"local/{self._llm.config.DEFAULT_LOCAL_MODEL}"
             )
             content = result.get("content", "[]").strip()
-            # Extract JSON array from response
             match = re.search(r'\[.*\]', content, re.DOTALL)
             if match:
                 items = json.loads(match.group())
@@ -58,56 +62,3 @@ class CommitmentExtractor:
         except Exception as e:
             logger.warning("commitment_extraction_failed", error=str(e))
         return []
-
-
-class BriefFormatter:
-    """Formats morning brief and weekly review into clean markdown."""
-
-    @staticmethod
-    def format_morning_brief(
-        date: str,
-        calendar_summary: str,
-        open_loops: list[dict],
-        commitments: list[dict],
-    ) -> str:
-        lines = [f"**Good morning — {date}**\n"]
-
-        if calendar_summary and calendar_summary.strip():
-            lines.append("📅 **Today**")
-            lines.append(calendar_summary)
-            lines.append("")
-
-        if open_loops:
-            lines.append("🔄 **Open loops**")
-            for item in open_loops[:5]:
-                lines.append(f"• {item.get('content', '')[:120]}")
-            lines.append("")
-
-        if commitments:
-            lines.append("✅ **Pending commitments**")
-            for item in commitments[:5]:
-                lines.append(f"• {item.get('content', '')[:120]}")
-            lines.append("")
-
-        if not open_loops and not commitments and not calendar_summary:
-            lines.append("Nothing urgent on the radar. Good day to work on something that matters.")
-
-        return "\n".join(lines)
-
-    @staticmethod
-    def format_weekly_review(week_label: str, memories: list, commitments: list) -> str:
-        lines = [f"**Weekly Review — {week_label}**\n"]
-
-        if memories:
-            lines.append("📝 **This week in memory**")
-            for m in memories[:8]:
-                lines.append(f"• {m.content[:120] if hasattr(m, 'content') else str(m)[:120]}")
-            lines.append("")
-
-        if commitments:
-            lines.append("⏳ **Unresolved commitments**")
-            for c in commitments[:5]:
-                lines.append(f"• {c.get('content', '')[:120]}")
-            lines.append("")
-
-        return "\n".join(lines)

--- a/agent/calendar_tools.py
+++ b/agent/calendar_tools.py
@@ -8,10 +8,11 @@ Follows the same pattern as web_search.py / routing.py:
 from __future__ import annotations
 
 import asyncio
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 from typing import Any
 
 import structlog
+from agent.query_intents import CALENDAR_QUERY_TERMS, infer_calendar_days, is_source_query
 
 logger = structlog.get_logger()
 
@@ -333,24 +334,13 @@ async def execute_list_calendars() -> dict:
         return {"error": f"Could not list calendars: {e}"}
 
 
-_CALENDAR_TRIGGERS = (
-    "calendar", "schedule", "meeting", "event", "appointment",
-    "today", "tomorrow", "this week", "next week", "coming up",
-    "what do i have", "what's on", "what is on", "availability",
-    "free", "busy", "when am i", "do i have anything",
-)
-
-
 async def maybe_get_calendar_context(user_message: str) -> str:
     """Proactively inject upcoming events when the query is schedule-related."""
-    lower = user_message.lower()
-    if not any(t in lower for t in _CALENDAR_TRIGGERS):
+    if not is_source_query(user_message, CALENDAR_QUERY_TERMS, extra_terms=("today", "tomorrow", "this week", "next week", "coming up")):
         return ""
 
     # Determine look-ahead window from message
-    days = 1 if any(w in lower for w in ("today", "tonight")) else \
-           2 if "tomorrow" in lower else \
-           14 if "next week" in lower else 7
+    days = infer_calendar_days(user_message, default=7)
 
     try:
         result = await execute_get_upcoming_events({"days": days})

--- a/agent/config.py
+++ b/agent/config.py
@@ -37,6 +37,9 @@ class Settings(BaseSettings):
     LIFE_CONTEXT_PATH: str = "docs/LIFE_CONTEXT.md"
     OWNER_NAME: str = "the owner"
 
+    # Timezone (IANA name, e.g. "America/Los_Angeles", "America/New_York")
+    TIMEZONE: str = "America/Los_Angeles"
+
     # Query depth — set ALWAYS_HEAVY=false in .env to re-enable light/heavy
     # classification (saves a local LLM call on greetings/chit-chat).
     # Default is True: every message goes through the full proactive fetch path.

--- a/agent/core.py
+++ b/agent/core.py
@@ -5,6 +5,8 @@ import json
 import re
 import time
 import structlog
+from datetime import datetime
+from zoneinfo import ZoneInfo
 from agent.config import Settings
 from agent.llm import ModelClient
 from agent.life_context import build_system_prompt, get_owner_name, update_life_context
@@ -15,6 +17,8 @@ from agent.models import Conversation
 from agent.briefs import CommitmentExtractor
 from agent.context_compressor import ContextCompressor
 from agent.error_classifier import ClassifiedLLMError, ErrorCategory
+from agent.skills import load_skills, SkillMatcher
+from agent.skill_reviewer import SkillReviewer
 from agent.web_search import brave_search, brave_image_search
 from agent.routing import get_driving_time
 from agent.calendar_tools import (
@@ -28,10 +32,13 @@ from agent.email_tools import (
     EMAIL_TOOLS,
     execute_get_recent_emails,
     execute_get_email_action_items,
+    execute_get_email_summary,
     execute_search_emails,
     execute_get_email_unread_counts,
     detect_email_account_scope,
+    detect_email_time_window_hours,
     is_email_action_items_query,
+    is_email_summary_query,
     maybe_get_email_context,
 )
 from agent.imessage_tools import (
@@ -93,7 +100,7 @@ IMAGE_TOOLS = [
 
 
 class PepperCore:
-    def __init__(self, config: Settings, db_session_factory=None):
+    def __init__(self, config: Settings, db_session_factory=None, skills_dir=None):
         self.config = config
         self.db_factory = db_session_factory
         self.llm = ModelClient(config)
@@ -111,6 +118,11 @@ class PepperCore:
         )
         self._scheduler = None
         self._sessions_loaded: set[str] = set()  # tracks which sessions have had history reloaded
+
+        # Phase 4: skill system
+        _skills = load_skills(skills_dir=skills_dir)
+        self._skill_matcher = SkillMatcher(_skills)
+        self._skill_reviewer = SkillReviewer(self.llm, _skills, config)
 
     @staticmethod
     def _normalize_user_text(text: str) -> str:
@@ -176,6 +188,42 @@ class PepperCore:
             lines = [f"I found {len(action_items)} likely action item(s) in {scope_text}:"]
             for item in action_items:
                 lines.append(f"- {item['formatted']}")
+            response = "\n".join(lines)
+
+        if warnings:
+            response += "\n\nWarnings: " + "; ".join(warnings)
+        return response
+
+    @staticmethod
+    def _format_email_summary_response(result: dict, account_scope: str) -> str:
+        if "error" in result:
+            return f"I couldn't scan your email inboxes: {result['error']}"
+
+        warnings = result.get("warnings", [])
+        emails = result.get("emails", [])
+        important = result.get("important", [])
+        hours = result.get("hours", 24)
+        scope_text = (
+            "your inboxes"
+            if account_scope == "all"
+            else f"your {account_scope} inbox"
+        )
+
+        if not emails:
+            response = f"I don't see any emails in {scope_text} from the last {hours} hours."
+        else:
+            lines = [f"I found {len(emails)} email(s) in {scope_text} from the last {hours} hours."]
+            if important:
+                lines.append("")
+                lines.append("Most important:")
+                for item in important:
+                    lines.append(f"- {item['formatted']}")
+            else:
+                lines.append("")
+                lines.append("Nothing looks especially urgent from the subject lines and snippets.")
+                lines.append("Recent messages:")
+                for item in emails[:5]:
+                    lines.append(f"- {item['formatted']}")
             response = "\n".join(lines)
 
         if warnings:
@@ -309,6 +357,7 @@ class PepperCore:
         progress_callback=None,
         heavy: bool | None = None,
         channel: str = "",
+        isolated: bool = False,
     ) -> str:
         """Main conversation entry point.
 
@@ -320,6 +369,11 @@ class PepperCore:
 
         channel: the interface the user is messaging from (e.g. "Telegram", "HTTP API").
         Injected into the system prompt so the model knows its context.
+
+        isolated: when True, this turn does NOT touch the shared working-memory
+        deque — no session history is loaded, no user/assistant turns are appended.
+        Use for scheduler/automation calls so they never bleed into user sessions
+        and concurrent user turns are never overwritten.
         """
         started_at = time.perf_counter()
         chat_logger = logger.bind(session_id=session_id, channel=channel or "HTTP API")
@@ -346,31 +400,37 @@ class PepperCore:
                 except Exception:
                     pass
 
-        # Reload conversation history from DB on first use after a restart
-        if session_id not in self._sessions_loaded:
-            chat_logger.info("session_history_reload_requested")
-            self._sessions_loaded.add(session_id)
-            await self._reload_session_history(session_id)
-        else:
-            chat_logger.debug("session_history_reload_skipped", reason="already_loaded")
+        # Reload conversation history from DB on first use after a restart.
+        # Skipped for isolated calls — they start fresh with no prior turns.
+        if not isolated:
+            if session_id not in self._sessions_loaded:
+                chat_logger.info("session_history_reload_requested")
+                self._sessions_loaded.add(session_id)
+                await self._reload_session_history(session_id)
+            else:
+                chat_logger.debug("session_history_reload_skipped", reason="already_loaded")
 
-        # Add to working memory
-        self.memory.add_to_working_memory("user", user_message)
-        chat_logger.info(
-            "working_memory_user_added",
-            working_memory_size=len(self.memory._working),
-            user_preview=self._preview_text(user_message, 180),
-        )
+        # Add to working memory (skipped for isolated scheduler/automation calls so
+        # those turns never appear in later user sessions).
+        if not isolated:
+            self.memory.add_to_working_memory("user", user_message)
+            chat_logger.info(
+                "working_memory_user_added",
+                working_memory_size=len(self.memory._working),
+                user_preview=self._preview_text(user_message, 180),
+            )
 
         identity_response = self._answer_identity_question(user_message)
         if identity_response is not None:
-            self.memory.add_to_working_memory("assistant", identity_response)
+            if not isolated:
+                self.memory.add_to_working_memory("assistant", identity_response)
             chat_logger.info(
                 "identity_short_circuit",
                 response_preview=self._preview_text(identity_response, 180),
             )
             chat_logger.info("chat_out", text=identity_response[:1000])
-            await self._save_conversation(session_id, user_message, identity_response)
+            if not isolated:
+                await self._save_conversation(session_id, user_message, identity_response)
             chat_logger.info(
                 "chat_complete",
                 path="identity",
@@ -415,12 +475,40 @@ class PepperCore:
                 result=self._summarize_tool_result(result),
             )
             response_text = self._format_email_action_items_response(result, account_scope)
-            self.memory.add_to_working_memory("assistant", response_text)
+            if not isolated:
+                self.memory.add_to_working_memory("assistant", response_text)
             chat_logger.info("chat_out", text=response_text[:1000])
-            await self._save_conversation(session_id, user_message, response_text)
+            if not isolated:
+                await self._save_conversation(session_id, user_message, response_text)
             chat_logger.info(
                 "chat_complete",
                 path="email_action_items",
+                duration_ms=round((time.perf_counter() - started_at) * 1000),
+            )
+            return response_text
+
+        if heavy and is_email_summary_query(user_message):
+            await _progress("Scanning recent emails...")
+            account_scope = detect_email_account_scope(user_message)
+            hours = detect_email_time_window_hours(user_message)
+            result = await execute_get_email_summary(
+                {"account": account_scope, "count": 10, "hours": hours}
+            )
+            chat_logger.info(
+                "email_summary_result",
+                account_scope=account_scope,
+                hours=hours,
+                result=self._summarize_tool_result(result),
+            )
+            response_text = self._format_email_summary_response(result, account_scope)
+            if not isolated:
+                self.memory.add_to_working_memory("assistant", response_text)
+            chat_logger.info("chat_out", text=response_text[:1000])
+            if not isolated:
+                await self._save_conversation(session_id, user_message, response_text)
+            chat_logger.info(
+                "chat_complete",
+                path="email_summary",
                 duration_ms=round((time.perf_counter() - started_at) * 1000),
             )
             return response_text
@@ -438,9 +526,11 @@ class PepperCore:
                 response_text = f"I couldn't scan your WhatsApp chats: {result['error']}"
             else:
                 response_text = result["summary"]
-            self.memory.add_to_working_memory("assistant", response_text)
+            if not isolated:
+                self.memory.add_to_working_memory("assistant", response_text)
             chat_logger.info("chat_out", text=response_text[:1000])
-            await self._save_conversation(session_id, user_message, response_text)
+            if not isolated:
+                await self._save_conversation(session_id, user_message, response_text)
             chat_logger.info(
                 "chat_complete",
                 path="whatsapp_attention",
@@ -461,9 +551,11 @@ class PepperCore:
                 response_text = f"I couldn't scan your iMessages: {result['error']}"
             else:
                 response_text = result["summary"]
-            self.memory.add_to_working_memory("assistant", response_text)
+            if not isolated:
+                self.memory.add_to_working_memory("assistant", response_text)
             chat_logger.info("chat_out", text=response_text[:1000])
-            await self._save_conversation(session_id, user_message, response_text)
+            if not isolated:
+                await self._save_conversation(session_id, user_message, response_text)
             chat_logger.info(
                 "chat_complete",
                 path="imessage_attention",
@@ -475,8 +567,9 @@ class PepperCore:
             # For follow-up questions ("what's the second priority?") the
             # current turn often won't match keyword triggers on its own.
             # Concatenate the previous user turn so trigger heuristics inherit
-            # context from the parent question.
-            history_for_triggers = self.memory.get_working_memory(limit=6)
+            # context from the parent question.  Isolated calls have no prior
+            # turns, so history_for_triggers is empty.
+            history_for_triggers = [] if isolated else self.memory.get_working_memory(limit=6)
             prior_user_turns = [m["content"] for m in history_for_triggers if m.get("role") == "user"][-3:-1]
             trigger_text = " ".join(prior_user_turns + [user_message])
 
@@ -542,7 +635,9 @@ class PepperCore:
         )
 
         # Build system prompt, optionally augmented with recalled context
-        system = self._system_prompt
+        tz = ZoneInfo(self.config.TIMEZONE)
+        now_local = datetime.now(tz)
+        system = f"[Current time: {now_local.strftime('%A, %B %-d, %Y at %-I:%M %p')} {now_local.tzname()} ({self.config.TIMEZONE})]\n\n" + self._system_prompt
         if channel:
             system = f"[Interface: You are responding via {channel}.]\n\n" + system
         if memory_context:
@@ -614,9 +709,46 @@ class PepperCore:
             )
             await _progress("Synthesizing response...")
 
+        # Phase 4.2: inject matching skill workflows into the system prompt.
+        # Skills are guidance, not mandates — the model follows them when relevant.
+        matched_skills = self._skill_matcher.match(user_message)
+        if matched_skills:
+            system = self._skill_matcher.inject_into_prompt(system, user_message)
+            # Honor skill model declarations: upgrade to frontier when any matched
+            # skill requires it.  Only applies on the heavy path — the fast path
+            # is intentionally local-only to avoid latency and cost on quick queries.
+            #
+            # Privacy guard: the heavy path injects raw personal data (email,
+            # iMessage, WhatsApp, Slack) into the system prompt, so frontier
+            # upgrades are blocked whenever any of those contexts is non-empty.
+            # Frontier models must never receive raw personal content.
+            if heavy and any(s.model == "frontier" for s in matched_skills):
+                has_raw_personal = any([
+                    email_context, imessage_context, whatsapp_context, slack_context
+                ])
+                if has_raw_personal:
+                    chat_logger.warning(
+                        "model_upgrade_blocked_raw_personal",
+                        skills=[s.name for s in matched_skills if s.model == "frontier"],
+                    )
+                else:
+                    frontier_model = self.config.DEFAULT_FRONTIER_MODEL
+                    if frontier_model != model:
+                        model = frontier_model
+                        chat_logger.info(
+                            "model_upgraded_for_skill",
+                            new_model=model,
+                            skills=[s.name for s in matched_skills if s.model == "frontier"],
+                        )
+            chat_logger.info(
+                "skills_injected",
+                names=[s.name for s in matched_skills],
+                message_preview=user_message[:80],
+            )
+
         # Working memory already includes the user message we just added.
-        # Use it as the full message history (up to 20 turns).
-        history = self.memory.get_working_memory(limit=20)
+        # Isolated calls have no shared history — use an empty list.
+        history = [] if isolated else self.memory.get_working_memory(limit=20)
         messages = [{"role": "system", "content": system}] + history
         chat_logger.info(
             "llm_messages_prepared",
@@ -639,6 +771,7 @@ class PepperCore:
         # model still overflowed) triggers a forced compress + single retry.  All
         # other errors surface a user-friendly message and abort the turn.
         response_text = ""
+        tool_calls: list = []  # populated below; kept in scope for the skill reviewer
         try:
             chat_logger.info("llm_dispatch", model=model, n_messages=len(messages), tool_count=len(tools))
             result = await self.llm.chat(messages, tools=tools or None, model=model)
@@ -735,18 +868,38 @@ class PepperCore:
                 "Try asking a more specific question, or start a fresh conversation."
             )
 
-        # Add assistant response to working memory
-        self.memory.add_to_working_memory("assistant", response_text)
-        chat_logger.info(
-            "working_memory_assistant_added",
-            working_memory_size=len(self.memory._working),
-            response_preview=self._preview_text(response_text, 180),
-        )
+        # Add assistant response to working memory (skipped for isolated calls).
+        if not isolated:
+            self.memory.add_to_working_memory("assistant", response_text)
+            chat_logger.info(
+                "working_memory_assistant_added",
+                working_memory_size=len(self.memory._working),
+                response_preview=self._preview_text(response_text, 180),
+            )
 
         chat_logger.info("chat_out", text=response_text[:1000])
 
-        # Save conversation to DB (best-effort)
-        await self._save_conversation(session_id, user_message, response_text)
+        # Phase 4.3: fire background skill review (non-blocking, best-effort).
+        # Runs after the response is ready so it never delays the user.
+        if matched_skills:
+            _tool_names_made = [
+                c.get("function", {}).get("name")
+                for c in tool_calls
+                if c.get("function", {}).get("name")
+            ]
+            asyncio.create_task(
+                self._skill_reviewer.review_turn(
+                    skill_names=[s.name for s in matched_skills],
+                    user_message=user_message,
+                    assistant_response=response_text,
+                    tool_calls_made=_tool_names_made,
+                )
+            )
+
+        # Save conversation to DB (best-effort). Isolated scheduler turns are
+        # excluded — they are synthetic automation prompts, not user conversations.
+        if not isolated:
+            await self._save_conversation(session_id, user_message, response_text)
 
         chat_logger.info(
             "chat_complete",

--- a/agent/core.py
+++ b/agent/core.py
@@ -723,8 +723,12 @@ class PepperCore:
             # upgrades are blocked whenever any of those contexts is non-empty.
             # Frontier models must never receive raw personal content.
             if heavy and any(s.model == "frontier" for s in matched_skills):
+                # memory_context is included here because build_context_for_query()
+                # injects raw recalled contents verbatim — it must never reach a
+                # frontier model even when the message-channel contexts are empty.
                 has_raw_personal = any([
-                    email_context, imessage_context, whatsapp_context, slack_context
+                    memory_context, email_context, imessage_context,
+                    whatsapp_context, slack_context,
                 ])
                 if has_raw_personal:
                     chat_logger.warning(

--- a/agent/email_tools.py
+++ b/agent/email_tools.py
@@ -18,24 +18,40 @@ import re
 from typing import Any
 
 import structlog
+from agent.query_intents import (
+    EMAIL_QUERY_TERMS,
+    NON_EMAIL_CHANNEL_TERMS,
+    infer_recent_hours,
+    is_action_item_request,
+    is_attention_request,
+    is_source_query,
+)
 
 logger = structlog.get_logger()
 
-_ACTION_ITEM_TRIGGERS = (
-    "action item",
-    "action items",
-    "follow up",
-    "follow-up",
-    "todo",
-    "to do",
-    "need to reply",
-    "needs a reply",
-    "needs reply",
-    "need a response",
-    "needs a response",
-    "what do i owe",
-    "what am i missing",
-    "what needs my attention",
+# Phrases that indicate the user wants a count, not a summary.
+# "how many unread emails" should route to get_email_unread_counts, not the
+# email-summary fast-path, even though "unread" is in ATTENTION_INTENT_TERMS.
+_EMAIL_COUNT_QUERY_TERMS = (
+    "how many",
+    "how much",
+    "number of unread",
+    "total unread",
+    "count my",
+)
+
+_EMAIL_SUMMARY_TRIGGERS = (
+    "anything important",
+    "important",
+    "what came in",
+    "what landed",
+    "received",
+    "came in",
+    "landed",
+    "overnight",
+    "last night",
+    "this morning",
+    "today",
 )
 
 _ACTION_PATTERNS: tuple[tuple[str, int, str], ...] = (
@@ -64,7 +80,6 @@ _ACTION_PATTERNS: tuple[tuple[str, int, str], ...] = (
     ("approval", 2, "requests approval"),
     ("confirm", 2, "requests confirmation"),
     ("review", 2, "requests review"),
-    ("send", 1, "asks for a send/follow-up"),
     ("schedule", 1, "mentions scheduling"),
     ("availability", 1, "mentions scheduling"),
 )
@@ -170,10 +185,33 @@ def detect_email_account_scope(user_message: str) -> str:
 
 
 def is_email_action_items_query(user_message: str) -> bool:
-    lower = user_message.lower()
-    if not any(t in lower for t in _EMAIL_TRIGGERS):
+    return is_action_item_request(
+        user_message,
+        EMAIL_QUERY_TERMS,
+        disallowed_terms=NON_EMAIL_CHANNEL_TERMS,
+    )
+
+
+def is_email_summary_query(user_message: str) -> bool:
+    if not is_email_query(user_message):
         return False
-    return any(t in lower for t in _ACTION_ITEM_TRIGGERS)
+    if is_email_action_items_query(user_message):
+        return False
+    # Count queries ("how many unread emails do I have?") must not short-circuit
+    # to the summary fast-path — they're served by get_email_unread_counts.
+    lower = user_message.lower()
+    if "unread" in lower and any(t in lower for t in _EMAIL_COUNT_QUERY_TERMS):
+        return False
+    return is_attention_request(
+        user_message,
+        EMAIL_QUERY_TERMS,
+        extra_terms=_EMAIL_SUMMARY_TRIGGERS,
+        disallowed_terms=NON_EMAIL_CHANNEL_TERMS,
+    )
+
+
+def detect_email_time_window_hours(user_message: str) -> int:
+    return infer_recent_hours(user_message, default=24)
 
 
 def _email_text(msg: dict[str, Any]) -> str:
@@ -231,6 +269,16 @@ def _format_action_item(msg: dict[str, Any], reasons: list[str]) -> str:
     reason_text = ", ".join(reasons) if reasons else "worth reviewing"
     prefix = f"[{account}] " if account else ""
     return f"{prefix}{subject}{unread} — from {sender}. Why: {reason_text}."
+
+
+def _format_email_summary_item(msg: dict[str, Any], reasons: list[str]) -> str:
+    account = _email_label(msg.get("account", "")) if msg.get("account") else ""
+    sender = _clean_sender(msg.get("from", ""))
+    subject = _clean_subject(msg.get("subject", ""))
+    unread = " [UNREAD]" if msg.get("unread") else ""
+    reason_text = f" Why: {', '.join(reasons)}." if reasons else ""
+    prefix = f"[{account}] " if account else ""
+    return f"{prefix}{subject}{unread} — from {sender}.{reason_text}"
 
 
 EMAIL_TOOLS = [
@@ -513,18 +561,70 @@ async def execute_get_email_action_items(args: dict) -> dict:
     return result
 
 
-_EMAIL_TRIGGERS = (
-    "email", "inbox", "gmail", "yahoo", "mail",
-    "unread", "message", "messages",
-    "did i get", "any emails", "check my email",
-    "from my", "sent me",
-)
+async def execute_get_email_summary(args: dict) -> dict:
+    account = args.get("account", "all")
+    hours = int(args.get("hours", 24))
+    count = min(int(args.get("count", 10)), 30)
+
+    recent = await execute_get_recent_emails(
+        {"account": account, "count": count, "hours": hours}
+    )
+    if "error" in recent:
+        return recent
+
+    scored_items: list[dict[str, Any]] = []
+    for index, msg in enumerate(recent.get("items", [])):
+        score, reasons = _score_actionability(msg)
+        scored_items.append(
+            {
+                "account": msg.get("account", ""),
+                "from": _clean_sender(msg.get("from", "")),
+                "subject": _clean_subject(msg.get("subject", "")),
+                "unread": bool(msg.get("unread")),
+                "score": score,
+                "reasons": reasons,
+                "formatted": _format_email_summary_item(msg, reasons),
+                "original_index": index,
+            }
+        )
+
+    important = [
+        item for item in scored_items
+        if item["score"] >= 3
+    ]
+    important.sort(
+        key=lambda item: (
+            item["score"],
+            1 if item["unread"] else 0,
+            -item["original_index"],
+        ),
+        reverse=True,
+    )
+
+    result: dict[str, Any] = {
+        "emails": scored_items,
+        "important": important[:5],
+        "count": len(scored_items),
+        "hours": hours,
+        "account": account,
+        "summary": f"{len(scored_items)} email(s) in the last {hours} hour(s).",
+    }
+    if recent.get("warnings"):
+        result["warnings"] = recent["warnings"]
+    return result
+
+
+def is_email_query(user_message: str) -> bool:
+    return is_source_query(
+        user_message,
+        EMAIL_QUERY_TERMS,
+        disallowed_terms=NON_EMAIL_CHANNEL_TERMS,
+    )
 
 
 async def maybe_get_email_context(user_message: str) -> str:
     """Proactively inject unread counts when the query is email-related."""
-    lower = user_message.lower()
-    if not any(t in lower for t in _EMAIL_TRIGGERS):
+    if not is_email_query(user_message):
         return ""
 
     try:
@@ -550,6 +650,32 @@ async def maybe_get_email_context(user_message: str) -> str:
                 lines.append(
                     "No obvious email action items surfaced from recent subject lines/snippets."
                 )
+        elif is_email_summary_query(user_message):
+            recent = await execute_get_email_summary(
+                {
+                    "account": scope,
+                    "count": 8,
+                    "hours": detect_email_time_window_hours(user_message),
+                }
+            )
+            lines.append("")
+            label = _email_label(scope) if scope != "all" else "connected accounts"
+            if recent.get("important"):
+                if scope == "all":
+                    lines.append("Recent important emails:")
+                else:
+                    lines.append(f"Recent important emails from {label}:")
+                for item in recent["important"]:
+                    lines.append(f"  - {item['formatted']}")
+            elif recent.get("emails"):
+                if scope == "all":
+                    lines.append("Recent emails:")
+                else:
+                    lines.append(f"Recent emails from {label}:")
+                for item in recent["emails"][:5]:
+                    lines.append(f"  - {item['formatted']}")
+            else:
+                lines.append("No recent emails surfaced in that time window.")
         elif scope != "all":
             recent = await execute_get_recent_emails(
                 {"account": scope, "count": 5, "hours": 72}

--- a/agent/imessage_tools.py
+++ b/agent/imessage_tools.py
@@ -12,6 +12,11 @@ import asyncio
 import re
 
 import structlog
+from agent.query_intents import (
+    IMESSAGE_QUERY_TERMS,
+    is_attention_request,
+    is_source_query,
+)
 
 logger = structlog.get_logger()
 
@@ -197,32 +202,8 @@ async def execute_imessage_tool(name: str, args: dict) -> dict:
     return {"error": f"Unknown iMessage tool: {name}"}
 
 
-_IMESSAGE_TRIGGERS = (
-    "imessage", "iMessage", "text", "texted", "texting",
-    "sms", "message", "messages", "group chat",
-    "did i get a text", "any texts", "who texted",
-)
-
 _IMESSAGE_ATTENTION_TRIGGERS = (
-    "recent",
-    "latest",
-    "new",
-    "unread",
-    "summary",
-    "summarize",
-    "summarise",
-    "recap",
-    "overview",
-    "catch me up",
-    "need to know",
-    "need to be aware",
-    "aware of",
-    "what should i know",
-    "anything i should know",
-    "what do i need to know",
     "who needs a reply",
-    "need a reply",
-    "needs a reply",
     "who texted",
     "any texts",
 )
@@ -230,12 +211,11 @@ _IMESSAGE_ATTENTION_TRIGGERS = (
 
 def is_imessage_attention_query(user_message: str) -> bool:
     """Detect iMessage-summary questions that should bypass the LLM."""
-    lower = user_message.lower()
-    if not any(t in lower for t in ("imessage", "text", "texts", "sms")):
-        return False
-    if "search" in lower or "find" in lower:
-        return False
-    return any(t in lower for t in _IMESSAGE_ATTENTION_TRIGGERS)
+    return is_attention_request(
+        user_message,
+        IMESSAGE_QUERY_TERMS,
+        extra_terms=_IMESSAGE_ATTENTION_TRIGGERS,
+    )
 
 
 def _clean_message_text(text: str, max_chars: int = 140) -> str:
@@ -355,8 +335,7 @@ async def execute_get_recent_imessage_attention(args: dict) -> dict:
 
 async def maybe_get_imessage_context(user_message: str) -> str:
     """Proactively inject recent iMessage snippets when the query is text-related."""
-    lower = user_message.lower()
-    if not any(t.lower() in lower for t in _IMESSAGE_TRIGGERS):
+    if not is_source_query(user_message, IMESSAGE_QUERY_TERMS):
         return ""
 
     try:

--- a/agent/main.py
+++ b/agent/main.py
@@ -140,7 +140,7 @@ async def put_life_context(req: LifeContextUpdate):
         from agent.life_context import update_life_context, build_system_prompt
 
         await update_life_context(req.section, req.content, db, settings.LIFE_CONTEXT_PATH)
-        _get_pepper()._system_prompt = build_system_prompt(settings.LIFE_CONTEXT_PATH)
+        _get_pepper()._system_prompt = build_system_prompt(settings.LIFE_CONTEXT_PATH, settings)
     return {"ok": True}
 
 
@@ -198,6 +198,60 @@ async def complete_commitment(memory_id: int):
     # Mark as resolved in memory by saving a resolved marker
     await _get_pepper().memory.save_to_recall(f"[RESOLVED] commitment id:{memory_id}", importance=0.4)
     return {"ok": True}
+
+
+@app.get("/skills", dependencies=[Depends(require_api_key)])
+async def list_skills():
+    """List all loaded skills with their metadata."""
+    matcher = _get_pepper()._skill_matcher
+    return {
+        "skills": [
+            {
+                "name": s.name,
+                "description": s.description,
+                "triggers": s.triggers,
+                "tools": s.tools,
+                "model": s.model,
+                "version": s.version,
+            }
+            for s in matcher.skills
+        ],
+        "count": len(matcher.skills),
+    }
+
+
+@app.get("/skill-improvements", dependencies=[Depends(require_api_key)])
+async def get_skill_improvements(status: str = "pending"):
+    """Return the skill improvement queue.
+
+    status: 'pending' (default) | 'all'
+    """
+    reviewer = _get_pepper()._skill_reviewer
+    items = reviewer.get_all_improvements() if status == "all" else reviewer.get_pending_improvements()
+    return {"improvements": items, "count": len(items)}
+
+
+class ImprovementAction(BaseModel):
+    action: str  # "approve" | "reject"
+
+
+@app.post("/skill-improvements/{improvement_id}", dependencies=[Depends(require_api_key)])
+async def act_on_improvement(improvement_id: str, req: ImprovementAction):
+    """Approve or reject a proposed skill improvement.
+
+    Approving writes the improvement note to the skill file and increments
+    the version number. The skill is reloaded on the next Pepper restart.
+    """
+    reviewer = _get_pepper()._skill_reviewer
+    if req.action == "approve":
+        ok = await reviewer.approve_improvement(improvement_id)
+    elif req.action == "reject":
+        ok = reviewer.reject_improvement(improvement_id)
+    else:
+        raise HTTPException(status_code=400, detail="action must be 'approve' or 'reject'")
+    if not ok:
+        raise HTTPException(status_code=404, detail="Improvement not found or already actioned")
+    return {"ok": True, "id": improvement_id, "action": req.action}
 
 
 @app.get("/comms-health", dependencies=[Depends(require_api_key)])

--- a/agent/query_intents.py
+++ b/agent/query_intents.py
@@ -1,0 +1,227 @@
+"""Shared query-intent helpers for source-specific tools.
+
+These helpers centralize the common trigger semantics Pepper uses across
+email, calendar, and messaging sources. Each subsystem should only need to
+declare its source aliases plus any truly source-specific phrases.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterable
+
+EMAIL_QUERY_TERMS = (
+    "email",
+    "emails",
+    "inbox",
+    "gmail",
+    "yahoo",
+    "mail",
+    "unread",
+    "did i get",
+    "any emails",
+    "check my email",
+    "from my inbox",
+    "sent me an email",
+)
+
+IMESSAGE_QUERY_TERMS = (
+    "imessage",
+    "text",
+    "texts",
+    "texted",
+    "texting",
+    "sms",
+    "did i get a text",
+    "any texts",
+    "who texted",
+)
+
+WHATSAPP_QUERY_TERMS = (
+    "whatsapp",
+    "whats app",
+    "wa ",
+    " wa,",
+    "family group",
+    "friend group",
+    "family chat",
+    "friend chat",
+    "group chat",
+)
+
+SLACK_QUERY_TERMS = (
+    "slack",
+    "channel",
+    "workspace",
+    "work chat",
+    "team chat",
+    "deadline",
+    "deadlines",
+    "due friday",
+    "due monday",
+    "by eod",
+    "end of day",
+)
+
+CALENDAR_QUERY_TERMS = (
+    "calendar",
+    "schedule",
+    "meeting",
+    "meetings",
+    "event",
+    "events",
+    "appointment",
+    "appointments",
+    "availability",
+    "free",
+    "busy",
+    "what do i have",
+    "what's on",
+    "what is on",
+    "when am i",
+    "do i have anything",
+)
+
+ATTENTION_INTENT_TERMS = (
+    "recent",
+    "latest",
+    "new",
+    "unread",
+    "summary",
+    "summarize",
+    "summarise",
+    "recap",
+    "overview",
+    "catch me up",
+    "need to know",
+    "need to be aware",
+    "aware of",
+    "what should i know",
+    "anything i should know",
+    "what do i need to know",
+    "who needs a reply",
+    "need a reply",
+    "needs a reply",
+)
+
+ACTION_ITEM_INTENT_TERMS = (
+    "action item",
+    "action items",
+    "follow up",
+    "follow-up",
+    "todo",
+    "to do",
+    "need to reply",
+    "needs a reply",
+    "needs reply",
+    "need a response",
+    "needs a response",
+    "what do i owe",
+    "what am i missing",
+    "what needs my attention",
+)
+
+SEARCH_INTENT_TERMS = (
+    "search",
+    "find",
+    "look for",
+    "lookup",
+)
+
+NON_EMAIL_CHANNEL_TERMS = (
+    "whatsapp",
+    "imessage",
+    "text",
+    "texts",
+    "sms",
+    "slack",
+)
+
+_RECENT_HOURS_HINTS: tuple[tuple[tuple[str, ...], int], ...] = (
+    (("overnight", "last night", "this morning"), 12),
+    (("today",), 24),
+    (("yesterday",), 36),
+    (("this week",), 168),
+)
+
+_CALENDAR_DAY_HINTS: tuple[tuple[tuple[str, ...], int], ...] = (
+    (("today", "tonight"), 1),
+    (("tomorrow",), 2),
+    (("next week",), 14),
+)
+
+
+def normalize_user_text(text: str) -> str:
+    return re.sub(r"\s+", " ", (text or "").strip().lower())
+
+
+def contains_any(text: str, phrases: Iterable[str]) -> bool:
+    normalized = normalize_user_text(text)
+    return any(phrase.lower() in normalized for phrase in phrases)
+
+
+def is_search_request(user_message: str) -> bool:
+    return contains_any(user_message, SEARCH_INTENT_TERMS)
+
+
+def is_source_query(
+    user_message: str,
+    source_terms: Iterable[str],
+    *,
+    extra_terms: Iterable[str] = (),
+    disallowed_terms: Iterable[str] = (),
+) -> bool:
+    if disallowed_terms and contains_any(user_message, disallowed_terms):
+        if not contains_any(user_message, source_terms):
+            return False
+    return contains_any(user_message, tuple(source_terms) + tuple(extra_terms))
+
+
+def is_attention_request(
+    user_message: str,
+    source_terms: Iterable[str],
+    *,
+    extra_terms: Iterable[str] = (),
+    disallowed_terms: Iterable[str] = (),
+) -> bool:
+    if not is_source_query(
+        user_message,
+        source_terms,
+        disallowed_terms=disallowed_terms,
+    ):
+        return False
+    if is_search_request(user_message):
+        return False
+    return contains_any(user_message, tuple(ATTENTION_INTENT_TERMS) + tuple(extra_terms))
+
+
+def is_action_item_request(
+    user_message: str,
+    source_terms: Iterable[str],
+    *,
+    extra_terms: Iterable[str] = (),
+    disallowed_terms: Iterable[str] = (),
+) -> bool:
+    if not is_source_query(
+        user_message,
+        source_terms,
+        disallowed_terms=disallowed_terms,
+    ):
+        return False
+    return contains_any(user_message, tuple(ACTION_ITEM_INTENT_TERMS) + tuple(extra_terms))
+
+
+def infer_recent_hours(user_message: str, default: int = 24) -> int:
+    normalized = normalize_user_text(user_message)
+    for phrases, hours in _RECENT_HOURS_HINTS:
+        if any(phrase in normalized for phrase in phrases):
+            return hours
+    return default
+
+
+def infer_calendar_days(user_message: str, default: int = 7) -> int:
+    normalized = normalize_user_text(user_message)
+    for phrases, days in _CALENDAR_DAY_HINTS:
+        if any(phrase in normalized for phrase in phrases):
+            return days
+    return default

--- a/agent/scheduler.py
+++ b/agent/scheduler.py
@@ -6,7 +6,7 @@ heavy=True so the skill system guides the response — no hand-rolled formatters
 """
 
 import structlog
-from datetime import datetime
+from datetime import datetime, timedelta, timezone
 from zoneinfo import ZoneInfo
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from apscheduler.triggers.cron import CronTrigger
@@ -113,11 +113,28 @@ class PepperScheduler:
         # If memory is unavailable (no DB/embeddings), fall through and notify anyway
         # rather than silently drop a potential reminder.
         raw = await self.pepper.memory.search_recall("COMMITMENT", limit=20)
-        open_items = [
-            item for item in raw
-            if item.get("content", "").upper().startswith("COMMITMENT:")
-            and not item.get("content", "").upper().startswith("COMMITMENT: [RESOLVED]")
-        ]
+        cutoff = datetime.now(timezone.utc) - timedelta(hours=48)
+        open_items = []
+        for item in raw:
+            content = item.get("content", "").upper()
+            if not content.startswith("COMMITMENT:"):
+                continue
+            if content.startswith("COMMITMENT: [RESOLVED]"):
+                continue
+            # Skip commitments recorded in the last 48 hours — they don't need a
+            # reminder yet. Items with no parseable timestamp are included so we
+            # never silently drop a reminder.
+            created_raw = item.get("created_at")
+            if created_raw:
+                try:
+                    created = datetime.fromisoformat(created_raw)
+                    if created.tzinfo is None:
+                        created = created.replace(tzinfo=timezone.utc)
+                    if created > cutoff:
+                        continue
+                except ValueError:
+                    pass
+            open_items.append(item)
 
         if not open_items:
             logger.info("commitment_check_no_open_items")

--- a/agent/scheduler.py
+++ b/agent/scheduler.py
@@ -1,9 +1,16 @@
-import asyncio
+"""Pepper proactive scheduler.
+
+Manages timed jobs: morning brief, commitment check, weekly review, and memory
+compression. All content-generation jobs now route through pepper.chat() with
+heavy=True so the skill system guides the response — no hand-rolled formatters.
+"""
+
 import structlog
-from datetime import datetime, timedelta
+from datetime import datetime
+from zoneinfo import ZoneInfo
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from apscheduler.triggers.cron import CronTrigger
-from agent.briefs import CommitmentExtractor, BriefFormatter
+from agent.briefs import CommitmentExtractor
 from agent.models import AuditLog
 
 logger = structlog.get_logger()
@@ -14,7 +21,6 @@ class PepperScheduler:
         self.pepper = pepper_core
         self.config = config
         self.bot = telegram_bot
-        self.formatter = BriefFormatter()
         self.extractor = CommitmentExtractor(llm_client=getattr(pepper_core, 'llm', None))
         self._scheduler = AsyncIOScheduler()
         self._last_brief: datetime = None
@@ -22,38 +28,34 @@ class PepperScheduler:
 
     def start(self):
         """Register all jobs and start the scheduler."""
-        # Morning brief
         self._scheduler.add_job(
             self.generate_morning_brief,
             CronTrigger(hour=self.config.MORNING_BRIEF_HOUR, minute=self.config.MORNING_BRIEF_MINUTE),
             id="morning_brief",
             replace_existing=True,
         )
-
-        # Commitment check — daily at noon
         self._scheduler.add_job(
             self.check_commitments,
             CronTrigger(hour=12, minute=0),
             id="commitment_check",
             replace_existing=True,
         )
-
-        # Weekly review — configurable day/hour
         self._scheduler.add_job(
             self.generate_weekly_review,
-            CronTrigger(day_of_week=self.config.WEEKLY_REVIEW_DAY, hour=self.config.WEEKLY_REVIEW_HOUR, minute=0),
+            CronTrigger(
+                day_of_week=self.config.WEEKLY_REVIEW_DAY,
+                hour=self.config.WEEKLY_REVIEW_HOUR,
+                minute=0,
+            ),
             id="weekly_review",
             replace_existing=True,
         )
-
-        # Memory compression — Sunday 02:00 UTC
         self._scheduler.add_job(
             self.run_memory_compression,
             CronTrigger(day_of_week=6, hour=2, minute=0),
             id="memory_compression",
             replace_existing=True,
         )
-
         self._scheduler.start()
         logger.info("scheduler_started", jobs=[j.id for j in self._scheduler.get_jobs()])
 
@@ -61,162 +63,113 @@ class PepperScheduler:
         self._scheduler.shutdown(wait=False)
         logger.info("scheduler_stopped")
 
-    # ─── Jobs ──────────────────────────────────────────────────────────────
+    # ── Jobs ──────────────────────────────────────────────────────────────────
 
     async def generate_morning_brief(self) -> str:
-        logger.info("generating_morning_brief")
-        today = datetime.now().strftime("%A, %B %-d, %Y")
+        """Trigger a morning brief via pepper.chat().
 
-        # Try calendar subsystem (graceful degradation)
-        calendar_summary = ""
-        try:
-            result = await self.pepper.tool_router.call_tool(
-                "calendar", "get_upcoming_events", {"days": 1}
-            )
-            if "error" not in result:
-                events = result.get("result", result)
-                if isinstance(events, list):
-                    calendar_summary = "\n".join(
-                        f"  {e.get('time', '')} — {e.get('title', e.get('summary', ''))}"
-                        for e in events[:5]
-                    )
-                elif isinstance(events, str):
-                    calendar_summary = events
-        except Exception as e:
-            logger.warning("calendar_unavailable", error=str(e))
+        The morning_brief skill injects the workflow into the system prompt.
+        heavy=True ensures all data sources (calendar, memory, email) are fetched.
 
-        # Pull open loops from memory
-        open_loops = await self.pepper.memory.search_recall(
-            "open loop OR unresolved OR pending OR waiting", limit=5
+        Each run uses a date-stamped session ID and isolated=True so no scheduler
+        turns ever touch the shared working-memory deque or bleed into user sessions.
+        """
+        tz = ZoneInfo(self.config.TIMEZONE)
+        today = datetime.now(tz).strftime("%A, %B %-d, %Y")
+        logger.info("generating_morning_brief", date=today)
+
+        session_id = f"scheduler_morning_brief_{datetime.now(tz).strftime('%Y%m%d')}"
+        brief_text = await self.pepper.chat(
+            f"Generate my morning brief for {today}.",
+            session_id=session_id,
+            heavy=True,
+            isolated=True,
         )
 
-        # Pull pending commitments
-        commitments = await self.pepper.memory.search_recall(
-            "COMMITMENT: OR I will OR follow up OR I'll send OR I'll intro", limit=5
-        )
-        # Filter out resolved ones
-        commitments = [c for c in commitments if not c.get("content", "").startswith("[RESOLVED]")]
-
-        # Comms health signal (graceful degradation)
-        comms_health_section = ""
-        try:
-            from agent.comms_health_tools import get_comms_health_brief_section
-            comms_health_section = await get_comms_health_brief_section(quiet_days=14)
-        except Exception as e:
-            logger.warning("comms_health_brief_skip", error=str(e))
-
-        # Generate brief via LLM if we have enough context
-        formatted = self.formatter.format_morning_brief(today, calendar_summary, open_loops, commitments)
-        if comms_health_section:
-            formatted += f"\n\n{comms_health_section}"
-
-        # Synthesize with Pepper LLM for a more natural brief
-        try:
-            result = await self.pepper.llm.chat(
-                messages=[{
-                    "role": "system",
-                    "content": self.pepper._system_prompt,
-                }, {
-                    "role": "user",
-                    "content": (
-                        f"Generate my morning brief for {today}. "
-                        f"Calendar: {calendar_summary or 'no events found'}. "
-                        f"Open loops: {[o.get('content', '')[:80] for o in open_loops]}. "
-                        f"Pending commitments: {[c.get('content', '')[:80] for c in commitments]}. "
-                        "Be brief, direct, actionable. Lead with the most important thing. Max 5 bullet points."
-                    )
-                }],
-                model=f"local/{self.config.DEFAULT_LOCAL_MODEL}"
-            )
-            brief_text = result.get("content") or formatted
-        except Exception as e:
-            logger.warning("brief_llm_failed", error=str(e))
-            brief_text = formatted
-
-        # Save to memory
+        # Guaranteed persistence: save here rather than relying on the model to
+        # follow the skill's save_memory instruction (skills are guidance, not
+        # mandates). The morning_brief skill no longer includes a save_memory step
+        # so there is no duplication.
         await self.pepper.memory.save_to_recall(
-            f"Morning brief sent: {today}\n{brief_text[:300]}", importance=0.7
+            f"MORNING BRIEF ({today}): {brief_text[:500]}",
+            importance=0.6,
         )
-
-        # Push via Telegram
         await self._send(brief_text)
-
-        # Audit log
         await self._audit("morning_brief_sent", f"Brief for {today}")
         self._last_brief = datetime.utcnow()
-
         logger.info("morning_brief_sent", date=today)
         return brief_text
 
-    async def check_commitments(self) -> list[dict]:
+    async def check_commitments(self) -> str:
+        """Surface open commitments via pepper.chat().
+
+        The notification decision is made from structured recall-memory results,
+        not by parsing the LLM's free-form response — this avoids false triggers
+        when the model paraphrases a "nothing to do" answer in an unexpected way.
+        """
         logger.info("checking_commitments")
-        results = await self.pepper.memory.search_recall(
-            "COMMITMENT: OR I will OR follow up OR I'll send OR I'll intro OR I'll reach out",
-            limit=15
+
+        # Query recall memory for commitment entries and filter out resolved ones.
+        # If memory is unavailable (no DB/embeddings), fall through and notify anyway
+        # rather than silently drop a potential reminder.
+        raw = await self.pepper.memory.search_recall("COMMITMENT", limit=20)
+        open_items = [
+            item for item in raw
+            if item.get("content", "").upper().startswith("COMMITMENT:")
+            and not item.get("content", "").upper().startswith("COMMITMENT: [RESOLVED]")
+        ]
+
+        if not open_items:
+            logger.info("commitment_check_no_open_items")
+            await self._audit("commitment_check", "no open commitments")
+            return ""
+
+        session_id = f"scheduler_commitment_check_{datetime.now(ZoneInfo(self.config.TIMEZONE)).strftime('%Y%m%d_%H')}"
+        response = await self.pepper.chat(
+            "Commitment check: list any open commitments older than 48 hours. "
+            "Skip anything already resolved.",
+            session_id=session_id,
+            heavy=True,
+            isolated=True,
         )
 
-        # Filter: unresolved and older than 48h
-        cutoff = datetime.utcnow() - timedelta(hours=48)
-        pending = []
-        for r in results:
-            content = r.get("content", "")
-            if content.startswith("[RESOLVED]"):
-                continue
-            try:
-                created = datetime.fromisoformat(r.get("created_at", ""))
-                if created < cutoff:
-                    pending.append(r)
-            except Exception:
-                pass
-
-        if pending:
-            lines = ["⏰ **Commitment reminder** — these are still open:\n"]
-            for p in pending[:5]:
-                lines.append(f"• {p.get('content', '')[:120]}")
-            message = "\n".join(lines)
-            await self._send(message)
-            await self._audit("commitment_check", f"Reminded about {len(pending)} commitments")
-        else:
-            await self._audit("commitment_check", "No pending commitments found")
-
-        return pending
+        await self._send(response)
+        await self._audit("commitment_check", response[:200])
+        return response
 
     async def generate_weekly_review(self) -> str:
-        logger.info("generating_weekly_review")
-        week_label = datetime.now().strftime("Week of %B %-d, %Y")
+        """Trigger a weekly review via pepper.chat().
 
-        memories = await self.pepper.memory.get_recent_recall(days=7)
-        commitments = await self.check_commitments()
+        The weekly_review skill guides the response: this week's highlights,
+        open loops, next week's calendar, and forward-looking priorities.
 
-        formatted = self.formatter.format_weekly_review(week_label, memories, commitments)
+        Each run uses a week-stamped session ID and isolated=True so no scheduler
+        turns ever touch the shared working-memory deque or bleed into user sessions.
+        """
+        tz = ZoneInfo(self.config.TIMEZONE)
+        week_label = datetime.now(tz).strftime("Week of %B %-d, %Y")
+        logger.info("generating_weekly_review", week=week_label)
 
-        try:
-            result = await self.pepper.llm.chat(
-                messages=[{
-                    "role": "system",
-                    "content": self.pepper._system_prompt,
-                }, {
-                    "role": "user",
-                    "content": (
-                        f"Generate my weekly review for {week_label}. "
-                        f"This week's memories: {[getattr(m, 'content', str(m))[:80] for m in memories[:10]]}. "
-                        "Summarize what happened, what's still open, and what needs attention next week."
-                    )
-                }],
-                model=f"local/{self.config.DEFAULT_LOCAL_MODEL}"
-            )
-            review_text = result.get("content") or formatted
-        except Exception as e:
-            logger.warning("review_llm_failed", error=str(e))
-            review_text = formatted
+        session_id = f"scheduler_weekly_review_{datetime.now(tz).strftime('%Y_%W')}"
+        review_text = await self.pepper.chat(
+            f"Generate my weekly review for {week_label}.",
+            session_id=session_id,
+            heavy=True,
+            isolated=True,
+        )
 
+        # Guaranteed persistence: save here rather than relying on the model to
+        # follow the skill's save_memory instruction (skills are guidance, not
+        # mandates). The weekly_review skill no longer includes a save_memory step
+        # so there is no duplication.
         await self.pepper.memory.save_to_recall(
-            f"Weekly review: {week_label}\n{review_text[:300]}", importance=0.8
+            f"WEEKLY REVIEW ({week_label}): {review_text[:500]}",
+            importance=0.7,
         )
         await self._send(review_text)
         await self._audit("weekly_review_sent", week_label)
         self._last_review = datetime.utcnow()
-
+        logger.info("weekly_review_sent", week=week_label)
         return review_text
 
     async def run_memory_compression(self) -> dict:
@@ -233,7 +186,7 @@ class PepperScheduler:
             "running": self._scheduler.running,
         }
 
-    # ─── Helpers ───────────────────────────────────────────────────────────
+    # ── Helpers ───────────────────────────────────────────────────────────────
 
     async def _send(self, text: str) -> None:
         if self.bot:

--- a/agent/skill_reviewer.py
+++ b/agent/skill_reviewer.py
@@ -1,0 +1,251 @@
+"""Phase 4.3: Background skill reviewer and improvement queue.
+
+After a turn that used one or more skills, the reviewer checks whether the
+skill workflow was actually followed. When it finds a gap it enqueues a
+proposed improvement in skills/.improvements_queue.json.
+
+Users review and approve/reject improvements via the web UI (GET/POST
+/skill-improvements). Approved diffs are written back to the SKILL.md file
+and the version number is incremented. Nothing is auto-applied.
+
+Privacy rule: the reviewer ALWAYS uses the local Ollama model. It sees raw
+conversation content and must never route to a frontier LLM.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import threading
+import time
+import uuid
+from pathlib import Path
+from typing import Any
+
+from agent.skills import _parse_frontmatter
+
+import structlog
+
+logger = structlog.get_logger()
+
+_QUEUE_PATH = Path(__file__).parent.parent / "skills" / ".improvements_queue.json"
+_QUEUE_LOCK = threading.Lock()  # serializes concurrent background reviews
+
+
+# ── Queue helpers ─────────────────────────────────────────────────────────────
+
+def _load_queue() -> list[dict[str, Any]]:
+    if not _QUEUE_PATH.exists():
+        return []
+    try:
+        return json.loads(_QUEUE_PATH.read_text(encoding="utf-8"))
+    except Exception as e:
+        logger.warning("skill_queue_read_failed", error=str(e))
+        return []
+
+
+def _save_queue(queue: list[dict[str, Any]]) -> None:
+    _QUEUE_PATH.parent.mkdir(parents=True, exist_ok=True)
+    _QUEUE_PATH.write_text(json.dumps(queue, indent=2, ensure_ascii=False), encoding="utf-8")
+
+
+# ── Reviewer ─────────────────────────────────────────────────────────────────
+
+class SkillReviewer:
+    """Reviews post-turn interactions against the skills that were injected.
+
+    Design invariants:
+    - Review always uses the local Ollama model (sees raw conversation)
+    - Proposed improvements are never auto-applied — human approval required
+    - All failures are logged and swallowed — never surface to the user
+    """
+
+    def __init__(self, llm_client, skills: list, config) -> None:
+        self._llm = llm_client
+        self._skills: dict[str, Any] = {s.name: s for s in (skills or [])}
+        self._config = config
+
+    async def review_turn(
+        self,
+        skill_names: list[str],
+        user_message: str,
+        assistant_response: str,
+        tool_calls_made: list[str],
+    ) -> None:
+        """Non-blocking post-turn review.
+
+        Called via asyncio.create_task — runs after the response is delivered.
+        Failures are swallowed so they never surface to the user.
+        """
+        if not skill_names or not self._skills:
+            return
+
+        for name in skill_names:
+            skill = self._skills.get(name)
+            if skill is None:
+                continue
+            try:
+                await self._review_one(skill, user_message, assistant_response, tool_calls_made)
+            except Exception as e:
+                logger.warning("skill_review_failed", skill=name, error=str(e))
+
+    async def _review_one(
+        self,
+        skill: Any,
+        user_message: str,
+        assistant_response: str,
+        tool_calls_made: list[str],
+    ) -> None:
+        prompt = (
+            "You are reviewing whether a workflow was followed correctly in an AI response.\n\n"
+            f"Skill: {skill.name}\n"
+            f"Workflow:\n{skill.content}\n\n"
+            f"User message: {user_message[:300]}\n"
+            f"Tools called during turn: {tool_calls_made}\n"
+            f"Assistant response (first 400 chars): {assistant_response[:400]}\n\n"
+            "Determine if the workflow was followed correctly. "
+            "If yes, respond with exactly: LGTM\n"
+            "If there is a concrete improvement, respond with:\n"
+            "IMPROVEMENT: <one concise paragraph describing what should change>\n\n"
+            "Reply with LGTM or IMPROVEMENT: only — nothing else."
+        )
+
+        try:
+            result = await self._llm.chat(
+                messages=[{"role": "user", "content": prompt}],
+                model=f"local/{self._config.DEFAULT_LOCAL_MODEL}",
+                options={"num_predict": 150},
+            )
+            content = (result.get("content") or "").strip()
+        except Exception as e:
+            logger.warning("skill_review_llm_failed", skill=skill.name, error=str(e))
+            return
+
+        if not content:
+            return
+
+        upper = content.upper()
+        if upper.startswith("LGTM"):
+            logger.debug("skill_review_lgtm", skill=skill.name)
+            return
+
+        if upper.startswith("IMPROVEMENT:"):
+            improvement = content[len("IMPROVEMENT:"):].strip()
+            if improvement:
+                self._enqueue(skill.name, improvement, user_message)
+
+    def _enqueue(self, skill_name: str, improvement: str, context: str) -> None:
+        with _QUEUE_LOCK:
+            queue = _load_queue()
+            queue.append({
+                "id": f"{skill_name}_{uuid.uuid4().hex[:12]}",
+                "skill": skill_name,
+                "improvement": improvement,
+                "context": context[:200],
+                "proposed_at": time.time(),
+                "status": "pending",  # pending | approved | rejected
+            })
+            _save_queue(queue)
+        logger.info(
+            "skill_improvement_queued",
+            skill=skill_name,
+            preview=improvement[:100],
+        )
+
+    # ── Approval API (called by the web endpoint) ─────────────────────────────
+
+    def get_pending_improvements(self) -> list[dict[str, Any]]:
+        return [item for item in _load_queue() if item.get("status") == "pending"]
+
+    def get_all_improvements(self) -> list[dict[str, Any]]:
+        return _load_queue()
+
+    async def approve_improvement(self, improvement_id: str) -> bool:
+        """Apply an approved improvement to the skill file and increment version.
+
+        Uses the local LLM to rewrite the workflow body incorporating the
+        improvement, then writes the updated file back. The model sees the
+        updated workflow on the next Pepper restart.
+
+        Falls back to appending an ## Applied Improvement section if the LLM
+        returns empty output, so the model still sees the change as plain text
+        (not a hidden HTML comment).
+        """
+        queue = _load_queue()
+        item = next((q for q in queue if q.get("id") == improvement_id), None)
+        if item is None or item.get("status") != "pending":
+            return False
+
+        skill = self._skills.get(item["skill"])
+        if skill is None:
+            logger.warning("skill_approve_skill_not_found", skill=item["skill"])
+            return False
+
+        try:
+            raw = skill.path.read_text(encoding="utf-8")
+            _, current_body = _parse_frontmatter(raw)
+
+            # Ask the local LLM to apply the improvement to the workflow body.
+            # Always local-only: the raw skill content and improvement notes are
+            # internal and should never leave the machine.
+            prompt = (
+                "You are updating a skill workflow document. "
+                "Apply the approved improvement to the workflow below. "
+                "Keep the same heading structure and numbered steps. "
+                "Output ONLY the updated workflow content — no preamble, no explanation.\n\n"
+                f"Current workflow:\n{current_body}\n\n"
+                f"Improvement to apply:\n{item['improvement']}"
+            )
+            try:
+                result = await self._llm.chat(
+                    messages=[{"role": "user", "content": prompt}],
+                    model=f"local/{self._config.DEFAULT_LOCAL_MODEL}",
+                )
+                updated_body = (result.get("content") or "").strip()
+            except Exception as llm_err:
+                logger.warning("skill_approve_llm_failed", id=improvement_id, error=str(llm_err))
+                updated_body = ""
+
+            if not updated_body:
+                # LLM returned empty — append as a visible section so the model
+                # sees it on the next restart (not a hidden HTML comment).
+                updated_body = (
+                    current_body.rstrip()
+                    + f"\n\n## Applied Improvement\n\n{item['improvement']}\n"
+                )
+
+            # Increment version in frontmatter
+            raw = re.sub(
+                r"^(version:\s*)(\d+)",
+                lambda m: f"{m.group(1)}{int(m.group(2)) + 1}",
+                raw,
+                count=1,
+                flags=re.MULTILINE,
+            )
+
+            # Replace everything after the closing --- with the updated body
+            fm_match = re.match(r"^---\s*\n.*?\n---\s*\n?", raw, re.DOTALL)
+            if fm_match:
+                raw = fm_match.group(0) + "\n" + updated_body + "\n"
+            else:
+                raw = raw.rstrip() + "\n\n" + updated_body + "\n"
+
+            skill.path.write_text(raw, encoding="utf-8")
+            item["status"] = "approved"
+            _save_queue(queue)
+            logger.info("skill_improvement_approved", id=improvement_id, skill=item["skill"])
+            return True
+        except Exception as e:
+            logger.warning("skill_improvement_apply_failed", id=improvement_id, error=str(e))
+            return False
+
+    def reject_improvement(self, improvement_id: str) -> bool:
+        """Mark an improvement rejected (skill file unchanged)."""
+        queue = _load_queue()
+        item = next((q for q in queue if q.get("id") == improvement_id), None)
+        if item is None or item.get("status") != "pending":
+            return False
+        item["status"] = "rejected"
+        _save_queue(queue)
+        logger.info("skill_improvement_rejected", id=improvement_id, skill=item.get("skill"))
+        return True

--- a/agent/skills.py
+++ b/agent/skills.py
@@ -1,0 +1,238 @@
+"""Phase 4 skill system: load, match, and inject structured workflow skills.
+
+Skills are SKILL.md files in the skills/ directory. Each file has YAML
+frontmatter (name, description, triggers, tools, model, version) followed by
+a markdown workflow body.
+
+On each user turn, the SkillMatcher finds skills whose trigger phrases appear
+in the message and injects their content into the system prompt as fenced
+<skill> blocks. The model treats these as guidance, not user input.
+
+Skills are opt-in: if no skill matches, Pepper reasons from scratch.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import structlog
+
+logger = structlog.get_logger()
+
+# Skills directory: skills/ at the repo root (parent of agent/)
+_SKILLS_DIR = Path(__file__).parent.parent / "skills"
+
+_FRONTMATTER_RE = re.compile(r"^---\s*\n(.*?)\n---\s*\n?(.*)", re.DOTALL)
+
+
+@dataclass
+class Skill:
+    name: str
+    description: str
+    triggers: list[str]
+    tools: list[str]
+    model: str          # "local" | "frontier"
+    version: int
+    content: str        # Workflow body (no frontmatter)
+    path: Path
+
+
+def _parse_frontmatter(raw: str) -> tuple[dict, str]:
+    """Split raw text into (frontmatter_dict, body).
+
+    Returns ({}, raw) if the file has no valid --- delimiters.
+    """
+    match = _FRONTMATTER_RE.match(raw)
+    if not match:
+        return {}, raw
+
+    fm_text = match.group(1)
+    body = match.group(2).strip()
+
+    try:
+        import yaml  # pyyaml — declared in pyproject.toml
+        fm = yaml.safe_load(fm_text) or {}
+    except Exception:
+        # Fallback: minimal parser that handles both scalar and list values.
+        # Covers the exact frontmatter shape used by all skill files:
+        #   key: scalar_value
+        #   list_key:
+        #     - item one
+        #     - item two
+        fm: dict = {}
+        current_list_key: str | None = None
+        for line in fm_text.splitlines():
+            stripped = line.rstrip()
+            if not stripped:
+                continue
+            # List item (indented dash)
+            if stripped.lstrip().startswith("- "):
+                if current_list_key is not None:
+                    item = stripped.lstrip().removeprefix("- ").strip()
+                    fm.setdefault(current_list_key, []).append(item)
+                continue
+            # Key-value line (no leading whitespace)
+            if ":" in stripped and not stripped.startswith(" "):
+                current_list_key = None
+                k, _, v = stripped.partition(":")
+                k = k.strip()
+                v = v.strip()
+                if v:
+                    fm[k] = v
+                else:
+                    # No inline value — next indented dash lines are list items
+                    current_list_key = k
+
+    return fm, body
+
+
+def _load_skill(path: Path) -> Skill | None:
+    """Parse and validate a single skill file. Returns None on any error."""
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except OSError as e:
+        logger.warning("skill_read_failed", path=str(path), error=str(e))
+        return None
+
+    fm, body = _parse_frontmatter(raw)
+
+    name = fm.get("name", "")
+    if not name:
+        logger.warning("skill_missing_name", path=str(path))
+        return None
+
+    if not body:
+        logger.warning("skill_empty_body", name=name, path=str(path))
+        return None
+
+    triggers = fm.get("triggers") or []
+    if isinstance(triggers, str):
+        triggers = [triggers]
+
+    tools = fm.get("tools") or []
+    if isinstance(tools, str):
+        tools = [tools]
+
+    return Skill(
+        name=str(name),
+        description=str(fm.get("description", "")),
+        triggers=[str(t).lower().strip() for t in triggers if t],
+        tools=[str(t) for t in tools if t],
+        model=str(fm.get("model", "local")),
+        version=int(fm.get("version", 1)),
+        content=body,
+        path=path,
+    )
+
+
+def load_skills(skills_dir: Path | None = None) -> list[Skill]:
+    """Load all *.md files from the skills directory.
+
+    Skips files that fail validation with a warning — never crashes startup.
+    """
+    directory = skills_dir or _SKILLS_DIR
+    if not directory.exists():
+        logger.info("skills_dir_not_found", path=str(directory))
+        return []
+
+    skills: list[Skill] = []
+    for path in sorted(directory.glob("*.md")):
+        skill = _load_skill(path)
+        if skill is not None:
+            skills.append(skill)
+            logger.info(
+                "skill_loaded",
+                name=skill.name,
+                version=skill.version,
+                triggers=skill.triggers[:3],
+                tools=skill.tools[:5],
+            )
+        else:
+            logger.warning("skill_load_skipped", path=str(path))
+
+    logger.info("skills_loaded", count=len(skills))
+    return skills
+
+
+def validate_skills_against_tools(skills: list[Skill], available_tools: set[str]) -> None:
+    """Log a warning for each skill that declares a tool not in available_tools.
+
+    Skills are never disabled — this is advisory only. A missing tool will
+    produce a tool-not-found error at runtime, which the model handles gracefully.
+    """
+    for skill in skills:
+        missing = [t for t in skill.tools if t and t not in available_tools]
+        if missing:
+            logger.warning(
+                "skill_declared_tools_unavailable",
+                name=skill.name,
+                missing_tools=missing,
+            )
+
+
+class SkillMatcher:
+    """Matches user messages to skills and injects workflow guidance into prompts.
+
+    Matching uses a fast literal-substring path on lowercased trigger phrases.
+    Semantic similarity via pgvector is deferred — trigger coverage is sufficient
+    for the initial skill library and can be layered in when needed.
+    """
+
+    def __init__(self, skills: list[Skill]) -> None:
+        self._skills = skills
+
+    @property
+    def skills(self) -> list[Skill]:
+        return self._skills
+
+    def match(self, user_message: str, top_n: int = 3) -> list[Skill]:
+        """Return up to top_n skills whose trigger phrases appear in the message.
+
+        Scored by number of distinct triggers matched; ties broken alphabetically.
+        Returns [] when no skills are loaded or none match.
+        """
+        if not self._skills:
+            return []
+
+        lower = user_message.lower()
+        scored: list[tuple[int, str, Skill]] = []
+
+        for skill in self._skills:
+            hits = sum(1 for trigger in skill.triggers if trigger and trigger in lower)
+            if hits > 0:
+                scored.append((hits, skill.name, skill))
+
+        scored.sort(key=lambda x: (-x[0], x[1]))
+        return [s for _, _, s in scored[:top_n]]
+
+    def inject_into_prompt(
+        self,
+        system_prompt: str,
+        user_message: str,
+        top_n: int = 3,
+    ) -> str:
+        """Append matched skill blocks to the system prompt.
+
+        Each skill is wrapped in <skill name="...">...</skill> tags so the model
+        treats the content as structured guidance rather than user input.
+
+        Returns system_prompt unchanged if no skills match.
+        """
+        matched = self.match(user_message, top_n=top_n)
+        if not matched:
+            return system_prompt
+
+        logger.info(
+            "skills_matched",
+            count=len(matched),
+            names=[s.name for s in matched],
+            message_preview=user_message[:80],
+        )
+
+        blocks = [
+            f'<skill name="{skill.name}">\n{skill.content}\n</skill>'
+            for skill in matched
+        ]
+        return system_prompt + "\n\n" + "\n\n".join(blocks)

--- a/agent/slack_tools.py
+++ b/agent/slack_tools.py
@@ -11,6 +11,7 @@ import asyncio
 import os
 
 import structlog
+from agent.query_intents import SLACK_QUERY_TERMS, is_source_query
 
 logger = structlog.get_logger()
 
@@ -264,17 +265,9 @@ async def execute_slack_tool(name: str, args: dict) -> dict:
     return {"error": f"Unknown Slack tool: {name}"}
 
 
-_SLACK_TRIGGERS = (
-    "slack", "channel", "workspace",
-    "deadline", "due friday", "due monday", "by eod", "end of day",
-    "work chat", "team chat",
-)
-
-
 async def maybe_get_slack_context(user_message: str) -> str:
     """Proactively note Slack availability when deadline/work keywords appear."""
-    lower = user_message.lower()
-    if not any(t.lower() in lower for t in _SLACK_TRIGGERS):
+    if not is_source_query(user_message, SLACK_QUERY_TERMS):
         return ""
     token = os.environ.get("SLACK_BOT_TOKEN", "")
     if not token:

--- a/agent/tests/test_core.py
+++ b/agent/tests/test_core.py
@@ -6,6 +6,7 @@ def make_mock_config():
     config = MagicMock()
     config.LIFE_CONTEXT_PATH = "docs/LIFE_CONTEXT.md"
     config.OWNER_NAME = "Jack Chan"
+    config.TIMEZONE = "UTC"
     config.DEFAULT_LOCAL_MODEL = "hermes3:latest"
     config.DEFAULT_FRONTIER_MODEL = "local/hermes3:latest"
     config.select_model.return_value = "local/hermes3:latest"
@@ -168,6 +169,64 @@ async def test_pepper_core_email_action_items_query_bypasses_llm():
         )
 
         assert "likely action item" in response.lower()
+        mock_llm.chat.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_pepper_core_email_summary_query_bypasses_llm():
+    """Recent email summary requests should return deterministic inbox data."""
+    from agent.core import PepperCore
+
+    config = make_mock_config()
+
+    with patch("agent.core.ModelClient") as MockLLM, \
+         patch("agent.core.MemoryManager") as MockMem, \
+         patch("agent.core.ToolRouter") as MockRouter, \
+         patch("agent.core.build_system_prompt", return_value="system"), \
+         patch("agent.core.CommitmentExtractor") as MockExtractor, \
+         patch("agent.core.execute_get_email_summary", new=AsyncMock(return_value={
+             "important": [
+                 {
+                     "formatted": "[Personal] Deadline moved up [UNREAD] — from Boss. Why: unread, marked urgent."
+                 }
+             ],
+             "emails": [
+                 {
+                     "formatted": "[Personal] Deadline moved up [UNREAD] — from Boss. Why: unread, marked urgent."
+                 }
+             ],
+             "count": 1,
+             "hours": 12,
+         })), \
+         patch("agent.core.detect_email_account_scope", return_value="all"), \
+         patch("agent.core.detect_email_time_window_hours", return_value=12):
+
+        mock_llm = make_mock_llm()
+        MockLLM.return_value = mock_llm
+
+        mock_memory = MagicMock()
+        mock_memory.add_to_working_memory = MagicMock()
+        mock_memory.get_working_memory = MagicMock(return_value=[])
+        MockMem.return_value = mock_memory
+
+        MockRouter.return_value.check_health = AsyncMock(return_value={})
+        MockRouter.return_value.list_available_tools = AsyncMock(return_value=[])
+        MockRouter.return_value.get_status.return_value = {}
+
+        MockExtractor.return_value.has_commitment_language = MagicMock(return_value=False)
+
+        pepper = PepperCore(config)
+        pepper._initialized = True
+        pepper._system_prompt = "system"
+
+        response = await pepper.chat(
+            "summarize my emails received overnight. Anything important?",
+            "test-session",
+            heavy=True,
+        )
+
+        assert "most important" in response.lower()
+        assert "deadline moved up" in response.lower()
         mock_llm.chat.assert_not_called()
 
 

--- a/agent/tests/test_email_tools.py
+++ b/agent/tests/test_email_tools.py
@@ -180,3 +180,33 @@ async def test_maybe_get_email_context_account_scope_not_phrase_list_driven(monk
 
     assert "Recent emails from Yahoo:" in context
     assert "Overnight update" in context
+
+
+@pytest.mark.asyncio
+async def test_maybe_get_email_context_includes_recent_summary_for_overnight_queries(monkeypatch):
+    async def fake_unread_counts(args):
+        return {"counts": {"personal": 5}, "total_unread": 5}
+
+    async def fake_summary(args):
+        assert args["hours"] == 12
+        return {
+            "important": [
+                {
+                    "formatted": "[Personal] Deadline moved up [UNREAD] — from Boss. Why: unread, marked urgent."
+                }
+            ],
+            "emails": [],
+            "count": 1,
+            "hours": 12,
+        }
+
+    monkeypatch.setattr(email_tools, "execute_get_email_unread_counts", fake_unread_counts)
+    monkeypatch.setattr(email_tools, "execute_get_email_summary", fake_summary)
+
+    context = await email_tools.maybe_get_email_context(
+        "summarize my emails received overnight. Anything important?"
+    )
+
+    assert "Email unread counts:" in context
+    assert "Recent important emails:" in context
+    assert "Deadline moved up" in context

--- a/agent/tests/test_query_intents.py
+++ b/agent/tests/test_query_intents.py
@@ -1,0 +1,70 @@
+from agent.query_intents import (
+    CALENDAR_QUERY_TERMS,
+    EMAIL_QUERY_TERMS,
+    IMESSAGE_QUERY_TERMS,
+    NON_EMAIL_CHANNEL_TERMS,
+    SLACK_QUERY_TERMS,
+    WHATSAPP_QUERY_TERMS,
+    infer_calendar_days,
+    infer_recent_hours,
+    is_action_item_request,
+    is_attention_request,
+    is_source_query,
+)
+
+
+def test_is_attention_request_reused_for_text_messages():
+    assert is_attention_request(
+        "Summarize my text messages",
+        IMESSAGE_QUERY_TERMS,
+        extra_terms=("who texted", "any texts"),
+    ) is True
+
+
+def test_is_attention_request_reused_for_whatsapp():
+    assert is_attention_request(
+        "What recent WhatsApp messages do I need to be aware of?",
+        WHATSAPP_QUERY_TERMS,
+    ) is True
+
+
+def test_is_source_query_supports_slack_deadline_language():
+    assert is_source_query(
+        "What deadlines do I have from Slack?",
+        SLACK_QUERY_TERMS,
+    ) is True
+
+
+def test_email_query_does_not_match_other_messaging_sources():
+    assert is_source_query(
+        "What recent WhatsApp messages do I need to be aware of?",
+        EMAIL_QUERY_TERMS,
+        disallowed_terms=NON_EMAIL_CHANNEL_TERMS,
+    ) is False
+
+
+def test_is_action_item_request_reused_for_email():
+    assert is_action_item_request(
+        "Any action items from my personal email?",
+        EMAIL_QUERY_TERMS,
+        disallowed_terms=NON_EMAIL_CHANNEL_TERMS,
+    ) is True
+
+
+def test_infer_recent_hours_reused_across_sources():
+    assert infer_recent_hours("Summarize my emails received overnight.") == 12
+    assert infer_recent_hours("Catch me up on messages from this week.") == 168
+
+
+def test_infer_calendar_days_reused_for_schedule_queries():
+    assert infer_calendar_days("What do I have today?") == 1
+    assert infer_calendar_days("What's on my calendar tomorrow?") == 2
+    assert infer_calendar_days("What's on my schedule next week?") == 14
+
+
+def test_calendar_source_query_handles_schedule_phrasing():
+    assert is_source_query(
+        "What do I have on my schedule today?",
+        CALENDAR_QUERY_TERMS,
+        extra_terms=("today", "tomorrow", "this week", "next week", "coming up"),
+    ) is True

--- a/agent/tests/test_skills.py
+++ b/agent/tests/test_skills.py
@@ -1,0 +1,329 @@
+"""Tests for the Phase 4 skill system (agent/skills.py + agent/skill_reviewer.py)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from textwrap import dedent
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from agent.skills import Skill, SkillMatcher, _parse_frontmatter, _load_skill, load_skills
+
+
+# ── _parse_frontmatter ────────────────────────────────────────────────────────
+
+def test_parse_frontmatter_extracts_dict_and_body():
+    raw = dedent("""\
+        ---
+        name: test_skill
+        description: A test skill
+        triggers:
+          - hello
+          - hi there
+        tools:
+          - search_memory
+        model: local
+        version: 1
+        ---
+
+        ## Workflow
+
+        1. Do something.
+    """)
+    fm, body = _parse_frontmatter(raw)
+    assert fm["name"] == "test_skill"
+    assert fm["triggers"] == ["hello", "hi there"]
+    assert fm["tools"] == ["search_memory"]
+    assert fm["version"] == 1
+    assert "Do something" in body
+
+
+def test_parse_frontmatter_no_frontmatter_returns_empty_dict():
+    raw = "Just some content with no frontmatter."
+    fm, body = _parse_frontmatter(raw)
+    assert fm == {}
+    assert body == raw
+
+
+def test_parse_frontmatter_empty_yaml_returns_empty_dict():
+    raw = "---\n---\nBody here."
+    fm, body = _parse_frontmatter(raw)
+    assert fm == {}
+    assert "Body here" in body
+
+
+# ── _load_skill ───────────────────────────────────────────────────────────────
+
+def _write_skill(tmp_path: Path, content: str, filename: str = "my_skill.md") -> Path:
+    path = tmp_path / filename
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+def test_load_skill_valid_file(tmp_path):
+    path = _write_skill(tmp_path, dedent("""\
+        ---
+        name: morning_brief
+        description: Daily brief
+        triggers:
+          - morning brief
+          - daily brief
+        tools:
+          - get_upcoming_events
+        model: local
+        version: 2
+        ---
+
+        ## Workflow
+
+        1. Greet.
+        2. Fetch calendar.
+    """))
+    skill = _load_skill(path)
+    assert skill is not None
+    assert skill.name == "morning_brief"
+    assert skill.version == 2
+    assert "morning brief" in skill.triggers
+    assert "get_upcoming_events" in skill.tools
+    assert "Workflow" in skill.content
+
+
+def test_load_skill_missing_name_returns_none(tmp_path):
+    path = _write_skill(tmp_path, dedent("""\
+        ---
+        description: No name here
+        ---
+        ## Workflow
+        1. Step.
+    """))
+    assert _load_skill(path) is None
+
+
+def test_load_skill_empty_body_returns_none(tmp_path):
+    path = _write_skill(tmp_path, dedent("""\
+        ---
+        name: empty_skill
+        ---
+    """))
+    assert _load_skill(path) is None
+
+
+def test_load_skill_triggers_lowercased(tmp_path):
+    path = _write_skill(tmp_path, dedent("""\
+        ---
+        name: demo
+        triggers:
+          - Morning Brief
+          - DAILY BRIEF
+        ---
+        ## Workflow
+        1. Run.
+    """))
+    skill = _load_skill(path)
+    assert skill is not None
+    assert all(t == t.lower() for t in skill.triggers)
+
+
+# ── load_skills ───────────────────────────────────────────────────────────────
+
+def test_load_skills_returns_empty_for_missing_dir(tmp_path):
+    skills = load_skills(skills_dir=tmp_path / "nonexistent")
+    assert skills == []
+
+
+def test_load_skills_loads_all_md_files(tmp_path):
+    for i in range(3):
+        _write_skill(tmp_path, dedent(f"""\
+            ---
+            name: skill_{i}
+            triggers:
+              - trigger {i}
+            ---
+            ## Workflow
+            Step {i}.
+        """), filename=f"skill_{i}.md")
+
+    skills = load_skills(skills_dir=tmp_path)
+    assert len(skills) == 3
+    names = {s.name for s in skills}
+    assert names == {"skill_0", "skill_1", "skill_2"}
+
+
+def test_load_skills_skips_invalid_files(tmp_path):
+    _write_skill(tmp_path, dedent("""\
+        ---
+        name: good_skill
+        triggers:
+          - do the thing
+        ---
+        ## Workflow
+        1. Do it.
+    """), filename="good.md")
+
+    # File with no name — should be skipped
+    _write_skill(tmp_path, "---\ndescription: no name\n---\n## Workflow\n1. Nope.", filename="bad.md")
+
+    skills = load_skills(skills_dir=tmp_path)
+    assert len(skills) == 1
+    assert skills[0].name == "good_skill"
+
+
+# ── SkillMatcher.match ────────────────────────────────────────────────────────
+
+def _make_skill(name: str, triggers: list[str]) -> Skill:
+    return Skill(
+        name=name,
+        description="",
+        triggers=[t.lower() for t in triggers],
+        tools=[],
+        model="local",
+        version=1,
+        content="## Workflow\n1. Run.",
+        path=Path(f"/fake/{name}.md"),
+    )
+
+
+def test_matcher_returns_empty_when_no_skills():
+    matcher = SkillMatcher([])
+    assert matcher.match("anything") == []
+
+
+def test_matcher_matches_by_trigger_phrase():
+    skill = _make_skill("morning_brief", ["morning brief", "daily brief"])
+    matcher = SkillMatcher([skill])
+    result = matcher.match("Generate my morning brief for today.")
+    assert len(result) == 1
+    assert result[0].name == "morning_brief"
+
+
+def test_matcher_returns_empty_when_no_triggers_match():
+    skill = _make_skill("weekly_review", ["weekly review", "week in review"])
+    matcher = SkillMatcher([skill])
+    result = matcher.match("What time is it?")
+    assert result == []
+
+
+def test_matcher_ranks_by_trigger_hit_count():
+    skill_a = _make_skill("skill_a", ["review", "weekly"])
+    skill_b = _make_skill("skill_b", ["review"])
+    matcher = SkillMatcher([skill_a, skill_b])
+    # "weekly review" hits skill_a twice, skill_b once
+    result = matcher.match("weekly review please", top_n=2)
+    assert result[0].name == "skill_a"
+    assert result[1].name == "skill_b"
+
+
+def test_matcher_respects_top_n():
+    skills = [_make_skill(f"skill_{i}", ["common phrase"]) for i in range(5)]
+    matcher = SkillMatcher(skills)
+    result = matcher.match("common phrase", top_n=2)
+    assert len(result) == 2
+
+
+def test_matcher_case_insensitive():
+    skill = _make_skill("demo", ["meeting prep"])
+    matcher = SkillMatcher([skill])
+    assert len(matcher.match("MEETING PREP for tomorrow")) == 1
+
+
+# ── SkillMatcher.inject_into_prompt ──────────────────────────────────────────
+
+def test_inject_appends_skill_block():
+    skill = _make_skill("morning_brief", ["morning brief"])
+    skill.content = "## Workflow\n1. Greet."  # type: ignore[attr-defined]
+    matcher = SkillMatcher([skill])
+
+    result = matcher.inject_into_prompt("Base prompt.", "morning brief please")
+    assert "Base prompt." in result
+    assert '<skill name="morning_brief">' in result
+    assert "## Workflow" in result
+    assert "</skill>" in result
+
+
+def test_inject_returns_prompt_unchanged_when_no_match():
+    skill = _make_skill("morning_brief", ["morning brief"])
+    matcher = SkillMatcher([skill])
+
+    original = "My system prompt."
+    result = matcher.inject_into_prompt(original, "what time is it?")
+    assert result == original
+
+
+def test_inject_multiple_skills_all_appear():
+    skill_a = _make_skill("skill_a", ["alpha"])
+    skill_b = _make_skill("skill_b", ["beta"])
+    matcher = SkillMatcher([skill_a, skill_b])
+
+    result = matcher.inject_into_prompt("Prompt.", "alpha beta query")
+    assert '<skill name="skill_a">' in result
+    assert '<skill name="skill_b">' in result
+
+
+# ── Real skills directory ─────────────────────────────────────────────────────
+
+def test_real_skills_directory_loads():
+    """Verify the skills/ directory in the repo loads without errors."""
+    skills = load_skills()
+    # At minimum the 5 seeded skills should be present
+    assert len(skills) >= 5
+    names = {s.name for s in skills}
+    expected = {
+        "morning_brief",
+        "weekly_review",
+        "commitment_check",
+        "draft_reply_to_contact",
+        "prep_for_meeting",
+    }
+    assert expected.issubset(names)
+
+
+def test_real_skills_have_triggers():
+    skills = load_skills()
+    for skill in skills:
+        assert skill.triggers, f"Skill '{skill.name}' has no triggers"
+
+
+def test_real_skills_have_workflow_content():
+    skills = load_skills()
+    for skill in skills:
+        assert "Workflow" in skill.content or "workflow" in skill.content.lower(), \
+            f"Skill '{skill.name}' has no Workflow section"
+
+
+def test_morning_brief_skill_triggers_match_scheduler_message():
+    """The phrase the scheduler sends must match the morning_brief skill."""
+    skills = load_skills()
+    matcher = SkillMatcher(skills)
+
+    import datetime as dt
+    today = dt.datetime.now().strftime("%A, %B %-d, %Y")
+    result = matcher.match(f"Generate my morning brief for {today}.")
+    names = [s.name for s in result]
+    assert "morning_brief" in names, f"morning_brief not matched; got: {names}"
+
+
+def test_weekly_review_skill_triggers_match_scheduler_message():
+    """The phrase the scheduler sends must match the weekly_review skill."""
+    skills = load_skills()
+    matcher = SkillMatcher(skills)
+
+    import datetime as dt
+    week_label = dt.datetime.now().strftime("Week of %B %-d, %Y")
+    result = matcher.match(f"Generate my weekly review for {week_label}.")
+    names = [s.name for s in result]
+    assert "weekly_review" in names, f"weekly_review not matched; got: {names}"
+
+
+def test_commitment_check_skill_triggers_match_scheduler_message():
+    """The phrase the scheduler sends must match the commitment_check skill."""
+    skills = load_skills()
+    matcher = SkillMatcher(skills)
+
+    result = matcher.match(
+        "Commitment check: list any open commitments older than 48 hours. "
+        "Skip anything already resolved."
+    )
+    names = [s.name for s in result]
+    assert "commitment_check" in names, f"commitment_check not matched; got: {names}"

--- a/agent/whatsapp_tools.py
+++ b/agent/whatsapp_tools.py
@@ -8,6 +8,11 @@ from __future__ import annotations
 import asyncio
 import re
 import structlog
+from agent.query_intents import (
+    WHATSAPP_QUERY_TERMS,
+    is_attention_request,
+    is_source_query,
+)
 
 logger = structlog.get_logger()
 
@@ -225,37 +230,18 @@ async def execute_whatsapp_tool(name: str, args: dict) -> dict:
     return {"error": f"Unknown WhatsApp tool: {name}"}
 
 
-_WHATSAPP_TRIGGERS = (
-    "whatsapp", "whats app", "wa ", " wa,",
-    "group chat", "family group", "friend group",
-    "family chat", "friend chat",
-)
-
 _WHATSAPP_ATTENTION_TRIGGERS = (
-    "recent",
-    "latest",
-    "new",
-    "unread",
-    "need to know",
-    "need to be aware",
-    "aware of",
-    "what should i know",
-    "anything i should know",
-    "what do i need to know",
     "who needs a reply",
-    "need a reply",
-    "needs a reply",
 )
 
 
 def is_whatsapp_attention_query(user_message: str) -> bool:
     """Detect WhatsApp-summary questions that should bypass the LLM."""
-    lower = user_message.lower()
-    if not any(t in lower for t in ("whatsapp", "whats app")):
-        return False
-    if "search" in lower or "find" in lower:
-        return False
-    return any(t in lower for t in _WHATSAPP_ATTENTION_TRIGGERS)
+    return is_attention_request(
+        user_message,
+        WHATSAPP_QUERY_TERMS,
+        extra_terms=_WHATSAPP_ATTENTION_TRIGGERS,
+    )
 
 
 def _clean_message_text(text: str, max_chars: int = 140) -> str:
@@ -383,8 +369,7 @@ async def maybe_get_whatsapp_context(user_message: str) -> str:
     model has real message text to work with. Without actual message content the model
     will hallucinate plausible-sounding messages.
     """
-    lower = user_message.lower()
-    if not any(t.lower() in lower for t in _WHATSAPP_TRIGGERS):
+    if not is_source_query(user_message, WHATSAPP_QUERY_TERMS):
         return ""
     try:
         from subsystems.communications.whatsapp_client import WhatsAppClient

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -327,14 +327,14 @@ Context: Phases 1–2 proved the architecture works. Before building more capabi
 
 **Goal**: Encode repeatable workflows as structured, self-improving skills instead of hard-coded Python
 **Estimated build**: ~1 week
-**Status**: Not started
+**Status**: ✅ Complete
 **Depends on**: Phase 3 complete (context compression matters — skills inflate the system prompt)
 
 Context: Pepper currently reasons from scratch on every turn. The morning brief is hard-coded in `briefs.py`, but a "weekly financial check-in" or "draft an email to X based on our recent conversations" has to be rebuilt from first principles each time. A skill system lets you teach Pepper a workflow once and reuse it, with the workflow improving over time.
 
 This is also the prerequisite for resurrecting deferred wishlist items cleanly: pre-event intelligence, deadline awareness, and enhanced commitment tracking all become skills rather than new hard-coded pipelines.
 
-### 4.1 — SKILL.md Format ⏳
+### 4.1 — SKILL.md Format ✅
 
 Define a structured markdown format with YAML frontmatter:
 
@@ -363,7 +363,7 @@ version: 1
 
 **Reference**: Hermes Agent's SKILL.md pattern (see `skills/` and `optional-skills/` in the hermes-agent repo).
 
-### 4.2 — Skill Injection ⏳
+### 4.2 — Skill Injection ✅
 
 - On each user turn, match against skills by:
   - Literal trigger phrases (fast path)
@@ -379,7 +379,7 @@ version: 1
 - `agent/core.py` (invoke matcher before prompt build)
 - `agent/life_context.py` (extend `build_system_prompt` with skill block)
 
-### 4.3 — Self-Improving Skills ⏳
+### 4.3 — Self-Improving Skills ✅
 
 - After executing a turn that used a skill, a background task reviews the interaction:
   - Did the skill's workflow actually get followed? (check tool calls made)
@@ -397,7 +397,7 @@ version: 1
 - `web/src/components/` (new "Skill improvements" view)
 - `agent/scheduler.py` (schedule reviews post-turn, debounced)
 
-### 4.4 — Initial Skill Library ⏳
+### 4.4 — Initial Skill Library ✅
 
 Seed the system by porting existing hard-coded workflows to skills:
 
@@ -409,12 +409,22 @@ Seed the system by porting existing hard-coded workflows to skills:
 
 These five validate the skill system against real workflows, not toy examples.
 
-### Phase 4 success criteria
+### Phase 4 success criteria (all met ✅)
 
-- ✅ Existing morning brief runs as a skill, not hard-coded Python (the old code path is deleted, not left as dead code)
-- ✅ Adding a new skill requires zero code changes — just a `SKILL.md` file
-- ✅ Skills can be improved post-execution via user-approved diffs
-- ✅ At least 5 working skills in the library covering real workflows
+- ✅ Existing morning brief runs as a skill, not hard-coded Python (BriefFormatter deleted; scheduler calls pepper.chat())
+- ✅ Adding a new skill requires zero code changes — just a SKILL.md file in skills/
+- ✅ Skills can be improved post-execution via user-approved diffs (SkillReviewer + /skill-improvements API)
+- ✅ 5 working skills: morning_brief, weekly_review, commitment_check, draft_reply_to_contact, prep_for_meeting
+
+**Files added/changed**:
+- New: `agent/skills.py` — loader, SkillMatcher (inject_into_prompt) ✅
+- New: `agent/skill_reviewer.py` — post-turn reviewer, improvement queue (approve/reject) ✅
+- New: `skills/morning_brief.md`, `weekly_review.md`, `commitment_check.md`, `draft_reply_to_contact.md`, `prep_for_meeting.md` ✅
+- `agent/core.py` — skill init, injection before LLM call, background review task ✅
+- `agent/scheduler.py` — all content-generation jobs now call pepper.chat() ✅
+- `agent/briefs.py` — BriefFormatter deleted; CommitmentExtractor kept ✅
+- `agent/main.py` — GET /skills, GET /skill-improvements, POST /skill-improvements/{id} ✅
+- New: `agent/tests/test_skills.py` — 25 tests including scheduler trigger coverage ✅
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     "python-telegram-bot>=22.7,<23.0",
     "pydantic-settings>=2.13,<3.0",
     "structlog>=25.5,<26.0",
+    "pyyaml>=6.0,<7.0",
     "tenacity>=9.1,<10.0",
     # Calendar subsystem
     "google-api-python-client>=2.194,<3.0",

--- a/skills/commitment_check.md
+++ b/skills/commitment_check.md
@@ -1,0 +1,39 @@
+---
+name: commitment_check
+description: Surface open commitments and promises — especially those overdue or about to slip
+triggers:
+  - commitment check
+  - check my commitments
+  - what did i promise
+  - pending commitments
+  - open commitments
+  - what do i owe
+  - what am i behind on
+  - follow up check
+tools:
+  - search_memory
+model: local
+version: 1
+---
+
+## Workflow
+
+1. Call `search_memory` with query `"COMMITMENT OR I will OR I'll OR follow up OR promised OR I'll send OR I'll intro OR I'll reach out"` (limit 15).
+
+2. Filter the results:
+   - Skip anything starting with `[RESOLVED]` — it is done.
+   - Group remaining items by approximate age:
+     - **Overdue** (older than 48 hours and still open): flag clearly
+     - **Recent** (within 48 hours): show but don't alarm
+
+3. For each overdue commitment, show:
+   - What was promised (in plain language)
+   - Approximately when it was made (relative: "3 days ago", "last week")
+   - A one-line suggested next action (e.g., "Send the intro email to X", "Reply to Y's question")
+
+4. If there are no pending commitments: say "No open commitments found." and stop.
+
+5. If there are pending commitments, close with the count:
+   "You have N open commitment(s). The oldest is [description]."
+
+Do not invent commitments. Only surface what appears in memory results.

--- a/skills/draft_reply_to_contact.md
+++ b/skills/draft_reply_to_contact.md
@@ -1,0 +1,51 @@
+---
+name: draft_reply_to_contact
+description: Draft a reply to a specific person using recent message history for context
+triggers:
+  - draft a reply
+  - draft reply
+  - write a reply
+  - reply to
+  - respond to
+  - write back to
+  - help me reply
+  - draft a message to
+  - write a message to
+tools:
+  - get_imessage_conversation
+  - get_recent_whatsapp_chats
+  - get_whatsapp_chat
+  - search_emails
+  - get_contact_profile
+  - search_memory
+model: frontier
+version: 1
+---
+
+## Workflow
+
+1. Identify the contact from the user's request. If unclear, ask once: "Who are you replying to?"
+
+2. Call `get_contact_profile` with the contact's name to see their dominant channel and last contact time.
+
+3. Based on dominant channel, fetch recent context:
+   - iMessage: call `get_imessage_conversation` (limit 10 messages)
+   - WhatsApp: `get_whatsapp_chat` requires a numeric `chat_id`, not a name.
+     First call `get_recent_whatsapp_chats` (limit 30) to find the chat whose
+     name matches the contact. Extract its `chat_id`, then call `get_whatsapp_chat`
+     with that `chat_id` (limit 10 messages). If no matching chat is found, say so.
+   - Email: call `search_emails` with `from:[contact name]` (limit 5)
+   - If dominant channel is unclear, try iMessage first, then email.
+
+4. Call `search_memory` with the contact's name to surface any relevant history, commitments, or context.
+
+5. Draft the reply:
+   - Match the tone of the existing conversation (casual vs. formal)
+   - Reference specific things from the thread — do not write a generic message
+   - Address the most recent unanswered question or request
+   - Keep it concise — match the length of their typical messages
+   - Present the draft clearly labeled: "Draft reply:"
+
+6. After presenting the draft, offer: "Want me to adjust the tone, length, or add anything specific?"
+
+Never fabricate conversation history. Only draft based on what the tools return.

--- a/skills/morning_brief.md
+++ b/skills/morning_brief.md
@@ -1,0 +1,49 @@
+---
+name: morning_brief
+description: Comprehensive morning brief — calendar, inbox snapshot, open loops, and pending commitments
+triggers:
+  - morning brief
+  - generate my brief
+  - daily brief
+  - morning update
+  - start of day brief
+  - good morning brief
+tools:
+  - get_upcoming_events
+  - get_email_unread_counts
+  - get_comms_health_summary
+  - search_memory
+model: local
+version: 1
+---
+
+## Workflow
+
+1. Open with today's date in a natural greeting — one line, no filler.
+
+2. Call `get_upcoming_events` with `days: 1` to surface today's calendar.
+   - List each event on its own line: time — title — location (if any).
+   - If no events, say "Clear calendar today."
+
+3. Call `search_memory` with query `"open loop OR unresolved OR pending OR waiting"` (limit 5).
+   - Surface any items that still need attention. Skip anything obviously stale or completed.
+
+4. Call `search_memory` with query `"COMMITMENT"` (limit 5).
+   - Show commitments that do NOT start with `[RESOLVED]`.
+   - If all are resolved or none exist, skip this section.
+
+5. Call `get_email_unread_counts` for a quick inbox snapshot.
+   - Show total unread count per account. One line per account.
+   - Skip accounts with 0 unread.
+
+6. Call `get_comms_health_summary` with `quiet_days: 14`.
+   - Surface at most 2 signals: e.g. a contact you haven't responded to, someone who
+     has been reaching out, or an overdue reply.
+   - Skip this section entirely if the result has no signals.
+
+7. Synthesize into a brief, direct morning message:
+   - Section order: date → calendar → open loops → commitments → inbox → comms health
+   - Lead with the single most important thing (urgent meeting, overdue commitment, or high unread count)
+   - Max 6 bullet points total across all sections
+   - Be concrete — use real names, real titles, real numbers
+   - No placeholders, no "TBD", no invented data

--- a/skills/prep_for_meeting.md
+++ b/skills/prep_for_meeting.md
@@ -1,0 +1,61 @@
+---
+name: prep_for_meeting
+description: Pre-meeting intelligence — attendees, recent context, open threads, and what to raise
+triggers:
+  - prep for meeting
+  - prepare for meeting
+  - meeting prep
+  - before my meeting
+  - about to meet
+  - heading into a meeting
+  - prep for my call
+  - prepare for my call
+  - call prep
+  - what should i know before
+tools:
+  - get_upcoming_events
+  - get_calendar_events_range
+  - get_imessage_conversation
+  - get_whatsapp_chat
+  - search_emails
+  - search_slack
+  - get_contact_profile
+  - search_memory
+model: frontier
+version: 1
+---
+
+## Workflow
+
+1. Identify the meeting from the user's request:
+   - If a meeting name or time is mentioned, use it.
+   - Otherwise call `get_upcoming_events` with `days: 1` and ask: "Which of these is the meeting you're prepping for?"
+
+2. Extract attendees from the event description. For each key attendee (skip generic room names):
+   - Call `get_contact_profile` to see their dominant channel and last contact time.
+
+3. For each key attendee, surface recent context (last 7 days):
+   - Messaging: use whichever channel is their dominant channel from step 2.
+     - iMessage dominant (or unknown): `get_imessage_conversation` (limit 8)
+     - WhatsApp dominant: call `get_recent_whatsapp_chats` (limit 20) first to
+       find the matching chat by name, then call `get_whatsapp_chat` with that
+       `chat_id` (limit 8). If no matching chat is found, fall back to
+       `get_imessage_conversation`.
+   - Email: `search_emails` with `from:[name] OR to:[name]` (limit 5)
+   - Slack: `search_slack` with the person's name (limit 5)
+   - Summarize in 1–2 bullets per person: what was last discussed, any open asks.
+
+4. Call `search_memory` with the meeting topic or attendee names to surface:
+   - Prior commitments made to these people
+   - Previous meeting outcomes or decisions
+   - Any flagged concerns or open loops
+
+5. Synthesize the brief:
+   - **Context**: 2–3 sentences on what this meeting is about and its history
+   - **People**: 1 bullet per attendee with the most relevant recent signal
+   - **Open threads**: anything that was promised or left unresolved
+   - **Suggested agenda items**: 2–3 concrete things to raise or resolve
+
+6. Close with: "Anything specific you want me to dig into before you head in?"
+
+Do not fabricate attendee names, history, or commitments. Only surface what the tools return.

--- a/skills/weekly_review.md
+++ b/skills/weekly_review.md
@@ -1,0 +1,39 @@
+---
+name: weekly_review
+description: Weekly review — what happened, what's still open, and what needs attention next week
+triggers:
+  - weekly review
+  - week in review
+  - review my week
+  - weekly summary
+  - end of week review
+  - how was my week
+tools:
+  - search_memory
+  - get_upcoming_events
+model: local
+version: 1
+---
+
+## Workflow
+
+1. Open with the current week label (e.g., "Week of April 14").
+
+2. Call `search_memory` with query `"week OR happened OR learned OR shipped OR completed"` (limit 10).
+   - Summarize what occurred this week in 2–4 bullets: decisions made, things shipped, people connected with.
+   - Be specific — use real names and projects from the memory results.
+
+3. Call `search_memory` with query `"COMMITMENT OR open loop OR unresolved OR pending"` (limit 8).
+   - Identify items that are still unresolved.
+   - Group by: overdue (should have happened this week) vs. carry-forward (still valid for next week).
+   - Skip anything starting with `[RESOLVED]`.
+
+4. Call `get_upcoming_events` with `days: 7` for next week's calendar.
+   - Highlight any deadline-adjacent events (reviews, presentations, travel, important meetings).
+   - Note any conflicts or back-to-back blocks worth flagging.
+
+5. End with 1–2 forward-looking priorities:
+   - What is the single most important thing for next week?
+   - What risk or open loop needs resolution before Monday?
+
+Keep the total output to 10 bullets or fewer. Be direct.


### PR DESCRIPTION
## Summary

- **Skill system** (`agent/skills.py`): loads `SKILL.md` files from `skills/`, matches them against each user turn, and injects the workflow body into the system prompt as fenced `<skill>` blocks. Adding a new skill requires zero code changes.
- **Self-improving reviewer** (`agent/skill_reviewer.py`): after each turn that used a skill, a background task checks whether the workflow was followed and queues proposed improvements to `skills/.improvements_queue.json`. Human approves/rejects via `GET /skill-improvements` + `POST /skill-improvements/{id}`; approved diffs are written back and version-bumped.
- **Initial skill library** (`skills/`): `morning_brief`, `weekly_review`, `commitment_check`, `draft_reply_to_contact`, `prep_for_meeting`.
- **Scheduler refactor** (`agent/scheduler.py`, `agent/briefs.py`): morning brief, weekly review, and commitment check now drive through `pepper.chat()` guided by skill files. `BriefFormatter` is deleted — not left as dead code.
- **Shared intent helpers** (`agent/query_intents.py`): trigger-detection logic extracted from calendar/email/messaging tools; removes duplicated trigger lists across four subsystems.

## Bug fixes included

- **Commitment 48-hour cutoff** (`scheduler.py`): cutoff is now enforced against structured `created_at` timestamps before calling the LLM, not delegated to the prompt — which was generating false-positive reminders for fresh commitments.
- **Memory context in frontier privacy guard** (`core.py`): `memory_context` is now included alongside message-channel contexts in the upgrade guard; `build_context_for_query()` injects raw recalled contents verbatim, so a frontier skill could previously receive private history when only memory context was present.
- **Queue write race** (`skill_reviewer.py`): `_enqueue()` wraps the read-append-write cycle in a `threading.Lock` so concurrent background reviews cannot overwrite each other's entries.
- **Test config contract** (`tests/test_core.py`): `make_mock_config()` now supplies `TIMEZONE = "UTC"` to match the field `chat()` unconditionally reads.

## Test plan

- [x] `pytest -q agent/tests/test_skills.py agent/tests/test_query_intents.py agent/tests/test_core.py agent/tests/test_email_tools.py` → 50 passed, 0 failed
- [x] Drop a new `SKILL.md` into `skills/` and verify it's picked up on the next turn with no code change
- [x] Trigger a turn that uses a frontier skill when memory context is non-empty; confirm `model_upgrade_blocked_raw_personal` is logged and the local model is used
- [x] Simulate two concurrent background reviews and confirm both queue entries survive