### PR TITLE
traces: ADR-0005 + canonical schema + frozen dataclass stub (#18, #19)

### DIFF
--- a/agent/tests/test_traces_schema.py
+++ b/agent/tests/test_traces_schema.py
@@ -1,0 +1,196 @@
+"""Schema-stub tests for `agent.traces.schema`.
+
+Locks in the invariants documented in `docs/trace-schema.md` so a future
+edit to the dataclass cannot silently drift from the canonical doc /
+ADR-0005. Wider behavioral tests land alongside the repository (#20)
+and the emitter (#22).
+"""
+from __future__ import annotations
+
+import dataclasses
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+
+from agent.error_classifier import DataSensitivity
+from agent.traces import (
+    EMBEDDING_DIM,
+    EMBEDDING_MODEL_DEFAULT,
+    PROMPT_VERSION_UNVERSIONED,
+    Archetype,
+    Trace,
+    TraceTier,
+    TriggerSource,
+)
+
+
+def _embedding(value: float = 0.1) -> list[float]:
+    return [value] * EMBEDDING_DIM
+
+
+class TestTraceDefaults:
+    def test_defaults_match_canonical_initial_state(self) -> None:
+        t = Trace()
+        # New traces are user-initiated orchestrator turns in the working tier.
+        assert t.trigger_source is TriggerSource.USER
+        assert t.archetype is Archetype.ORCHESTRATOR
+        assert t.tier is TraceTier.WORKING
+        # Privacy-conservative default: assume RAW_PERSONAL until proven otherwise.
+        assert t.data_sensitivity is DataSensitivity.LOCAL_ONLY
+        # Embedding is opt-in.
+        assert t.embedding is None
+        assert t.embedding_model_version is None
+        # User reaction is lazy.
+        assert t.user_reaction is None
+        # Pre-#48: prompt_version defaults to the documented sentinel.
+        assert t.prompt_version == PROMPT_VERSION_UNVERSIONED
+        # Timing fields are populated.
+        assert isinstance(t.created_at, datetime)
+        assert t.created_at.tzinfo is timezone.utc
+        # ID is a valid UUID4 string.
+        uuid.UUID(t.trace_id)
+
+    def test_each_trace_id_is_unique(self) -> None:
+        ids = {Trace().trace_id for _ in range(50)}
+        assert len(ids) == 50
+
+
+class TestTraceImmutability:
+    def test_trace_is_frozen(self) -> None:
+        t = Trace()
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            t.data_sensitivity = DataSensitivity.PUBLIC  # type: ignore[misc]
+
+    def test_dataclasses_replace_revalidates(self) -> None:
+        # `dataclasses.replace` is the canonical way to derive a new trace.
+        # Validation MUST run on the derived instance — otherwise frozen=True
+        # is meaningless for invariant enforcement.
+        t = Trace()
+        with pytest.raises(ValueError, match="embedding dimension"):
+            dataclasses.replace(t, embedding=[0.0] * 8, embedding_model_version="x")
+
+
+class TestTraceInvariants:
+    def test_embedding_requires_model_version(self) -> None:
+        with pytest.raises(ValueError, match="embedding_model_version"):
+            Trace(embedding=_embedding())
+
+    def test_embedding_dimension_is_locked(self) -> None:
+        with pytest.raises(ValueError, match="embedding dimension"):
+            Trace(embedding=[0.0] * 768, embedding_model_version="nomic-embed-text")
+
+    def test_embedding_with_model_version_is_allowed(self) -> None:
+        t = Trace(embedding=_embedding(), embedding_model_version=EMBEDDING_MODEL_DEFAULT)
+        assert t.embedding_model_version == EMBEDDING_MODEL_DEFAULT
+        assert len(t.embedding or []) == EMBEDDING_DIM
+
+    def test_scheduler_job_name_requires_scheduler_trigger(self) -> None:
+        with pytest.raises(ValueError, match="scheduler_job_name"):
+            Trace(
+                trigger_source=TriggerSource.USER,
+                scheduler_job_name="morning_brief",
+            )
+
+    def test_scheduler_trigger_accepts_job_name(self) -> None:
+        t = Trace(
+            trigger_source=TriggerSource.SCHEDULER,
+            scheduler_job_name="weekly_review",
+        )
+        assert t.scheduler_job_name == "weekly_review"
+
+    def test_scheduler_trigger_without_job_name_is_allowed(self) -> None:
+        # Pre-#23 wiring may emit scheduler traces without a job name; the
+        # schema does not require it. #23 makes population mandatory at the
+        # call site.
+        t = Trace(trigger_source=TriggerSource.SCHEDULER)
+        assert t.scheduler_job_name is None
+
+
+class TestJsonbShapeValidation:
+    def test_assembled_context_must_be_dict(self) -> None:
+        with pytest.raises(TypeError, match="assembled_context"):
+            Trace(assembled_context=["not", "a", "dict"])  # type: ignore[arg-type]
+
+    def test_tools_called_must_be_list(self) -> None:
+        with pytest.raises(TypeError, match="tools_called"):
+            Trace(tools_called={"not": "a list"})  # type: ignore[arg-type]
+
+    def test_tools_called_element_must_be_dict(self) -> None:
+        with pytest.raises(TypeError, match=r"tools_called\[0\]"):
+            Trace(tools_called=["not a dict"])  # type: ignore[list-item]
+
+    def test_tools_called_element_must_have_name(self) -> None:
+        with pytest.raises(ValueError, match="missing required keys"):
+            Trace(tools_called=[{"args": {}, "result_summary": "ok"}])
+
+    def test_tools_called_well_formed_passes(self) -> None:
+        t = Trace(
+            tools_called=[
+                {
+                    "name": "send_telegram_message",
+                    "args": {"chat_id": "123", "text": "hi"},
+                    "result_summary": "ok",
+                    "latency_ms": 42,
+                    "error": None,
+                },
+            ],
+        )
+        assert t.tools_called[0]["name"] == "send_telegram_message"
+
+    def test_unjsonable_payload_is_rejected(self) -> None:
+        # A circular reference is the canonical "JSON-impossible" payload.
+        bad: dict[str, object] = {}
+        bad["self"] = bad
+        with pytest.raises(ValueError, match="JSON-serialisable"):
+            Trace(assembled_context=bad)
+
+
+class TestReprRedaction:
+    def test_repr_does_not_leak_input_or_output(self) -> None:
+        secret_in = "social security 123-45-6789"
+        secret_out = "transferred to account 9876543210"
+        t = Trace(input=secret_in, output=secret_out)
+        r = repr(t)
+        assert "123-45-6789" not in r
+        assert "9876543210" not in r
+        assert "<redacted" in r
+        # Metadata that helps debugging is still present.
+        assert t.trace_id[:8] in r
+        assert "trigger_source" in r
+
+    def test_repr_does_not_leak_assembled_context_values(self) -> None:
+        t = Trace(
+            assembled_context={"items": [{"summary": "leaked-pii-string"}]},
+        )
+        assert "leaked-pii-string" not in repr(t)
+
+    def test_repr_does_not_leak_tool_call_args(self) -> None:
+        t = Trace(
+            tools_called=[
+                {"name": "lookup", "args": {"phone": "555-leaked"}, "result_summary": "ok"},
+            ],
+        )
+        assert "555-leaked" not in repr(t)
+
+
+class TestEnumCoverage:
+    def test_trigger_source_members_match_doc(self) -> None:
+        assert {m.value for m in TriggerSource} == {"user", "scheduler", "agent"}
+
+    def test_archetype_members_match_adr_0004(self) -> None:
+        assert {m.value for m in Archetype} == {
+            "orchestrator",
+            "reflector",
+            "monitor",
+            "researcher",
+        }
+
+    def test_tier_members_match_compression_policy(self) -> None:
+        assert {m.value for m in TraceTier} == {"working", "recall", "archival"}
+
+    def test_data_sensitivity_is_reused_not_duplicated(self) -> None:
+        # Schema mirrors the existing enum exactly — no parallel definition.
+        from agent.error_classifier import DataSensitivity as Source
+
+        assert DataSensitivity is Source

--- a/agent/traces/__init__.py
+++ b/agent/traces/__init__.py
@@ -1,0 +1,28 @@
+"""Trace substrate — canonical per-turn record of agent behavior.
+
+See `docs/adr/0005-trace-schema.md` and `docs/trace-schema.md` for the
+schema contract. This package starts as a schema stub (#18) and grows
+into a full append-only repository (#20), emitter (#22), compression
+policy (#21), and read-only HTTP surface (#24).
+"""
+from agent.error_classifier import DataSensitivity
+from agent.traces.schema import (
+    EMBEDDING_DIM,
+    EMBEDDING_MODEL_DEFAULT,
+    PROMPT_VERSION_UNVERSIONED,
+    Archetype,
+    Trace,
+    TraceTier,
+    TriggerSource,
+)
+
+__all__ = [
+    "Archetype",
+    "DataSensitivity",
+    "EMBEDDING_DIM",
+    "EMBEDDING_MODEL_DEFAULT",
+    "PROMPT_VERSION_UNVERSIONED",
+    "Trace",
+    "TraceTier",
+    "TriggerSource",
+]

--- a/agent/traces/schema.py
+++ b/agent/traces/schema.py
@@ -1,0 +1,208 @@
+"""Canonical Python contract for the `traces` table.
+
+This file is the in-code mirror of `docs/trace-schema.md`. Any change here
+must be reflected there (and in the migration #20 once that lands).
+
+Scope of #18 is the schema only — the SQLAlchemy model, repository, and
+emitter all land in later sub-issues. This module intentionally does not
+import from `agent.db` so it can be loaded standalone (e.g. by the
+optimizer, by tests that fake the store).
+
+The dataclass is `frozen=True` so an in-process holder cannot silently
+mutate a constructed `Trace` between `start()` and persistence. The
+mutable accumulator that turns a turn-in-progress into a finalized
+`Trace` lands as `TraceBuilder` in #22.
+"""
+from __future__ import annotations
+
+import json
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Any, Optional
+
+from agent.error_classifier import DataSensitivity
+
+# Embedding dimension is locked to qwen3-embedding:0.6b's output. Mismatched
+# dimensions would silently store and explode at the pgvector layer; the
+# dataclass refuses them up front. See ADR-0005 §"Storage decision".
+EMBEDDING_DIM: int = 1024
+EMBEDDING_MODEL_DEFAULT: str = "qwen3-embedding:0.6b"
+
+# Sentinel for prompt version when #48's prompt-versioning has not yet
+# wrapped a code path. #22 callers may set this freely; the optimizer
+# (#46) treats `unversioned` as "ineligible for prompt-level rollups".
+PROMPT_VERSION_UNVERSIONED: str = "unversioned"
+
+
+class TriggerSource(str, Enum):
+    """What initiated the turn this trace records."""
+
+    USER = "user"
+    SCHEDULER = "scheduler"
+    AGENT = "agent"
+
+
+class Archetype(str, Enum):
+    """Which agent process produced this trace.
+
+    Maps 1:1 to the four processes named in ADR-0004.
+    """
+
+    ORCHESTRATOR = "orchestrator"
+    REFLECTOR = "reflector"
+    MONITOR = "monitor"
+    RESEARCHER = "researcher"
+
+
+class TraceTier(str, Enum):
+    """Compression tier (see #21).
+
+    New rows are created in WORKING. The nightly job from #21 is the only
+    writer that may transition a row from WORKING → RECALL → ARCHIVAL —
+    one of the documented UPDATE carve-outs in ADR-0005 §Mutability.
+    """
+
+    WORKING = "working"
+    RECALL = "recall"
+    ARCHIVAL = "archival"
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _new_trace_id() -> str:
+    return str(uuid.uuid4())
+
+
+# Keys that every element of `tools_called` must carry. The full shape
+# lives in `docs/trace-schema.md`; this is the minimum #20's GIN index
+# can rely on.
+_TOOLS_CALLED_REQUIRED_KEYS = frozenset({"name"})
+
+
+@dataclass(frozen=True)
+class Trace:
+    """One turn of agent behavior — input through outcome.
+
+    Field semantics, nullability, and RAW_PERSONAL annotations live in
+    `docs/trace-schema.md`. This dataclass is the contract that #20's
+    SQLAlchemy model and #22's `TraceBuilder` materialize against.
+
+    Frozen: a constructed `Trace` is the row that will be persisted.
+    Pre-persist accumulation happens in `TraceBuilder` (#22), which calls
+    `Trace(...)` exactly once at `finish()`.
+    """
+
+    # Identity & timing
+    trace_id: str = field(default_factory=_new_trace_id)
+    created_at: datetime = field(default_factory=_utcnow)
+
+    # Provenance
+    trigger_source: TriggerSource = TriggerSource.USER
+    archetype: Archetype = Archetype.ORCHESTRATOR
+    scheduler_job_name: Optional[str] = None
+
+    # Conversation payload (RAW_PERSONAL — redacted from __repr__)
+    input: str = ""
+    assembled_context: dict[str, Any] = field(default_factory=dict)
+    output: str = ""
+
+    # Model & prompt
+    model_selected: str = ""
+    model_version: str = ""
+    prompt_version: str = PROMPT_VERSION_UNVERSIONED
+
+    # Tool calls (RAW_PERSONAL inside .args / .result_summary — redacted from __repr__)
+    tools_called: list[dict[str, Any]] = field(default_factory=list)
+
+    # Outcome
+    latency_ms: int = 0
+    user_reaction: Optional[dict[str, Any]] = None
+    data_sensitivity: DataSensitivity = DataSensitivity.LOCAL_ONLY
+
+    # Embedding (lazy-populated; nullable by design — see #21 / #22)
+    embedding: Optional[list[float]] = None
+    embedding_model_version: Optional[str] = None
+
+    # Compression tier — only the #21 nightly job advances this.
+    tier: TraceTier = TraceTier.WORKING
+
+    def __post_init__(self) -> None:
+        # ── Embedding invariants ──
+        if self.embedding is not None:
+            if not self.embedding_model_version:
+                raise ValueError(
+                    "embedding_model_version is required when embedding is set",
+                )
+            if len(self.embedding) != EMBEDDING_DIM:
+                raise ValueError(
+                    f"embedding dimension must be {EMBEDDING_DIM}, "
+                    f"got {len(self.embedding)}",
+                )
+
+        # ── Provenance invariants ──
+        if (
+            self.trigger_source != TriggerSource.SCHEDULER
+            and self.scheduler_job_name is not None
+        ):
+            raise ValueError(
+                "scheduler_job_name set on a non-scheduler trace",
+            )
+
+        # ── Shape invariants on the open jsonb columns ──
+        if not isinstance(self.assembled_context, dict):
+            raise TypeError(
+                f"assembled_context must be dict, got {type(self.assembled_context).__name__}",
+            )
+        if not isinstance(self.tools_called, list):
+            raise TypeError(
+                f"tools_called must be list, got {type(self.tools_called).__name__}",
+            )
+        for i, tc in enumerate(self.tools_called):
+            if not isinstance(tc, dict):
+                raise TypeError(
+                    f"tools_called[{i}] must be dict, got {type(tc).__name__}",
+                )
+            missing = _TOOLS_CALLED_REQUIRED_KEYS - tc.keys()
+            if missing:
+                raise ValueError(
+                    f"tools_called[{i}] missing required keys: {sorted(missing)}",
+                )
+
+        # ── JSON serialisability — the row is going to jsonb, fail at the boundary
+        # rather than deep inside the SQLAlchemy emitter. ──
+        try:
+            json.dumps(self.assembled_context, default=str)
+            json.dumps(self.tools_called, default=str)
+            if self.user_reaction is not None:
+                json.dumps(self.user_reaction, default=str)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(
+                f"trace jsonb columns must be JSON-serialisable: {exc}",
+            ) from exc
+
+    # __repr__ is the most likely accidental leak path: a stray
+    # `logger.info(trace)` between now and #25's regression test would
+    # spill RAW_PERSONAL into structured logs that are not part of the
+    # traces table's privacy posture. Redact those columns; keep the
+    # metadata that helps debugging.
+    def __repr__(self) -> str:  # pragma: no cover - exercised by tests
+        return (
+            f"Trace(trace_id={self.trace_id!r}, "
+            f"created_at={self.created_at.isoformat()!r}, "
+            f"trigger_source={self.trigger_source.value!r}, "
+            f"archetype={self.archetype.value!r}, "
+            f"model_selected={self.model_selected!r}, "
+            f"prompt_version={self.prompt_version!r}, "
+            f"latency_ms={self.latency_ms}, "
+            f"data_sensitivity={self.data_sensitivity.value!r}, "
+            f"tier={self.tier.value!r}, "
+            f"input=<redacted len={len(self.input)}>, "
+            f"output=<redacted len={len(self.output)}>, "
+            f"assembled_context=<redacted keys={sorted(self.assembled_context.keys())}>, "
+            f"tools_called=<redacted n={len(self.tools_called)}>, "
+            f"embedding=<{'present' if self.embedding is not None else 'none'}>)"
+        )

--- a/docs/adr/0005-trace-schema.md
+++ b/docs/adr/0005-trace-schema.md
@@ -1,0 +1,118 @@
+# ADR-0005: Trace schema — canonical record of every agent turn
+
+- **Status:** Proposed
+- **Date:** 2026-05-02
+
+## Context
+
+Pepper has run for several months without a structured per-turn record. Diagnostics live in scattered logs (`agent/chat_turn_logger.py` writes JSONL, `routing_events` captures router decisions, `mcp_audit` captures tool invocations) and there is no single place that joins *what was asked → what context was assembled → which model was selected → which tools fired → what was returned → how the user reacted*.
+
+That gap blocks two roadmap epics:
+
+- **Epic 04 (`agents/reflector`)** — daily/weekly reflection only works if there is one queryable record per turn.
+- **Epic 05 (DSPy/GEPA optimizer)** — prompt optimization requires labelled trajectories, which is exactly what a trace is.
+
+Source: [OJ calibration import #1](https://www.notion.so/jacksteroo/OpenJarvis-calibration-lessons-challenges-shortest-path-354fb736739081ae8834eb6be2d361c0) called out that without traces, reflection collapses into "vibes-based LLM self-prompting that hallucinates as confidently as `hermes3` does about health metrics" — the same failure mode the maintainer already filed in `feedback_hermes3_health_hallucination.md`.
+
+The schema is the contract that downstream epics read against. Getting field names, types, and nullability wrong now forces a painful migration after E4/E5 land.
+
+## Decision
+
+Define the canonical `Trace` record. Every agent turn — user-triggered or scheduler-triggered, every archetype — produces exactly one row with the fields below.
+
+### Fields
+
+| Field | Type | Nullable | RAW_PERSONAL | Notes |
+|---|---|---|---|---|
+| `trace_id` | uuid | no | no | Primary key. |
+| `created_at` | timestamptz | no | no | Indexed (B-tree). |
+| `trigger_source` | enum (`user` \| `scheduler` \| `agent`) | no | no | Distinguishes proactive vs reactive turns. |
+| `scheduler_job_name` | text | yes | no | Set when `trigger_source = scheduler`. |
+| `archetype` | enum (`orchestrator` \| `reflector` \| `monitor` \| `researcher`) | no | no | Indexed jointly with `created_at`. |
+| `input` | text | no | **yes** | The user message or scheduler trigger payload. |
+| `assembled_context` | jsonb | no | **yes** | Output of E3 context assembly with provenance (`{items: [{source, ref, summary}], strategy}`). Stub-populated until #33 lands. |
+| `model_selected` | text | no | no | E.g. `hermes3-local`, `claude-opus-4-7`. |
+| `model_version` | text | no | no | Pinned model identifier (e.g. SHA, API version tag). |
+| `prompt_version` | text | no | no | Versioned per E5 (#48). |
+| `tools_called` | jsonb | no | **yes** | Array of `{name, args, result_summary, latency_ms, error}`. Indexed (GIN) for "which traces called X". |
+| `output` | text | no | **yes** | Final assistant response text. |
+| `latency_ms` | int | no | no | End-to-end turn latency. |
+| `user_reaction` | jsonb | yes | yes | `{thumbs: +1\|-1\|null, followup_correction: bool, source: explicit\|inferred}` — populated when signal arrives, may stay null forever. |
+| `data_sensitivity` | enum (mirrors `agent.error_classifier.DataSensitivity`) | no | no | First-class column so consumers filter without parsing the row. |
+| `embedding` | vector(1024) | yes | derived | Embedding of `input` + `output`. Nullable by design — recall-tier compression drops it (recoverable). |
+| `embedding_model_version` | text | yes | no | E.g. `qwen3-embedding:0.6b`. Required when `embedding` is non-null. |
+| `tier` | enum (`working` \| `recall` \| `archival`) | no | no | Compression tier (#21). New rows are `working`. |
+
+### Storage decision: pgvector on traces from day one
+
+Per #19 (resolved 2026-05-02): the trace store exists for the agent to reason over its own behavior. That is fundamentally a similarity problem. Embedding cost is negligible because `qwen3-embedding:0.6b` (1024-dim) is already loaded for the router. Re-embedding on model swap is tractable as long as `embedding_model_version` is recorded per row (which it is). HNSW index on `embedding`. Recall-tier compression treats the embedding as expendable — text is preserved, embedding can be recomputed.
+
+### Mutability
+
+Append-only at the application layer for the **conversation payload** — `input`, `output`, `assembled_context`, `tools_called`, `latency_ms`, and the provenance fields are written exactly once at `INSERT` and never change.
+
+Three columns are explicit, narrow UPDATE carve-outs because the row is created before the value is known:
+
+| Column | Updated by | When |
+|---|---|---|
+| `embedding`, `embedding_model_version` | async embedding worker (#22 step 5) | After the orchestrator finishes the turn — embedding generation runs off the critical path. |
+| `tier` | nightly compression job (#21) | Once per row, advancing `working → recall → archival`. Companion column trims (e.g. setting `embedding = NULL` at the recall boundary) ride this same UPDATE. |
+| `user_reaction` | reaction-capture path (separate from this epic) | When an explicit thumb arrives or a follow-up correction is inferred. |
+
+`data_sensitivity` is **not** an UPDATE carve-out: a row's sensitivity is set at `INSERT` and immutable for the row's lifetime. Reclassification (e.g. promoting a `local_only` row to `sanitized` after redaction) is performed by inserting a new derivative row, never by mutating the original.
+
+The Python `Trace` dataclass (`agent/traces/schema.py`) is `frozen=True` so an in-process holder cannot circumvent these rules between `start()` and persistence. The mutable accumulator that turns a turn-in-progress into a finalized `Trace` is `TraceBuilder`, landing in #22.
+
+### Postgres roles & grants (mandate for #20)
+
+Three roles divide trace-table privilege:
+
+- **`pepper_traces_writer`** (used by `agent/core.py`, `agent/scheduler.py`, and the four agent processes) — `INSERT` only. No `UPDATE`, no `DELETE`.
+- **`pepper_traces_compactor`** (used by the embedding worker and the nightly compression job) — `SELECT` plus `UPDATE` on `(embedding, embedding_model_version, tier)`. No `DELETE`. No `UPDATE` on any other column.
+- **`pepper_traces_reader`** (used by E4 reflector, E5 optimizer, and the `/traces` HTTP route #24) — `SELECT` only.
+
+The compactor role is the only path by which the carve-out columns may change. Postgres permits per-column `GRANT UPDATE (col1, col2, col3) ON traces`; #20 uses that. Without a per-column `UPDATE` grant the compactor would have full-row update rights, defeating the invariant at the database layer.
+
+`DELETE` is not granted to any role. Retention is enforced exclusively through the `tier` column — there is no path that removes a trace from the table once it has been written.
+
+### Privacy
+
+`input`, `assembled_context`, `output`, `tools_called.result_summary`, and (transitively) `embedding` may contain raw personal data. The schema is local-only by construction:
+
+- The `traces` table lives in the same Postgres instance as `memory_events` and `routing_events` — no separate cloud-hosted store, ever.
+- No tool, MCP server, or HTTP route may serialize a trace to a destination outside the host. #25 enforces this with a regression test in the existing 59-test MCP suite.
+- The `data_sensitivity` column is a first-class filter so consumers (UI panel #24, optimizer #45) can drop rows above their handling capability without parsing field-by-field.
+
+### Consequences
+
+**Positive**
+
+- E4 and E5 unblocked — both epics can read against a stable contract.
+- One source of truth for "what happened on turn X" replaces three scattered log streams.
+- Embedding-on-traces enables free clustering and "find similar past turns" (#24's similarity action).
+
+**Negative**
+
+- Storage cost: ~1024-dim vector + jsonb per turn. Mitigated by tiered compression (#21).
+- Trace emission adds latency to every turn. Bounded by #22's <50ms p95 acceptance criterion; embedding generation is async to keep the path off the critical path.
+- Schema changes after this ADR require a real migration with backfill, not a SQLAlchemy `create_all` no-op.
+
+**Neutral**
+
+- `agent/chat_turn_logger.py` (JSONL writer) keeps existing semantic-router responsibilities. Trace emission is additive, not a replacement. Reconciliation between the two log streams is intentionally out of scope for E1 and is filed for follow-up if the redundancy becomes a maintenance burden.
+
+## Alternatives considered
+
+- **Status quo (do nothing).** Reflection and optimization both stall on missing data. Rejected — explicitly the failure mode named in the OJ calibration import.
+- **Relational-only traces (no embeddings).** Cheaper storage, no model-swap re-embed risk. Rejected per #19 — the dominant access pattern for E4/E5 is similarity search.
+- **Reuse `routing_events` and add columns.** Avoids a new table. Rejected — `routing_events` is router-scoped, already at 8 indexes, and conflating per-turn trace data with router telemetry would couple two epics that should evolve independently.
+- **External trace store (LangSmith, Helicone, Phoenix).** Off-the-shelf UI. Rejected — violates the privacy principle that raw personal data never leaves the host.
+
+## References
+
+- Parent epic: [Epic 01: Trace Substrate (#17)](https://github.com/jacksteroo/Pepper/issues/17)
+- Sub-issues: [#18 schema](https://github.com/jacksteroo/Pepper/issues/18), [#19 pgvector decision](https://github.com/jacksteroo/Pepper/issues/19)
+- Notion: [OJ calibration import #1](https://www.notion.so/jacksteroo/OpenJarvis-calibration-lessons-challenges-shortest-path-354fb736739081ae8834eb6be2d361c0)
+- Related ADRs: [ADR-0002 compounding capability](0002-fifth-anchoring-principle-compounding-capability.md), [ADR-0003 Layer 2 is the active surface](0003-layer-2-is-the-active-surface.md), [ADR-0004 introduce `agents/` directory](0004-introduce-agents-directory.md)
+- Canonical schema doc: [`docs/trace-schema.md`](../trace-schema.md)
+- Python contract: [`agent/traces/schema.py`](../../agent/traces/schema.py)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -43,5 +43,6 @@ ADRs do not get deleted. Their numbers do not get reused.
 - [0002-fifth-anchoring-principle-compounding-capability.md](0002-fifth-anchoring-principle-compounding-capability.md) — add fifth anchoring principle (compounding capability)
 - [0003-layer-2-is-the-active-surface.md](0003-layer-2-is-the-active-surface.md) — Layer 2 (Intelligence) is the active surface
 - [0004-introduce-agents-directory.md](0004-introduce-agents-directory.md) — introduce `agents/` directory parallel to `subsystems/`
+- [0005-trace-schema.md](0005-trace-schema.md) — canonical `Trace` record (Epic 01)
 
-The four foundational ADRs above are tracked in [Epic 00: Foundations & ADRs](https://github.com/jacksteroo/Pepper/issues/9).
+The four foundational ADRs above (0001–0004) are tracked in [Epic 00: Foundations & ADRs](https://github.com/jacksteroo/Pepper/issues/9). ADR-0005 is the first decision record produced under [Epic 01: Trace Substrate](https://github.com/jacksteroo/Pepper/issues/17).

--- a/docs/trace-schema.md
+++ b/docs/trace-schema.md
@@ -1,0 +1,172 @@
+# Trace Schema (canonical)
+
+This is the canonical reference for the `traces` table. Decision rationale lives in [ADR-0005](adr/0005-trace-schema.md). The Python contract that mirrors this doc lives in [`agent/traces/schema.py`](../agent/traces/schema.py). The Postgres migration that materializes it lands in #20.
+
+## Field reference
+
+Every field in the `Trace` record, with its writer (where the value is set) and at least one reader (where it is consumed).
+
+### Identity & timing
+
+| Field | Type | Nullable | Writer | Reader |
+|---|---|---|---|---|
+| `trace_id` | uuid | no | `TraceBuilder.start()` | UI detail view (#24); reflector cross-reference (#39) |
+| `created_at` | timestamptz | no | `TraceBuilder.start()` | reflector daily window (#39); UI list filter (#24) |
+
+### Provenance
+
+| Field | Type | Nullable | Writer | Reader |
+|---|---|---|---|---|
+| `trigger_source` | enum | no | `agent/core.py` (`user`), `agent/scheduler.py` (`scheduler`), `agents/*` (`agent`) | reflector (proactive vs reactive analysis) |
+| `scheduler_job_name` | text | yes | `agent/scheduler.py` per-job wiring (#23) | reflector failure-mode rollups (#41) |
+| `archetype` | enum | no | the agent process emitting the trace | reflector per-archetype rollups (#37, #39) |
+
+`trigger_source` enum members:
+
+- `user` — turn originated from a user message (Telegram, web UI, Slack passthrough).
+- `scheduler` — APScheduler invoked `pepper.chat()`.
+- `agent` — another agent process (reflector, monitor, researcher) invoked the orchestrator.
+
+`archetype` enum members map 1:1 to the four agent processes named in [ADR-0004](adr/0004-introduce-agents-directory.md):
+
+- `orchestrator` — the user-facing turn-by-turn agent (current `PepperCore`).
+- `reflector` — periodic introspection over recent traces (#39).
+- `monitor` — recurring failure-mode detector (#41).
+- `researcher` — long-horizon background research agent (placeholder; no producer yet).
+
+### Conversation payload (RAW_PERSONAL)
+
+| Field | Type | Nullable | Writer | Reader |
+|---|---|---|---|---|
+| `input` | text | no | `TraceBuilder.start(input=...)` | UI detail view; reflector |
+| `assembled_context` | jsonb | no | `TraceBuilder.set_context(...)` | UI detail view; optimizer (#46) |
+| `output` | text | no | `TraceBuilder.finish(output=...)` | UI detail view; reflector eval rubric (#42) |
+
+`assembled_context` shape (stub until #33 fully implements E3):
+
+```jsonc
+{
+  "strategy": "recall+memory+life_context",   // assembly strategy name
+  "items": [
+    {
+      "source": "memory_events",            // table or subsystem name
+      "ref": "<row id or external locator>",
+      "summary": "...",                     // human-readable summary; for the UI
+      "score": 0.83                         // optional retrieval score
+    }
+  ],
+  "version": 1                              // bumped when this jsonb shape changes
+}
+```
+
+### Model & prompt
+
+| Field | Type | Nullable | Writer | Reader |
+|---|---|---|---|---|
+| `model_selected` | text | no | `TraceBuilder.set_model(...)` (called from the LLM dispatch site) | reflector (model performance comparison); optimizer |
+| `model_version` | text | no | `TraceBuilder.set_model(version=...)` | reflector (regression detection across model swaps) |
+| `prompt_version` | text | no | `TraceBuilder.set_model(prompt_version=...)` | optimizer (#48) — joins traces back to the prompt artifact that produced them |
+
+Until #48 lands, every dispatch site that does not yet wrap a versioned prompt MUST pass `agent.traces.PROMPT_VERSION_UNVERSIONED` (`"unversioned"`). The optimizer treats this sentinel as "ineligible for prompt-level rollups" and skips those rows when computing per-prompt deltas. The same convention applies to `model_version` — pass an empty string until the dispatch site is wired to record an actual model identifier (SHA, API tag, etc.); a future hardening PR will gate non-empty `model_version` once every dispatch site is wired.
+
+### Tool calls (RAW_PERSONAL)
+
+| Field | Type | Nullable | Writer | Reader |
+|---|---|---|---|---|
+| `tools_called` | jsonb | no | `TraceBuilder.add_tool_call(...)` per call | UI detail view; reflector (tool failure rates); optimizer |
+
+Each element shape:
+
+```jsonc
+{
+  "name": "send_telegram_message",
+  "args": {"chat_id": "<redacted-or-raw>", "text": "..."},
+  "result_summary": "ok",      // free-form short string; raw payload never persisted
+  "latency_ms": 412,
+  "success": true,             // mirrors agent/mcp_audit.py AuditEntry.success
+  "error": null                 // free-form short error string when success=false; null otherwise
+}
+```
+
+`name` is the only required key — `__post_init__` enforces it so the GIN index in #20 always has a value to index. `success` and `latency_ms` mirror the names used by `agent.mcp_audit.AuditEntry` to avoid a translation layer in #22 when wrapping an existing audit log entry into a trace element. `error` is **not** drawn from `agent.error_classifier.ErrorCategory` — that enum is LLM-call-scoped (RATE_LIMIT, AUTH, NETWORK, …) and does not describe tool-call failure modes. Tool-call errors carry whatever short string the failing tool returned.
+
+### Outcome
+
+| Field | Type | Nullable | Writer | Reader |
+|---|---|---|---|---|
+| `latency_ms` | int | no | `TraceBuilder.finish()` | UI list view; reflector latency rollups |
+| `user_reaction` | jsonb | yes | populated lazily — see below | reflector (graded turn outcomes); optimizer (label source) |
+| `data_sensitivity` | enum | no | `TraceBuilder.start(data_sensitivity=...)` | UI filter; optimizer eligibility check; **#25 privacy regression** |
+
+`user_reaction` shape:
+
+```jsonc
+{
+  "thumbs": 1,                           // -1, 0, +1, or null
+  "followup_correction": false,          // true if a follow-up turn was inferred to correct this one
+  "source": "explicit"                   // "explicit" | "inferred"
+}
+```
+
+`data_sensitivity` mirrors `agent.error_classifier.DataSensitivity` exactly:
+
+- `local_only` — raw personal data; trace stays in Pepper Postgres.
+- `sanitized` — summary-shaped data; safe to surface in cross-archetype joins.
+- `public` — no personal data.
+
+Note: even `data_sensitivity = public` traces are local-only at the *storage* layer. The column annotates *content* sensitivity, not destination — destination is hard-locked to local Postgres for every trace.
+
+### Embedding
+
+| Field | Type | Nullable | Writer | Reader |
+|---|---|---|---|---|
+| `embedding` | vector(1024) | yes | async post-persist worker (#22 step 5) | UI "find similar" (#24); reflector retrieval (#39); optimizer clustering (#45) |
+| `embedding_model_version` | text | yes | same writer; required when `embedding` is non-null | reflector (skip rows whose embedding model is incompatible with current query embedding) |
+
+### Compression tier
+
+| Field | Type | Nullable | Writer | Reader |
+|---|---|---|---|---|
+| `tier` | enum (`working` \| `recall` \| `archival`) | no | `TraceBuilder.start()` initializes to `working`; nightly job (#21) advances tier | UI filter; reflector access window decisions |
+
+Tier semantics live in [#21](https://github.com/jacksteroo/Pepper/issues/21).
+
+## Indexing
+
+Defined in #20's migration. Required indexes:
+
+- B-tree on `created_at` — every reflector and UI query is time-windowed.
+- B-tree on `(archetype, created_at)` — per-archetype recent traces. Cardinality of `archetype` is small (4) but the composite index lets `WHERE archetype = X ORDER BY created_at DESC` skip a sort.
+- B-tree on `(model_selected, created_at)` — UI list filter by model (#24); reflector model-comparison rollups.
+- GIN on `tools_called` — "which traces called X". Use `jsonb_path_ops` to keep the index tight; Postgres still supports the `@>` containment operator that "called X" queries use.
+- HNSW on `embedding`, **partial** with `WHERE embedding IS NOT NULL` — pgvector rejects nulls in HNSW; the partial predicate keeps recall-tier rows (where the embedding is dropped) out of the index.
+- Full-text search on `(input || ' ' || output)` is **not** required for v0 — the UI's `contains-text` filter uses `LIKE '%term%'` until search volume justifies the index cost. Document the upgrade path in the migration's README.
+
+Maintenance notes (informational, not migration-blocking):
+
+- HNSW degrades on growing tables. Once the working tier exceeds ~100k rows, run `REINDEX INDEX CONCURRENTLY` on the embedding index nightly. Recall-tier rows are excluded from HNSW (partial predicate above), so the index stays bounded by the working window even as the table grows.
+
+## Read patterns (mandate for #24 and downstream consumers)
+
+The schema includes a 4 KB `embedding` and unbounded jsonb columns per row. Naive `SELECT *` queries OOM the reflector and slow the UI list. Consumers MUST project:
+
+- **List view (#24):** `trace_id, created_at, trigger_source, archetype, model_selected, latency_ms, data_sensitivity, tier`. Never `SELECT *`. The list view also never returns `input` / `output` text — only the detail view does.
+- **Detail view (#24):** full row except `embedding` (which is fetched only when the user clicks "Find similar").
+- **Similarity search (#24):** project `(trace_id, embedding)` only when computing nearest-neighbor; then re-fetch full rows for the matches.
+- **Reflector daily window (#39):** project `(trace_id, created_at, archetype, latency_ms, data_sensitivity, tools_called, output)`. Skip `embedding` and `assembled_context` unless the rollup needs them.
+- **Optimizer rollups (#46):** project the columns relevant to the rollup; rely on the `(model_selected, created_at)` and `(archetype, created_at)` indexes.
+
+#20's SQLAlchemy model SHOULD mark the `embedding`, `assembled_context`, and `tools_called` columns with `deferred()` so default loads exclude them; consumers opt back in via `undefer()` per query.
+
+## Privacy invariants (enforced by #25)
+
+- A trace row never appears in an outbound HTTP request body or MCP tool argument that targets a destination outside the host.
+- The frontier-LLM dispatch site (`agent/llm.py`) does not accept a `Trace` instance as input. Traces feed reflectors which themselves call LLMs with summaries; the boundary is enforced by typing, not convention.
+- The HTTP route that exposes traces (#24) is bound to localhost by default and audit-logged on every read.
+- Compression's summarization step (#21) hard-pins to local Ollama, mirroring the existing context-compression invariant in `agent/llm.py`.
+- `data_sensitivity` is set at `INSERT` and immutable for the row's lifetime. Reclassification means inserting a new derivative row, never updating the original. (See ADR-0005 §Mutability.)
+- The `Trace` dataclass is `frozen=True` and its `__repr__` redacts `input`, `output`, `assembled_context`, and `tools_called`. A stray `logger.info(trace)` between now and #25's regression test does not leak RAW_PERSONAL into structured logs.
+
+## Open questions resolved
+
+- **#19 — pgvector vs relational-only?** pgvector. Per the storage decision in [ADR-0005](adr/0005-trace-schema.md). 1024-dim, `qwen3-embedding:0.6b`, HNSW index, `embedding_model_version` recorded per row.


### PR DESCRIPTION
## Summary

Closes the schema-design half of [Epic 01: Trace Substrate](https://github.com/jacksteroo/Pepper/issues/17):

- ADR-0005 records the canonical `Trace` record decision and folds in the [#19](https://github.com/jacksteroo/Pepper/issues/19) pgvector-on-traces resolution (Option B, `qwen3-embedding:0.6b`, HNSW partial index, embedding expendable on archival).
- `agent/traces/schema.py` is the in-code mirror of `docs/trace-schema.md`: `frozen=True` dataclass with `__post_init__` guards on embedding dim, jsonb shape, JSON-serialisability, and provenance consistency. `__repr__` redacts RAW_PERSONAL columns so a stray `logger.info(trace)` cannot leak input/output/context/tool args.
- ADR-0005 §Mutability + §"Postgres roles & grants" gives [#20](https://github.com/jacksteroo/Pepper/issues/20) an unambiguous mandate: `pepper_traces_writer` is INSERT-only; only `embedding`, `embedding_model_version`, `tier`, `user_reaction` are UPDATE carve-outs (and only via `pepper_traces_compactor` with per-column grants); `DELETE` is ungranted to every role.
- `docs/trace-schema.md` adds the read-patterns subsection mandating projected loads (no `SELECT *`) and the index plan [#20](https://github.com/jacksteroo/Pepper/issues/20) will materialise (B-tree on `created_at`, `(archetype, created_at)`, `(model_selected, created_at)`; GIN `jsonb_path_ops` on `tools_called`; partial HNSW on `embedding` `WHERE NOT NULL`).

This PR resolves two sub-issues in one merge because [#19](https://github.com/jacksteroo/Pepper/issues/19) is purely a documented decision that lands directly inside ADR-0005's §"Storage decision" subsection — splitting them would produce an empty follow-up PR.

Closes #18.
Closes #19.

## Test plan

- [x] `.venv/bin/python -m pytest agent/tests/test_traces_schema.py -v` — 23/23 pass (defaults, immutability, embedding/scheduler invariants, jsonb shape, repr redaction, enum coverage).
- [x] `.venv/bin/python -m ruff check agent/traces/ agent/tests/test_traces_schema.py` clean.
- [x] Import cycle check: `python -c "import agent.traces; import agent.error_classifier; import agent.core"` succeeds.
- [x] Doc/dataclass field-by-field reconciliation (every field in `docs/trace-schema.md` has a writer + reader and a typed equivalent in `agent/traces/schema.py`).

## Acceptance criteria for #18

- [x] `docs/adr/0005-trace-schema.md` opened.
- [x] Every field has a typed Python equivalent in `agent/traces/schema.py`.
- [x] No field has ambiguous semantics — each row in the schema doc names ≥1 writer and ≥1 reader.