### PR TITLE
docs: establish docs/adr/ directory + ADR template (#10)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,6 +31,7 @@ maintenance/    # Self-upgrade and health check agents
 ## Key References
 
 - **Guardrails**: [docs/GUARDRAILS.md](docs/GUARDRAILS.md) — **READ THIS FIRST** — development guardrails based on OpenAI's harness engineering
+- **Architectural decisions**: [docs/adr/](docs/adr/) — canonical home for architectural decision records (ADRs). Any decision that survives a Notion thread becomes an ADR before the implementation PR opens.
 - Architecture: [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md)
 - Roadmap: [docs/ROADMAP.md](docs/ROADMAP.md)
 - Life Context: [docs/LIFE_CONTEXT.md](docs/LIFE_CONTEXT.md) — this is Pepper's ground truth about its owner

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -6,6 +6,8 @@ Pepper is a layered system. The orchestrator agent sits at the center with full 
 
 Nothing is monolithic. Every layer is independently replaceable.
 
+> Architectural decisions that shape this system are recorded in [`adr/`](adr/). When a section here cites an ADR, that ADR is the binding source for the decision — this document is the descriptive surface. `docs/GUARDRAILS.md` still takes precedence over any ADR.
+
 ---
 
 ## Layer Model

--- a/docs/GUARDRAILS.md
+++ b/docs/GUARDRAILS.md
@@ -16,7 +16,8 @@ Pepper must operate under similar principles: **the harness makes the agent reli
 
 **Rule**: Anything the agent can't access in-context doesn't exist.
 
-- All architectural decisions live in `docs/`
+- All architectural decisions live in [`adr/`](adr/) as ADRs. Descriptive docs (architecture, roadmap, principles) live elsewhere in `docs/`; ADRs are the normative source for the decision they record. **This file (GUARDRAILS.md) overrides any ADR if they conflict** — see "ADR precedence" below.
+- **Any decision that survives a Notion thread becomes an ADR before the implementation PR opens.** If the discussion converged, the rationale exists somewhere — capture it in an ADR or it will rot.
 - All configuration schemas live in code or example files (`.env.example`, `config/`)
 - All personal data mappings live in gitignored config files (`config/local/accounts.json`)
 - Knowledge in Google Docs, Slack threads, or people's heads is invisible to the agent
@@ -27,8 +28,11 @@ Pepper must operate under similar principles: **the harness makes the agent reli
 - Life context in `docs/LIFE_CONTEXT.md` (version controlled)
 - Roadmap in `docs/ROADMAP.md` (version controlled)
 - Architecture in `docs/ARCHITECTURE.md` (version controlled)
+- Architectural decisions in [`docs/adr/`](adr/) (version controlled)
 - Development instructions in `CLAUDE.md` (version controlled)
 - Personal config in `config/local/accounts.json` (gitignored, template in repo)
+
+**ADR precedence.** ADRs are normative for the architectural decisions they record, but they sit below this file in the precedence stack. If an ADR — proposed, accepted, or otherwise — conflicts with a guardrail in `GUARDRAILS.md` (Privacy-First, Subsystem Boundaries, Permission Boundaries, etc.), the guardrail wins and the ADR cannot be merged in that form. Reviewers should reject any ADR that weakens a guardrail without a corresponding update to this file landed first.
 
 ### 2. Privacy-First Architecture (Non-Negotiable)
 

--- a/docs/adr/0000-template.md
+++ b/docs/adr/0000-template.md
@@ -1,0 +1,42 @@
+# ADR-NNNN: <one-line title of the decision>
+
+- **Status:** Proposed | Accepted | Superseded by ADR-XXXX | Rejected
+- **Date:** YYYY-MM-DD
+
+## Context
+
+What forces are at play that make this decision necessary now? Capture the situation, the problem, and the constraints. Explain why the status quo is no longer acceptable. A reader who has never seen the project should be able to understand why a decision is being made.
+
+Reference concrete signals: usage data, incidents, capability gaps, prior decisions that have aged poorly. Avoid restating the decision here.
+
+## Decision
+
+State the decision in plain language. One paragraph is usually enough. The reader should be able to act on this section without needing to read further.
+
+If the decision has scope limits ("only applies to X", "does not apply to Y"), spell them out.
+
+## Consequences
+
+What changes as a result of this decision? Be explicit about all three categories:
+
+- **Positive** — what becomes easier, faster, safer, more reliable.
+- **Negative** — what becomes harder, what we are giving up, what new costs we are taking on.
+- **Neutral** — what changes shape but neither helps nor hurts.
+
+Include any follow-up work this decision creates: docs to update, code to migrate, deprecations to schedule.
+
+## Alternatives considered
+
+List every option that was seriously considered. At minimum, include the **status quo** ("do nothing") option, even when it was obviously inadequate — naming it explicitly stops it from being re-proposed later.
+
+For each alternative, state:
+
+- What it was.
+- Why it was rejected, in one or two sentences.
+
+## References
+
+- Notion threads, Linear tickets, GitHub issues that drove this decision.
+- Prior or related ADRs.
+- External writing (papers, blog posts) that informed the choice.
+- The PR that landed this ADR.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,47 @@
+# Architectural Decision Records (ADRs)
+
+This directory is the canonical home for Pepper's architectural decisions.
+
+An ADR captures a single decision, the forces that drove it, the alternatives considered, and the consequences. ADRs are immutable once accepted: if a future decision overturns them, write a new ADR with status `Superseded by ADR-XXXX` and update the old one's status accordingly.
+
+ADRs are not design docs, planning docs, or how-to guides. Those belong in `docs/`. ADRs only exist to record decisions whose rationale would otherwise rot in a Slack thread, a Notion page, or somebody's head.
+
+## When to write an ADR
+
+Write one whenever a decision meets all of:
+
+- It is **architectural** — it shapes the system's structure, boundaries, dependencies, or operating principles.
+- It is **non-obvious** — a future contributor reading the code alone could not reconstruct the rationale.
+- It **survives a Notion thread** — the discussion has converged and is about to land in code.
+
+`docs/GUARDRAILS.md` formalizes the rule: any decision that survives a Notion thread becomes an ADR before the implementation PR opens.
+
+## Lifecycle
+
+Each ADR has a `Status` field that follows this state machine:
+
+- **Proposed** — drafted, in review. The decision is not yet binding.
+- **Accepted** — merged to `main`. The decision is binding for new work.
+- **Superseded by ADR-XXXX** — a newer ADR replaced it. The old ADR stays in the directory for historical context; only the status changes.
+- **Rejected** — drafted but explicitly not adopted. Kept so the same idea is not re-litigated from scratch later.
+
+ADRs do not get deleted. Their numbers do not get reused.
+
+## How to add a new ADR
+
+1. Pick the next free number `NNNN`. Numbers are zero-padded to four digits and assigned in the order ADRs are proposed.
+2. Copy `0000-template.md` to `NNNN-<slug>.md` where `<slug>` is a short kebab-case description (e.g. `0005-introduce-event-bus.md`). Do not edit `0000-template.md` itself.
+3. Fill in every section. If a section genuinely does not apply, write `N/A — <reason>` rather than deleting it.
+4. Open a PR with `Status: Proposed`. The PR is the discussion venue.
+5. On merge, flip the status to `Accepted` (or `Rejected` and merge anyway, so future contributors see the rejected option).
+6. If the ADR makes a roadmap-level commitment, add a one-line reference to it from `docs/ROADMAP.md`.
+
+## Index
+
+- [0000-template.md](0000-template.md) — template (do not edit; copy it)
+- [0001-resequence-around-oj-calibration.md](0001-resequence-around-oj-calibration.md) — re-sequence around OJ-calibration third option
+- [0002-fifth-anchoring-principle-compounding-capability.md](0002-fifth-anchoring-principle-compounding-capability.md) — add fifth anchoring principle (compounding capability)
+- [0003-layer-2-is-the-active-surface.md](0003-layer-2-is-the-active-surface.md) — Layer 2 (Intelligence) is the active surface
+- [0004-introduce-agents-directory.md](0004-introduce-agents-directory.md) — introduce `agents/` directory parallel to `subsystems/`
+
+The four foundational ADRs above are tracked in [Epic 00: Foundations & ADRs](https://github.com/jacksteroo/Pepper/issues/9).


### PR DESCRIPTION
Implements [#10](https://github.com/jacksteroo/Pepper/issues/10) — the ADR scaffolding that the four foundational ADRs (#11–#14) build on.

## Summary

- Adds `docs/adr/README.md` (purpose, lifecycle, numbering, how-to-add-an-ADR).
- Adds `docs/adr/0000-template.md` with the seven required sections: Status, Date, Context, Decision, Consequences (positive/negative/neutral split out), Alternatives considered, References.
- `CLAUDE.md` and `docs/ARCHITECTURE.md` now point to `docs/adr/` as the canonical home for architectural decisions.
- `docs/GUARDRAILS.md` adds the Notion-thread rule (*"Any decision that survives a Notion thread becomes an ADR before the implementation PR opens"*) and an explicit precedence clause: GUARDRAILS overrides any ADR if they conflict.

## Reviewable in isolation

Docs only. No code, no dependencies, no CI changes.

## Test plan

- [x] `docs/adr/0000-template.md` is the template that #11–#14 will copy verbatim.
- [x] All cross-links resolve (`docs/adr/` from root, `adr/` from `docs/`).
- [x] `docs/adr/` is referenced from `CLAUDE.md`, `docs/ARCHITECTURE.md`, and `docs/GUARDRAILS.md`.
- [x] GUARDRAILS precedence over ADRs is explicit so an ADR can't quietly weaken a guardrail.

Parent epic: #9.