### PR TITLE
docs: broaden health to multi-source devices + decouple People subsystem from Corela

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,11 +18,11 @@ Pepper is a sovereign, local-first AI life assistant. Think Iron Man's Pepper �
 agent/          # Pepper core orchestrator
 docs/           # Architecture, roadmap, principles
 subsystems/
-  people/       # Future: Corela integration (~/Developer/corela)
+  people/       # Future: relationship intelligence subsystem
   calendar/     # iCal/CalDAV reader
   communications/ # iMessage, email
   knowledge/    # Notes, documents, decisions
-  health/       # Apple Health
+  health/       # Health data (Apple Health, Oura Ring, Garmin, Whoop, etc.)
   finance/      # Financial data
 security/       # Adversarial and monitoring agents
 maintenance/    # Self-upgrade and health check agents
@@ -35,6 +35,7 @@ maintenance/    # Self-upgrade and health check agents
 - Roadmap: [docs/ROADMAP.md](docs/ROADMAP.md)
 - Life Context: [docs/LIFE_CONTEXT.md](docs/LIFE_CONTEXT.md) — this is Pepper's ground truth about its owner
 - LLM Strategy: [docs/LLM_STRATEGY.md](docs/LLM_STRATEGY.md)
+- Agent Infrastructure: [docs/INFRA_GUIDELINES.md](docs/INFRA_GUIDELINES.md) — tool registry, memory pipeline, autonomy ladder, eval flywheel
 
 ## Development Guardrails (Harness Engineering)
 
@@ -106,13 +107,13 @@ Pepper follows **harness engineering** principles from OpenAI: the system around
 - Python 3.10+ for all backend services
 - Each subsystem exposes a standard MCP-compatible tool interface (future: standalone services)
 - Subsystems communicate via tool definitions only — never direct imports
-- PostgreSQL + pgvector as the persistence layer (same pattern as Corela)
+- PostgreSQL + pgvector as the persistence layer
 - Environment config via `.env` files, never hardcoded
 - All agents must handle graceful degradation when a subsystem is unavailable
 - Structured logging with `structlog` for observability
 
-## Relationship to Corela
+## Relationship to the People Subsystem
 
-Corela (`~/Developer/corela`) is a separate project and will eventually become the People subsystem. It is NOT a dependency of Pepper Phase 1. Pepper will drive Corela's evolution over time by surfacing what's needed based on actual usage — not the other way around.
+The People subsystem is intentionally deferred. It is NOT a dependency of Pepper Phase 1. Pepper should surface what relationship capabilities are actually needed through real usage before the implementation is expanded.
 
 ## No Co-Author Lines in Commits

--- a/README.md
+++ b/README.md
@@ -168,5 +168,6 @@ file is persisted on the host.
 - **[GUARDRAILS.md](docs/GUARDRAILS.md)** — Development guardrails based on OpenAI's harness engineering (read this first!)
 - **[ARCHITECTURE.md](docs/ARCHITECTURE.md)** — System architecture and subsystem design
 - **[ROADMAP.md](docs/ROADMAP.md)** — Phase-by-phase build plan
+- **[CONTINUOUS_IMPROVEMENT_PLAN.md](docs/CONTINUOUS_IMPROVEMENT_PLAN.md)** — How Pepper gets iteratively better through evals, simulated chats, and judgment-focused upgrades
 - **[CLAUDE.md](CLAUDE.md)** — Instructions for Claude Code when working on this project
 - **[LLM_STRATEGY.md](docs/LLM_STRATEGY.md)** — How Pepper uses local vs frontier LLMs

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -39,10 +39,10 @@ Nothing is monolithic. Every layer is independently replaceable.
 ┌─────────▼──────┐ ┌───────▼──────┐ ┌──────────▼──────┐
 │   PEOPLE       │ │    TIME      │ │  COMMUNICATIONS  │
 │                │ │              │ │                  │
-│ Corela (future)│ │ Google Cal ✅ │ │ Gmail ✅         │
+│ Future layer   │ │ Google Cal ✅ │ │ Gmail ✅         │
 │ Relationship   │ │ Deadlines ⏳  │ │ Yahoo Mail ✅    │
-│ graph, scoring │ │ (needs Slack)│ │ Telegram ✅      │
-│ 61 tools       │ │ Event prep ⏳ │ │ iMessage ✅      │
+│ context +      │ │ (needs Slack)│ │ Telegram ✅      │
+│ outreach       │ │ Event prep ⏳ │ │ iMessage ✅      │
 │                │ │              │ │ WhatsApp ✅      │
 │                │ │              │ │ Slack ✅         │
 └────────────────┘ └──────────────┘ └─────────────────-┘
@@ -51,9 +51,9 @@ Nothing is monolithic. Every layer is independently replaceable.
 │   KNOWLEDGE    │ │    HEALTH    │ │    FINANCE       │
 │                │ │              │ │                  │
 │ Notes/Obsidian │ │ Apple Health │ │ Bank CSV exports │
-│ Documents      │ │ Activity     │ │ Investment feeds │
-│ Decisions log  │ │ Patterns     │ │ Planning models  │
-│ Claude history │ │              │ │                  │
+│ Documents      │ │ Oura Ring    │ │ Investment feeds │
+│ Decisions log  │ │ Garmin/Whoop │ │ Planning models  │
+│ Claude history │ │ + others     │ │                  │
 └────────────────┘ └──────────────┘ └──────────────────┘
 
 ┌─────────────────────────────────────────────────────────────┐
@@ -231,9 +231,9 @@ This contract means any subsystem can be replaced without modifying Pepper Core.
 
 ### Not Yet Started
 
-- **PEOPLE** — Corela integration (future, post Phase 5)
+- **PEOPLE** — future People subsystem integration (post Phase 5)
 - **KNOWLEDGE** (post Phase 5) — Notes, documents, decision log
-- **HEALTH** (post Phase 5) — Apple Health export parsing
+- **HEALTH** (post Phase 5) — health data ingestion (Apple Health export, Oura Ring, Garmin, Whoop, and others)
 - **FINANCE** (post Phase 5) — Bank CSV parsing
 - **macOS DESKTOP APP** — Swift shell, embedded PostgreSQL, no Docker
 

--- a/docs/CONTINUOUS_IMPROVEMENT_PLAN.md
+++ b/docs/CONTINUOUS_IMPROVEMENT_PLAN.md
@@ -1,0 +1,580 @@
+# Pepper — Continuous Improvement Plan
+
+## Purpose
+
+Turn Pepper from a capable local assistant into a trusted life and executive assistant that:
+
+- notices what matters without being asked
+- knows when to interrupt and when to stay quiet
+- tracks commitments and follows through
+- understands family, work, household, and time together
+- researches and recommends well
+- drafts actions safely and asks for approval only when appropriate
+- continuously improves from real usage, simulated chats, and measured failures
+
+This document is the operating plan for that evolution.
+
+It is intentionally not a generic "AI assistant roadmap." It is grounded in what Pepper already has: life context, memory, scheduler, communications, calendar, routing, skills, pending actions, simulator transcripts, and hallucination checks.
+
+---
+
+## North Star
+
+Pepper is "alive" when these statements are true most days:
+
+- Pepper reliably surfaces the 1-3 things that actually deserve attention.
+- Pepper catches urgent family, work, and logistics issues before you do.
+- Pepper is calm and quiet when nothing important is happening.
+- Pepper drafts useful actions and queues them for review instead of making you start from zero.
+- Pepper remembers people, timing, promises, patterns, and open loops accurately.
+- Pepper knows the difference between urgent, important, sensitive, and ignorable.
+- Pepper improves from mistakes through instrumentation, evals, and small corrective iterations.
+
+Perfection here does not mean "fully autonomous writes." It means "deeply trustworthy judgment under strong approval and privacy guardrails."
+
+---
+
+## What A True Life + Executive Assistant Must Do
+
+Each area below is the capability ceiling. Pepper does not need all of it at once — the subphases below climb it deliberately.
+
+### 1. Attention Management
+
+- Triage inboxes, messages, Slack, and calendar into urgent / important / defer / ignore.
+- Tell you what changed overnight, this morning, today, this week, and before the next major event.
+- Notice when something time-sensitive is slipping.
+- Decide *which channel* (Telegram push, web-UI card, silent log) and *what tone* to use — not every surfacing is an interruption.
+
+### 2. Calendar and Time Protection
+
+- Know what is happening today, this week, and around major deadlines.
+- Prep you ~30 min before every meeting: attendees, last conversation, open items, suggested talking points.
+- Capture action items and follow-up commitments ~5 min after a meeting ends.
+- Detect conflicts, overbooking, travel friction, and unrealistic days.
+
+### 3. Relationship Management
+
+- Know who matters most.
+- Notice quiet contacts, overdue replies, and relationship imbalance.
+- Track birthdays, anniversaries, school deadlines, family events, and people who need a check-in.
+- Build a pre-call context pack when a known contact is about to be reached.
+
+### 4. Commitment Follow-Through
+
+- Remember promises you made — explicit ("I'll send it by Friday") and implicit ("we should really do X").
+- Re-surface them at the right moment.
+- Distinguish resolved, stale, blocked, and still-active commitments.
+
+### 5. Research and Recommendations
+
+- Research travel, household, school, health, vendors, purchases, and local options.
+- Present recommendations with current facts, tradeoffs, and why they matter for your family.
+- Refresh time-sensitive facts before advising.
+- Carry a research thread over days instead of restarting from zero.
+
+### 6. Household and Family Operations
+
+- Track logistics for children, spouse/partner, parents, travel, meals, bills, forms, renewals, and home tasks.
+- Suggest who to contact and what to do next.
+- Notice when family priorities conflict with work priorities.
+
+### 7. News and External Awareness
+
+- Surface important news relevant to your life, work, safety, and location.
+- Distinguish breaking news from noise: freshness window + multi-source convergence before escalating.
+- Emergency news (weather, safety, events in known family regions) follows a different, faster threshold.
+
+### 8. Communication Drafting and Escalation
+
+- Draft replies, follow-ups, reminders, and nudges in the right tone across every channel Pepper can read.
+- Know when a draft is enough, when approval is needed, and when escalation is warranted.
+- Never send sensitive communication without the right approval path.
+- Route every outbound write through the pending-actions queue.
+
+### 9. Memory and Judgment
+
+- Build durable memory about people, goals, open loops, and routines.
+- Use that memory to prioritize correctly, not just answer questions.
+- Stay honest about uncertainty and missing access.
+
+### 10. Self-Maintenance
+
+- Detect degraded integrations, stale auth, slow tools, and routing failures.
+- Evaluate itself continuously via the simulator + eval corpus.
+- Turn repeated failures into explicit product work within 24-48 hours.
+- Run a nightly self-retrospective that becomes weekly tuning proposals.
+
+---
+
+## Pepper Today: Comparison
+
+### Gap Matrix
+
+| Area | Status | Notes |
+|---|---|---|
+| Read across 5 comms channels | ✅ | Gmail, Yahoo, iMessage, WhatsApp, Slack |
+| Priority grading v1 | ✅ | `PriorityGrader` — non-learning rule-based |
+| Quiet-contact detection | ✅ | `find_quiet_contacts`, comms-health dashboard |
+| Commitment capture + slot-based re-surfacing | ✅ | `CommitmentExtractor` + `CommitmentFollowup` |
+| Clarifying-question path | ✅ | `needs_clarification` wired end-to-end in 6.7 |
+| Draft-and-queue outbound writes | ✅ plumbing | `PendingActionsQueue` in-memory; only email draft skill uses it |
+| Capability honesty | ✅ | Registry live, refreshes on failure, periodic re-probe |
+| Simulator + hallucination checks + EA eval corpus | ✅ | `scripts/pepper_simulator.py`, `scripts/pepper_eval.py`, `test_exec_assistant_eval.py` |
+| Morning brief | ✅ | Skill-driven; news integration partial |
+| Pre-event prep fires automatically | 🟡 | `prep_for_meeting.md` exists but no scheduler trigger per event |
+| Post-meeting capture | ❌ | No "meeting ended" hook |
+| Reply drafting across all channels | 🟡 | Email only; SMS/iMessage/WhatsApp/Slack not covered |
+| SLA follow-up on unreplied threads | ❌ | Per-thread tracking missing |
+| Durable pending actions across restarts | ❌ | In-memory only |
+| Birthdays / anniversaries / life events | ❌ | No registry, no surfacing |
+| Pre-call context pack trigger | 🟡 | Contact enricher exists but not wired to call/meeting triggers |
+| Household operations layer | ❌ | No structured ops queue |
+| Research workflows with recency + preference memory | ❌ | Ad-hoc web search only |
+| News digest filtered to life context | 🟡 | Brave Search integrated; no scheduled curated digest |
+| Breaking-news watcher | ❌ | No RSS polling, no convergence rule |
+| Emergency-news geolocation watcher | ❌ | Nothing |
+| Autonomous outbound initiation | ❌ | Pepper speaks when spoken to or on morning cron |
+| Channel + tone selection | ❌ | All proactive pushes go to Telegram |
+| Attention engine (shared decision layer) | ❌ | Every proactive path makes its own decision |
+| Daily self-retrospective | ❌ | Nothing structured |
+| Adaptive tuning from real response patterns | ❌ | Priority grader is rule-only |
+
+---
+
+## The Real Gap
+
+The biggest missing piece is not raw capability surface area. It is judgment orchestration:
+
+- what deserves interruption
+- what can wait for the morning brief
+- what is just background noise
+- what requires research before advice
+- what is safe to draft automatically
+- what should be escalated because it affects family, money, safety, or reputation
+
+The continuous improvement program should therefore optimize for trust and judgment first, then expand capability surface area.
+
+---
+
+## Continuous Improvement Program
+
+### Track 1 — Build The Attention Engine
+
+Create a single decision layer that every proactive Pepper behavior uses.
+
+**Inputs:**
+
+- calendar proximity
+- sender / contact importance
+- relationship health
+- commitment state
+- keyword urgency
+- event type
+- time of day (+ quiet hours)
+- owner preferences from `docs/LIFE_CONTEXT.md`
+- source confidence / capability status
+- news severity and local relevance
+
+**Outputs:**
+
+- `interrupt_now`
+- `show_in_next_brief`
+- `queue_as_pending_action`
+- `watch_silently`
+- `ignore`
+
+Plus a chosen `delivery_channel` (Telegram urgent / Telegram normal / web-UI card / silent log) and `tone`.
+
+**First implementation tasks:**
+
+- introduce a shared `AttentionDecision` model that wraps the existing `PriorityGrader` as one signal among several
+- externalize thresholds in `config/proactive_rules.yaml` so they are tuneable without code
+- centralize morning brief, commitment follow-ups, comms-health prompts, and future news/research surfacing behind it
+- add explicit reasons for every proactive surfacing decision
+- log every proactive decision for later review
+
+**Success criteria:**
+
+- every proactive alert is traceable to a visible decision record
+- false-positive interruptions decrease over time
+- important-but-not-urgent items land in briefs instead of noisy interrupts
+
+### Track 2 — Build The Personal Operations Layer
+
+Pepper needs first-class structured objects for life operations, not just free-text memory.
+
+**Add durable models for:**
+
+- people and relationship milestones
+- family events and school deadlines
+- household tasks and renewals
+- commitments and pending actions
+- research topics and recommendations
+- recurring seasonal events: birthdays, anniversaries, travel prep, school cycles, taxes
+
+**Likely first additions:**
+
+- `subsystems/people/` (the first real inhabitant of the deferred People layer — deliberately minimal and implementation-agnostic)
+- birthday / anniversary registry sourced from macOS Contacts (read-only, local) + life context, user-confirmed before stored
+- life-event ledger: job change, relocation, health event, major project — detected from conversation + comms, always user-confirmed
+- household ops queue: forms, bills, renewals, kid logistics, travel tasks
+- recommendation memory: what Pepper suggested, what you chose, and whether it worked
+- pre-call context pack: when a calendar event has a known attendee, auto-build a prep card
+
+**Success criteria:**
+
+- "who should I reach out to?" and "what family things are coming up?" feel grounded
+- birthdays and key family dates are proactively surfaced
+- Pepper can carry a research thread over days instead of restarting from zero
+
+### Track 3 — Build The Research + Recommendation Loop
+
+Pepper should become good at answering:
+
+- what should we book?
+- who should we call?
+- what should we buy?
+- what are the best options for the family right now?
+
+**Plan:**
+
+- add a `SituationDetector` that inspects calendar + memory nightly and emits situation records (upcoming trip, recurring unresolved decision, topic the principal has asked about repeatedly)
+- `proactive_research` skill fires on situation records; drafts a research brief (Claude for drafting, summaries only; local for all personal-data context)
+- research workflow captures requirements, sources checked, recency, and recommendation rationale
+- separate timeless preferences from time-sensitive facts
+- require current verification for travel, prices, schedules, weather, school deadlines, and news
+- persist recommendation outcomes so Pepper learns your actual taste and trust thresholds
+
+**Success criteria:**
+
+- recommendations cite fresh evidence
+- Pepper remembers household preferences
+- research output becomes more concise and more accurate over repeated cycles
+
+### Track 4 — Build The News + Alerting Layer
+
+Pepper should not merely "have web search." It needs policy for what news matters.
+
+**Classes:**
+
+- emergency / safety
+- local breaking news
+- market / work-relevant developments
+- family-relevant disruptions: weather, traffic, school, travel
+- general background headlines for the brief
+
+**Implement:**
+
+- `news_digest` scheduled skill: Brave Search + curated RSS, filtered against life-context interests via local LLM, summarized to 5-7 items
+- breaking-news watcher: polls trusted RSS every ~15 min; escalates only when (topic matches interests) AND (freshness < 30 min) AND (multiple trusted outlets converge)
+- emergency-news watcher: geolocation-matched to life-context regions (principal + family); a single trusted source is sufficient for weather/disaster/security
+- escalation routes through the Attention Engine → `interrupt_now` with `Telegram urgent` channel
+- quiet-hours policy suppresses non-emergency escalations
+
+**Success criteria:**
+
+- emergency news bypasses normal brief cadence
+- routine headlines stay out of the way unless relevant
+- the morning brief contains useful outside-world context, not generic noise
+
+### Track 5 — Harden The Action Loop
+
+Pepper should close loops safely.
+
+**Improve:**
+
+- persist `PendingActionsQueue` in PostgreSQL so drafts survive restarts
+- outbound action categories (email, iMessage, WhatsApp, Slack, calendar event create) with per-category approval policies
+- extend `draft_reply_to_contact` to every readable channel, each gated through the queue
+- `reply_sla_tracker` scheduled skill: flags threads where the principal read a message > N hours ago without replying; N is per-contact, slowly learned from real reply latency
+- follow-up reminders on queued but unapproved drafts
+- clearer approval UX in web and Telegram
+- explicit "why Pepper suggested this action now" line on every queued draft
+
+**Success criteria:**
+
+- no good draft disappears on restart
+- draft → approve/edit/reject becomes a daily habit path
+- commitment capture and action suggestion feel connected
+
+### Track 6 — Build The Self-Improvement Harness
+
+This is the meta-layer that makes Pepper better every week. Built on the existing simulator + eval scripts, not from scratch.
+
+**Every failure should end up in one of these buckets:**
+
+- routing failure
+- missing tool or missing data source
+- stale or weak life context
+- poor prioritization
+- weak drafting quality
+- missing clarification
+- false urgency
+- missed urgency
+- hallucination / overclaim
+- degraded subsystem / auth / permission issue
+
+**For each bucket, define:**
+
+- how it is detected
+- where it is logged
+- what test/eval reproduces it
+- what "fixed" means
+
+**New infrastructure:**
+
+- **Scenario specs** (`agent/tests/ea_scenarios/*.yaml`): multi-turn scripted situations with input state, simulated events over time, required and forbidden behaviors, scoring weights. Examples: morning-with-urgent-slack, mom-birthday-tomorrow, meeting-prep-auto, flight-to-sf, breaking-news-family-area, stopped-replying, false-alarm. Extends the existing `pepper_simulator` themes with deterministic, graded scenarios.
+- **`CritiqueReviewer`**: generalizes `SkillReviewer` so it accepts a scenario transcript + expected behaviors and emits proposed fixes (skill diff, routing rule, prompt edit, new tool). Fixes land in a shared "Pepper improvements" review queue in the web UI.
+- **`daily_retro` skill**: runs nightly on local Ollama; reads the day's conversations, proactive pushes, tool failures, approvals/rejections; produces a "what I got right / what I missed / what to do differently tomorrow" note; saves to memory tagged `self_retro`.
+- **`retro_rollup` skill**: weekly; reads the past 7 retros; proposes adjustments to priority-grader weights, attention-engine thresholds, news-digest item count, reply-SLA windows per contact. Proposals land in the improvements queue.
+
+**Success criteria:**
+
+- repeated mistakes turn into evals and tests within 24-48 hours
+- quality improves because of failures, not in spite of them
+- the improvements queue is the primary source of Pepper's own roadmap within 6 weeks
+
+---
+
+## Operating Loop: How We Improve Pepper Continuously
+
+This is the loop to run over and over.
+
+### Step 1. Capture Failures
+
+Sources:
+
+- real chats
+- morning brief output
+- weekly review output
+- pending-action approvals/rejections
+- simulator transcripts (`scripts/pepper_simulator.py`)
+- hallucination detector
+- routing eval regressions (`test_exec_assistant_eval.py`)
+- capability failures and auth degradations
+
+Artifacts:
+
+- tagged log entries
+- short failure notes in docs or issue tracker
+- new eval cases copied from the exact failing phrasing
+- new scenario specs under `agent/tests/ea_scenarios/` when the failure is multi-turn
+
+### Step 2. Write The Smallest Correct Plan
+
+For each iteration, define:
+
+- exact failure being fixed
+- metric that should improve
+- files likely to change
+- what should be tested manually
+- what should be tested automatically
+
+Keep scope tight. One judgment behavior at a time beats broad rewrites.
+
+### Step 3. Implement
+
+Typical change shapes:
+
+- prompt / skill improvement
+- router / grader / scheduler logic
+- attention-engine rule change in `proactive_rules.yaml`
+- new structured model or queue
+- UI for status, approvals, or observability
+- new subsystem or MCP integration
+
+### Step 4. Restart Pepper
+
+After meaningful runtime changes:
+
+- restart backend
+- verify health
+- verify scheduler
+- verify capability registry state
+
+### Step 5. Simulate Real Interactions
+
+Run targeted and broad checks:
+
+- `python scripts/pepper_simulator.py --theme <theme> --once`
+- `python scripts/pepper_eval.py --since 10m`
+- `pytest agent/tests/ea_scenarios/<scenario>.py` for the specific failing scenario
+- targeted `pytest` for touched areas
+- one or two manual chats that match the real use case
+
+### Step 6. Inspect Faults
+
+Look at:
+
+- wrong tools called
+- no tools called when tools were needed
+- low-quality prioritization
+- weak explanations
+- generic or noisy proactive behavior
+- missed or excessive clarification
+- state lost across turns or restarts
+- privacy-boundary violations (hard fail — any single violation rejects the iteration)
+
+### Step 7. Fix And Re-Test
+
+Add one or more of:
+
+- regression test
+- simulator theme
+- scenario spec
+- eval corpus case
+- logging/audit improvement
+- code fix
+
+Then rerun the same scenario until the failure stops.
+
+### Step 8. Promote The Next Capability
+
+Once a behavior is stable:
+
+- add the next adjacent behavior
+- avoid stacking two new judgment systems at once
+- prefer extending the harness before extending autonomy
+- let the `retro_rollup` output (once Track 6 lands) drive what gets promoted next
+
+---
+
+## What To Measure
+
+Pepper should be judged on a small visible scorecard.
+
+### Judgment Metrics
+
+- urgent precision: how often an "interrupt now" item was truly urgent
+- urgent recall: how often Pepper missed something that should have interrupted
+- brief usefulness: percentage of brief items the owner considered genuinely useful
+- draft usefulness: percentage of queued drafts needing only light edits
+- recommendation trust: percentage of recommendations accepted or shortlisted
+
+### Reliability Metrics
+
+- tool-grounding rate on data-dependent questions
+- hallucination rate from `scripts/pepper_eval.py`
+- routing accuracy from `test_exec_assistant_eval.py`
+- subsystem availability and auth freshness
+- pending-action survival across restart
+- privacy-boundary violation count (must stay at 0)
+
+### Behavior Metrics
+
+- clarification rate on ambiguous queries
+- false interruption count per week
+- missed commitment resurfacing count
+- quiet-contact / relationship reminder usefulness
+- pre-event prep usefulness
+
+Expose this as `/scorecard` endpoint + a panel in the web UI.
+
+---
+
+## Priority Order
+
+The right order is:
+
+1. Trust and attention policy
+2. Durable action loop
+3. Family / household operations
+4. Research and recommendations
+5. News and external awareness
+6. Broader autonomy and self-maintenance
+
+Reason: a noisy or poorly prioritized assistant becomes a burden even if it has many integrations.
+
+---
+
+## Immediate 6-Week Plan
+
+Each week's work plugs into the tracks above. Each week must end with scenarios green in `pepper_simulator` *and* a restart-and-test pass in live chat.
+
+### Week 1-2: Instrument Judgment
+
+- create a failure taxonomy and logging convention for proactive decisions
+- ship the `/scorecard` endpoint + web UI panel
+- expand simulator themes around urgency, news, family logistics, and relationship reminders
+- add the first 6 scenario specs under `agent/tests/ea_scenarios/` (see Track 6 list)
+- turn recent real failures into eval cases
+
+### Week 2-3: Attention Engine V1
+
+- introduce `AttentionDecision` + `config/proactive_rules.yaml`
+- route morning brief items, commitment follow-ups, and comms-health prompts through one scoring path
+- add channel + tone selection (v1 rule-based)
+- log why each item was surfaced
+- scenario coverage: false-alarm + missed-urgency cases
+
+### Week 3-4: Durable Action Loop + Pre/Post-Event
+
+- persist `PendingActionsQueue` in Postgres; add restart-safe retrieval and approval state
+- surface stale queued drafts and remind appropriately
+- scheduler dispatches `prep_for_meeting` 30 min before every calendar event
+- new `post_meeting_capture` skill runs 5 min after each event
+- scenario coverage: meeting-prep-auto, stale-draft-revived-after-restart
+
+### Week 4-5: Family Ops V1
+
+- stand up `subsystems/people/` with macOS Contacts read + life-event ledger
+- birthday / anniversary registry with proactive surfacing via Attention Engine
+- household ops queue: first pass on forms, bills, renewals, kid logistics
+- life-context-backed tests for family priority conflicts
+- scenario coverage: mom-birthday-tomorrow, family-vs-work-conflict
+
+### Week 5-6: News + Research V1
+
+- `news_digest` + breaking-news watcher + emergency-news watcher (Track 4)
+- `SituationDetector` + `proactive_research` skill (Track 3)
+- verify all surfacing goes through Attention Engine (no back-door interrupts)
+- verify privacy boundaries: news/research never sends raw personal data externally
+- scenario coverage: breaking-news-family-area, flight-to-sf research card
+
+### Week 6 closing: Self-Improvement Wiring
+
+- `CritiqueReviewer` generalizes `SkillReviewer`
+- `daily_retro` skill scheduled nightly
+- `retro_rollup` scheduled weekly
+- Pepper improvements queue becomes the primary roadmap input from here on
+
+---
+
+## Definition Of "Ready For Daily Trust"
+
+Pepper is ready to behave like a true life and executive assistant when:
+
+- it can run for weeks without manual babysitting
+- it rarely interrupts for the wrong reason
+- it reliably catches urgent communication and time-sensitive family logistics
+- it drafts useful follow-ups and preserves them safely
+- it surfaces birthdays, deadlines, renewals, and important relationships proactively
+- it gives researched recommendations with current facts
+- it explains why it is surfacing something
+- every important failure becomes a reproducible test or eval
+
+---
+
+## Practical Rule For Every Iteration
+
+Do not ask "what feature should Pepper have next?"
+
+Ask:
+
+- what important thing did Pepper miss?
+- what noisy thing did Pepper surface unnecessarily?
+- what judgment call did Pepper get wrong?
+- what loop did Pepper fail to close?
+- what behavior should become measurable before we trust it more?
+
+If we keep answering those questions with small, test-backed iterations, Pepper will come to life the right way.
+
+---
+
+## Out Of Scope (Explicitly Deferred)
+
+- Health + finance subsystems — remain on `docs/WISHLIST.md`; their own future phase
+- Voice interface — tracked on `docs/ARCHITECTURE.md` as Future
+- Full People subsystem integration — `subsystems/people/` added in Week 4-5 is deliberately minimal and replaceable; deeper relationship intelligence only if usage demands it
+- macOS desktop app — tracked separately in `docs/MACOS_DESKTOP_APP_PLAN.md`
+- Red-team / security-agent layer — on `docs/WISHLIST.md`

--- a/docs/INFRA_GUIDELINES.md
+++ b/docs/INFRA_GUIDELINES.md
@@ -1,0 +1,186 @@
+# Pepper — Agent Infrastructure Guidelines
+
+## Why Infrastructure Over Model
+
+Pepper will improve faster from better infrastructure around the model than from chasing a newer model. This document translates current best practices from Anthropic, OpenAI, and MCP guidance into Pepper-specific rules.
+
+The system around the agent — the tool registry, memory pipeline, session log, approval policies, and eval flywheel — is what makes Pepper reliably useful. The model is the brain; these are the hands, the nervous system, and the immune system.
+
+---
+
+## 1. Separate Brain, Hands, and Memory
+
+The orchestrator (brain), tools (hands), and session/event log (memory) must stay independent. No tight coupling between them.
+
+- **Orchestrator**: replaceable; knows how to route, plan, and decide
+- **Tools**: isolated subsystems; one job each; no shared state
+- **Session log**: lives outside the live prompt; persists across runs; can be replayed
+
+Applied to Pepper: `agent/core.py` is the brain. `subsystems/*/` are the hands. The PostgreSQL event log is the durable memory. None of these should depend on the internals of another.
+
+---
+
+## 2. Start Single-Agent; Add Subagents Only When Earned
+
+One main orchestrator plus tools covers most of what Pepper needs today. Don't add subagents just because it sounds powerful.
+
+Add a subagent only when you need one of:
+- Parallel retrieval across multiple independent sources
+- Context isolation (untrusted content processed in a separate window)
+- A truly distinct domain with its own tool set and safety profile
+
+Before adding a subagent, ask: could a tool + a well-scoped prompt replace it? Usually yes.
+
+---
+
+## 3. Tools Are First-Class Product Surfaces
+
+Every tool Pepper has should be designed with the same care as a product feature:
+
+| Property | Requirement |
+|---|---|
+| Name | Unambiguous, verb-noun (`search_calendar`, `draft_message`) |
+| Description | Precise; includes when to use and when NOT to use |
+| Schema | Strict types; no freeform string blobs as inputs |
+| Examples | At least one in the description |
+| Risk level | `read` / `write` / `external` / `irreversible` |
+| Approval policy | See §6 |
+| Error contract | Returns `{"error": "..."}` on failure; never raises |
+
+Tool descriptions are the primary interface between the model and the system. Vague descriptions cause wrong tool calls. Wrong tool calls cause trust failures.
+
+---
+
+## 4. Memory Is a Pipeline, Not a Dump
+
+Raw personal data must not sit in the model context. Memory flows through a distillation pipeline:
+
+```
+Raw data (local only)
+  → Structured extraction (Ollama, local)
+  → Facts / summaries with provenance + confidence + timestamp
+  → pgvector store (local)
+  → Selective retrieval into context
+  → Periodic review / expiry
+```
+
+Every memory write must record:
+- **Source**: where did this come from?
+- **Confidence**: how certain is this?
+- **Timestamp**: when was it observed?
+- **Expiry or review date**: when should it be re-verified?
+
+Never overwrite historical memory — append and archive. This is the Additive principle from CLAUDE.md.
+
+---
+
+## 5. Prefer Explicit Retrieval Over Semantic Search Where Possible
+
+For a life assistant, exact retrieval often beats approximate recall:
+
+- Calendar events → SQL filter by date range, not cosine similarity
+- Contact info → exact lookup by name or identifier
+- Financial amounts → precise query, not fuzzy match
+
+Use vector search (pgvector) where the query is inherently fuzzy: "what have I said about this person?", "find a decision I made about X", "what's my general feeling about Y?"
+
+Mixing explicit and semantic retrieval in the right places is the skill. Default to explicit; add semantic where fuzziness is the feature.
+
+---
+
+## 6. Risk Ladder for Autonomy
+
+Not all actions carry the same stakes. Pepper should operate at the appropriate autonomy level for each action type:
+
+| Action Type | Autonomy Level |
+|---|---|
+| Read-only retrieval (calendar, contacts, notes) | Automatic |
+| Summarization, analysis, drafting | Automatic |
+| Creating drafts (message, event, note) | Semi-automatic (show before commit) |
+| Sending messages, posting externally | Requires confirmation |
+| Creating / editing calendar events | Requires confirmation |
+| Financial actions | Requires explicit confirmation |
+| Deleting or overwriting data | Requires explicit confirmation |
+
+When in doubt, err toward confirmation. A life assistant that asks once too often is annoying. A life assistant that takes an irreversible action without asking once is a trust failure.
+
+---
+
+## 7. Hard Boundaries Around Untrusted Text
+
+Emails, messages, web pages, and documents are untrusted. They must not directly shape privileged prompts or tool inputs.
+
+The rule: **convert untrusted content to validated structured fields before it touches tool schemas.**
+
+```
+Raw email body
+  → local extraction (Ollama): sender, subject, intent, entities
+  → validated struct: { from, subject, action_requested, entities[] }
+  → that struct enters the orchestrator context, not the raw body
+```
+
+This prevents prompt injection from emails or messages that contain instructions designed to manipulate Pepper.
+
+---
+
+## 8. Credentials Out of Model-Reachable Environments
+
+API tokens, OAuth credentials, and secrets must not be accessible in the same sandbox where generated code or arbitrary tool outputs execute.
+
+- Credentials live in `.env` files, never in prompts or tool outputs
+- External API calls are made by tool implementations, not by code the model generates
+- No tool should return a credential, token, or secret in its output
+
+---
+
+## 9. Build the Eval Flywheel Early
+
+Pepper's quality compounds only if failures become tests. Log structured traces; inspect failures; turn real failures into eval cases.
+
+Key things to grade:
+- **Tool choice accuracy**: did Pepper pick the right tool for the job?
+- **Privacy leakage**: did any raw personal data reach an external API?
+- **Retrieval quality**: did the right memories surface?
+- **Proactivity calibration**: over-eager or missed?
+- **Approval policy adherence**: did irreversible actions get confirmed?
+
+Even a lightweight eval — 20 traced interactions reviewed weekly — compounds into a meaningfully better system over months.
+
+---
+
+## 10. Optimize for Trust, Not Maximum Agency
+
+The goal is a life assistant the owner would give access to their inbox, calendar, and finances because it has earned that trust. That means:
+
+- Predictable behavior over clever behavior
+- Conservative on irreversible actions
+- Transparent about what it's doing and why
+- Good at knowing when to ask
+
+Trust is the product. Agency is the mechanism. Don't confuse them.
+
+---
+
+## Pepper's Next Highest-Leverage Infrastructure Work
+
+Based on the above, in priority order:
+
+1. **Risk-rated tool registry** — every tool tagged with risk level and approval policy (§3, §6)
+2. **Durable session/event log** — outside the live prompt, replayable, queryable (§1)
+3. **Stricter memory write policy** — provenance, confidence, expiry on every write (§4)
+4. **Trace-based evals** — tool choice, privacy, proactivity quality (§9)
+5. **Stronger people/commitments layer** — commitments, follow-ups, relationship context (§4, §5)
+
+---
+
+## References
+
+- [OpenAI: A practical guide to building agents](https://openai.com/research/a-practical-guide-to-building-agents)
+- [OpenAI: Safety in building agents](https://openai.com/safety/safety-in-building-agents)
+- [OpenAI: Evaluate agent workflows](https://openai.com/research/evaluate-agent-workflows)
+- [Anthropic: Writing effective tools for AI agents](https://docs.anthropic.com/en/docs/build-with-claude/tool-use)
+- [Anthropic: Building agents with the Claude Agent SDK](https://docs.anthropic.com/en/docs/agents-and-tools/claude-code/overview)
+- [Model Context Protocol intro](https://modelcontextprotocol.io/introduction)
+- [MCP security best practices](https://modelcontextprotocol.io/docs/concepts/security)
+- [docs/GUARDRAILS.md](GUARDRAILS.md) — Pepper's harness engineering rules
+- [docs/ARCHITECTURE.md](ARCHITECTURE.md) — system layer model

--- a/docs/PRINCIPLES.md
+++ b/docs/PRINCIPLES.md
@@ -95,7 +95,7 @@ Every subsystem (People, Calendar, Communications, Knowledge, Health, Finance) i
 
 - Subsystems expose standard MCP-compatible tool interfaces
 - No direct imports between subsystems — all communication via local REST or MCP
-- Corela can be upgraded, replaced, or forked without touching Pepper core
+- The People subsystem can be upgraded, replaced, or forked without touching Pepper core
 - The interface layer (Telegram today, something else tomorrow) is similarly replaceable
 
 ---

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -176,7 +176,7 @@ See [LIFE_CONTEXT.md.example](LIFE_CONTEXT.md.example) for the annotated templat
 - Tools: `get_contact_profile`, `find_quiet_contacts`, `search_contacts`
 - `get_contact_profile`: last contact time per channel, dominant channel, multi-channel presence
 - `find_quiet_contacts`: surfaces people who've gone quiet above a threshold (default 14 days)
-- Groundwork for Corela integration
+- Groundwork for future People subsystem integration
 
 **2.6 — Communication Health Dashboard** ✅
 
@@ -845,7 +845,7 @@ This is the largest of the three extension subphases and the one with the most u
 With runtime, skills, and MCP in place, the wishlist items become dramatically cheaper to build:
 
 - **Knowledge layer** → most items become MCP server integrations (Obsidian MCP, filesystem MCP) + skills
-- **Health & Finance** → CSV parsing becomes a skill; Apple Health becomes a local MCP server
+- **Health & Finance** → CSV/export parsing becomes a skill; health sources (Apple Health, Oura Ring, Garmin, Whoop, etc.) each become a local MCP server
 - **Pre-event intelligence / deadline awareness** → already listed as planned skills in 4.4
 - **Maintenance & Security** → scheduled skills running on the background scheduler; the Phase 3.3 error classifier is the foundation
 
@@ -857,7 +857,7 @@ At that point, revisit [WISHLIST.md](WISHLIST.md) and pull items back onto the a
 
 Once the active roadmap is stable, the system begins driving its own evolution:
 
-**Pepper recommends improvements to Corela** based on observed gaps in people/relationship data. When Pepper repeatedly fails to answer a relationship question, it logs that as a Corela improvement opportunity.
+**Pepper recommends improvements to the People subsystem** based on observed gaps in people/relationship data. When Pepper repeatedly fails to answer a relationship question, it logs that as a People subsystem improvement opportunity.
 
 **Pepper recommends new skills** when it notices a workflow being reinvented from scratch repeatedly. The skill reviewer (4.3) is the first step toward this.
 

--- a/docs/SUBSYSTEMS.md
+++ b/docs/SUBSYSTEMS.md
@@ -4,20 +4,20 @@ Each subsystem is a focused data and tool service. Pepper Core calls them; they 
 
 ---
 
-## Subsystem 1: People (Corela)
+## Subsystem 1: People
 
-**Status**: Exists as separate project (`~/Developer/corela`). Integration is a future phase.  
+**Status**: Deferred future phase  
 **Directory**: `subsystems/people/` — currently a stub with interface spec only
 
 ### What it does
 
 Maintains the relationship graph: who's in your life, how they're connected, conversation history across platforms, relationship health signals, scoring, and semantic search over people and communications.
 
-### Why Corela is not Phase 1
+### Why the People subsystem is not Phase 1
 
-Corela is functional but the underlying relationship data hasn't been fully curated or polished. Pepper will identify what relationship data actually matters through usage, then drive Corela's evolution. Better to know what you need before building it.
+Relationship intelligence is useful, but the exact capabilities Pepper needs should be driven by real usage. Better to learn what matters from actual questions and workflows before expanding this layer.
 
-### What Pepper will eventually drive in Corela
+### What Pepper will eventually drive in the People subsystem
 
 - Populate contacts based on people mentioned in iMessage, email, calendar
 - Recommend relationship health improvements based on Pepper's broader life context
@@ -27,7 +27,7 @@ Corela is functional but the underlying relationship data hasn't been fully cura
 ### Integration interface (when ready)
 
 ```text
-GET  /tools                          # 61 tools available
+GET  /tools                          # Available people tools
 POST /tools/get_contact_details      # Person profile
 POST /tools/get_outreach_recs        # Who to reach out to
 POST /tools/get_dormant_contacts     # Relationships going quiet
@@ -200,17 +200,20 @@ Pepper proposes decision log entries through conversation. You accept, edit, or 
 
 ### What it does
 
-Reads Apple Health data and gives Pepper awareness of your physical patterns and energy levels. Not medical — context for better life recommendations.
+Reads health data from multiple sources and gives Pepper awareness of your physical patterns and energy levels. Not medical — context for better life recommendations.
 
 ### Data sources
 
-- **Apple Health export**: Health app → Export All Health Data → XML
-- Full export can be large; process incrementally using `startDate` filtering
-- Categories: steps, sleep, heart rate, exercise, body metrics
+- **Apple Health export**: Health app → Export All Health Data → XML; process incrementally using `startDate` filtering
+- **Oura Ring**: sleep stages, HRV, readiness scores via local export or API
+- **Garmin**: activity, GPS, heart rate via Garmin Connect export
+- **Whoop**: strain, recovery, sleep via export
+- **Other wearables**: any device that exports CSV or JSON (Fitbit, Polar, etc.)
+- Categories across all sources: steps, sleep, heart rate, HRV, exercise, body metrics
 
 ### Privacy
 
-- Apple Health data never leaves the machine
+- All health data stays on the machine
 - Raw metrics stored locally; Pepper receives summaries
 - No integration with any health API — export-only
 
@@ -281,4 +284,4 @@ Subsystems run as independent processes on localhost with different ports:
 - Knowledge: 8102
 - Health: 8103
 - Finance: 8104
-- People (Corela): 8001 (existing)
+- People: TBD

--- a/docs/WISHLIST.md
+++ b/docs/WISHLIST.md
@@ -17,7 +17,7 @@ Revisit this list quarterly, or whenever actual usage surfaces a specific gap th
 - 30 minutes before any calendar event: Pepper pushes a briefing
 - **Work events** (meetings with people): context on who you're meeting, last conversation, open items, suggested talking points
 - **Personal events** (family activities): logistics check — "Do you have what you need? Kids' gear ready? Anything to grab before leaving?"
-- Pulls context from memory and (later) Corela
+- Pulls context from memory and (later) the People subsystem
 - Different prep modes: conversation prep vs practical readiness
 
 **Why deferred**: Once the skill system (active Phase 4) is in place, this becomes a `prep_for_meeting` skill rather than hard-coded Python. Building it now would mean rewriting it later.
@@ -81,12 +81,12 @@ Revisit this list quarterly, or whenever actual usage surfaces a specific gap th
 
 > _Deferred from original Phase 5._
 
-### Apple Health Reader
+### Health Data Reader
 
-- Export and parse Apple Health XML (via Health app export)
-- Incrementally sync activity, sleep, heart rate, key health metrics
+- Support multiple health data sources: Apple Health XML export, Oura Ring, Garmin Connect, Whoop, Fitbit, and others
+- Incrementally sync activity, sleep, heart rate, HRV, and key health metrics from whichever devices the user owns
 - Pepper gains awareness of energy levels, sleep quality, activity patterns
-- Privacy: processed entirely locally
+- Privacy: all processing done locally — raw data never leaves the machine
 
 ### Financial Reader
 
@@ -156,7 +156,7 @@ Revisit this list quarterly, or whenever actual usage surfaces a specific gap th
 
 Once the active roadmap and this wishlist are stable, Pepper begins driving its own evolution:
 
-- **Pepper recommends improvements to Corela** based on observed gaps in people/relationship data
+- **Pepper recommends improvements to the People subsystem** based on observed gaps in people/relationship data
 - **Pepper recommends new subsystems** when patterns suggest a domain isn't covered
 - **Pepper evolves its own life context** as it learns more about your patterns, values, and what matters to you
 - **Pepper begins managing others** — drafting family communications, preparing you for difficult conversations, tracking how family members are doing based on all available signals

--- a/subsystems/people/README.md
+++ b/subsystems/people/README.md
@@ -1,36 +1,33 @@
 # People Subsystem — Stub
 
 **Status**: Future integration  
-**Source project**: `~/Developer/corela`
 
-This subsystem will eventually expose Corela's relationship intelligence (61 tools, pgvector semantic search, relationship scoring) as a standard Pepper subsystem interface.
+This subsystem will eventually expose relationship intelligence as a standard Pepper subsystem interface.
 
 ## Integration is NOT Phase 1
 
-Corela exists and is functional, but:
+This layer is intentionally deferred because:
 
 1. The relationship data hasn't been fully curated
 2. Pepper needs to be operational first to know what relationship data it actually needs
-3. Pepper will drive Corela's evolution based on observed gaps — not the other way around
+3. Pepper should expand this layer based on observed gaps, not speculation
 
-## What Pepper Will Drive in Corela Over Time
+## What Pepper Will Drive in the People Layer Over Time
 
 - Populate contacts from iMessage, email, and calendar attendees Pepper encounters
 - Flag relationship health issues based on Pepper's broader life context (not just message frequency)
-- Recommend Corela feature improvements based on questions Pepper can't answer
+- Recommend People subsystem improvements based on questions Pepper can't answer
 - Provide richer context for people who appear across multiple life domains
 
 ## When Integration Happens
 
-The trigger is: Pepper repeatedly fails to answer a people/relationship question and the answer exists in Corela's data. That failure surfaces the integration as a real need, not a hypothetical one.
+The trigger is: Pepper repeatedly fails to answer a people/relationship question and that failure points to a clear capability gap. That surfaces the integration as a real need, not a hypothetical one.
 
 ## Interface Contract (to be implemented)
 
 ```text
 GET  /health
-GET  /tools           # Subset of Corela's 61 tools relevant to Pepper
+GET  /tools           # People tools relevant to Pepper
 POST /tools/{name}    # Execute tool
 GET  /status
 ```
-
-Port: 8001 (Corela's existing port)


### PR DESCRIPTION
## Summary

This PR updates Pepper's documentation across two related themes: expanding the health subsystem's scope to cover multiple wearable data sources, and removing all hard-coded references to "Corela" in favour of generic People subsystem language. It also introduces two new guideline documents that have been referenced in CLAUDE.md.

---

## Health subsystem: multi-source data

Previously all health-related docs referred exclusively to Apple Health as the data source. This was too narrow — Pepper should be device-agnostic from the start.

**Changes:**
- `CLAUDE.md` — `subsystems/health/` comment now lists Apple Health, Oura Ring, Garmin, Whoop, etc.
- `docs/ARCHITECTURE.md` — HEALTH box in the diagram updated; "Not Yet Started" note broadened
- `docs/SUBSYSTEMS.md` — Health section rewritten: each data source (Apple Health XML, Oura Ring, Garmin Connect, Whoop, Fitbit/Polar CSV) listed explicitly with its ingestion mechanism; privacy note generalised
- `docs/WISHLIST.md` — "Apple Health Reader" renamed to "Health Data Reader" with multi-source framing
- `docs/ROADMAP.md` — MCP server note now lists all major device sources

---

## People subsystem: decouple from Corela

All references to "Corela" (a separate private project) have been replaced with generic "People subsystem" language. This keeps the docs self-contained and accurate regardless of what implementation ends up backing the subsystem.

**Files changed:**
- `CLAUDE.md` — people/ comment and section header updated; PostgreSQL note de-coupled
- `docs/ARCHITECTURE.md` — PEOPLE box and "Not Yet Started" entry updated
- `docs/PRINCIPLES.md` — pluggability example generalised
- `docs/ROADMAP.md` — Phase 2.5 groundwork note + self-evolution section updated
- `docs/SUBSYSTEMS.md` — Subsystem 1 header, rationale, interface contract, and port entry updated; hardcoded "61 tools" count removed
- `docs/WISHLIST.md` — two Corela mentions replaced
- `subsystems/people/README.md` — fully rewritten to remove all Corela-specific details while preserving intent and interface contract

---

## New guideline documents

- **`docs/INFRA_GUIDELINES.md`** — Agent infrastructure guidelines: tool registry patterns, memory pipeline design, autonomy ladder, and eval flywheel. Referenced from CLAUDE.md Key References.
- **`docs/CONTINUOUS_IMPROVEMENT_PLAN.md`** — How Pepper gets iteratively better through evals, simulated chats, and judgment-focused upgrades. Referenced from README.md.

---

## Files changed

| File | Change type |
|---|---|
| `CLAUDE.md` | Updated (health comment, Corela → People, INFRA_GUIDELINES link) |
| `README.md` | Updated (CONTINUOUS_IMPROVEMENT_PLAN link) |
| `docs/ARCHITECTURE.md` | Updated (HEALTH diagram, PEOPLE diagram, Not Yet Started) |
| `docs/PRINCIPLES.md` | Updated (Corela → People subsystem) |
| `docs/ROADMAP.md` | Updated (health MCP note, Corela → People × 2) |
| `docs/SUBSYSTEMS.md` | Updated (Subsystem 1 + Subsystem 5 health section) |
| `docs/WISHLIST.md` | Updated (Health Data Reader rename, Corela → People × 2) |
| `subsystems/people/README.md` | Rewritten (Corela references removed) |
| `docs/INFRA_GUIDELINES.md` | New |
| `docs/CONTINUOUS_IMPROVEMENT_PLAN.md` | New |