### PR TITLE
docs(adr): ADR-0011 — Layer 3 master, thin clients on Tailscale (#71)

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ Two LLM tiers:
 | **Phase 3** | Runtime — parallel tool execution, context compression, classified error handling | ✅ Complete |
 | **Phase 4** | Skill System — SKILL.md structured workflows, self-improving via user-approved diffs | Planned |
 | **Phase 5** | MCP Integration — subsystems as MCP servers, external MCP tools (GitHub, Linear, Obsidian) | Planned |
-| **macOS App** | Desktop app — Swift shell + WKWebView, embedded PostgreSQL, no Docker | Planned |
+| **Layer 3** | Mobile + macOS thin clients on Tailscale-accessible server (FastAPI + long polling); home server primary, operator-owned VPS as fallback. See Epic 08 (issue #70). | Planned |
 
 ---
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -30,7 +30,7 @@ Per [ADR-0003](adr/0003-layer-2-is-the-active-surface.md), Layer 2 is the **acti
 
 ### Layer 3 — Presentation
 
-How Pepper meets the operator. Telegram is the primary interface today; the local React + Vite web app is secondary; a notarized macOS desktop app is the next platform direction (see [`MACOS_DESKTOP_APP_PLAN.md`](MACOS_DESKTOP_APP_PLAN.md)). Voice is on the wishlist.
+How Pepper meets the operator. Telegram is the primary interface today; the local React + Vite web app is secondary. The next platform direction is a **thin-client + server-heavy** posture: a Capacitor mobile wrapper and a Swift/WKWebView macOS shell, both reaching a FastAPI server over a Tailscale tailnet, home server primary with an operator-owned VPS as fallback. See Epic 08 (issue #70) and the master ADR-0011 (in flight). The earlier embedded-PostgreSQL desktop plan in [`MACOS_DESKTOP_APP_PLAN.md`](MACOS_DESKTOP_APP_PLAN.md) is superseded by this direction. Voice is on the wishlist.
 
 Layer 3 is in steady state. A better presentation layer over a confused agent would be a demo, not a tool, so Layer 3 work is not the active surface during the Layer 2 window.
 

--- a/docs/MACOS_DESKTOP_APP_PLAN.md
+++ b/docs/MACOS_DESKTOP_APP_PLAN.md
@@ -1,5 +1,9 @@
 # Pepper — macOS Desktop App Plan
 
+> **Status: Superseded** (2026-05-02). The embedded-PostgreSQL-on-macOS-desktop direction described below is no longer the plan. Layer 3 has been re-scoped to a thin-client + server-heavy posture: a Swift/WKWebView macOS shell and a Capacitor mobile wrapper reach a FastAPI server over a Tailscale tailnet (home server primary, operator-owned VPS as fallback). The macOS shell is retained, but it does **not** bundle PostgreSQL.
+>
+> This document is retained as historical context. See Epic 08 (issue #70) and the master ADR-0011 (in flight) for the live plan.
+
 ## Goal
 
 Build a first-class macOS desktop app for Pepper that:

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -8,6 +8,7 @@ The current sequencing of this roadmap is set by ratified ADRs. When the sequenc
 - [ADR-0002](adr/0002-fifth-anchoring-principle-compounding-capability.md) — fifth anchoring principle: the system improves itself in response to its own behaviour, within human-reviewable bounds.
 - [ADR-0003](adr/0003-layer-2-is-the-active-surface.md) — Layer 2 (Intelligence + agent runtime) is the active surface for the next two sprints; Layer 1 is in maintenance.
 - [ADR-0004](adr/0004-introduce-agents-directory.md) — `agents/` directory parallel to `subsystems/`, with the same isolation rule, as the structural home for cognitive functions (reflector, monitor, researcher) the substrate phase will introduce.
+- [ADR-0011](adr/0011-layer-3-thin-clients-tailscale.md) — Layer 3 master ADR: thin clients (Capacitor mobile + Swift/WKWebView macOS) on a Tailscale-accessible FastAPI server; home server primary, operator-owned VPS as fallback. Retires the embedded-PostgreSQL desktop direction. Master for Epic 08 (issue #70).
 
 See [docs/adr/](adr/) for the full list.
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -23,9 +23,9 @@ Deferred capability work (knowledge layer, health & finance, maintenance & secur
 
 The **People subsystem** is also deferred. The criteria for un-deferring it — both the concrete usage signals that would justify building it and the out-of-scope signals that should not — are captured in [people-subsystem-criteria.md](people-subsystem-criteria.md). That document is the canonical answer to "should we build People?" so the question does not get re-litigated each quarter.
 
-**Next platform direction**: a notarized macOS desktop app that wraps the existing React UI in a Swift shell, embeds PostgreSQL + pgvector locally, and removes Docker from the end-user experience. See [MACOS_DESKTOP_APP_PLAN.md](MACOS_DESKTOP_APP_PLAN.md).
+**Next platform direction**: thin clients (Capacitor mobile + Swift/WKWebView macOS) over a Tailscale tailnet against a FastAPI server, with a home-server-primary / operator-owned-VPS-fallback posture. The earlier embedded-PostgreSQL desktop plan in [MACOS_DESKTOP_APP_PLAN.md](MACOS_DESKTOP_APP_PLAN.md) is superseded by this direction. Tracked in Epic 08 (issue #70); master decision is ADR-0011 (in flight).
 
-**Near-term auth/platform work**: formalize credential lifecycle behavior across Docker today and the macOS app later:
+**Near-term auth/platform work**: formalize credential lifecycle behavior across Docker today and the thin-client / Tailscale posture later:
 
 - restart-safe auth (no unnecessary reauth on backend/app/container restart)
 - explicit account auth states (`connected`, `needs_reauth`, `needs_local_login`, `upgrade_required`, etc.)

--- a/docs/adr/0011-layer-3-thin-clients-tailscale.md
+++ b/docs/adr/0011-layer-3-thin-clients-tailscale.md
@@ -1,0 +1,83 @@
+# ADR-0011: Layer 3 — thin clients on a Tailscale-accessible server
+
+- **Status:** Proposed
+- **Date:** 2026-05-02
+
+## Context
+
+Layer 3 (Presentation) was previously framed as a notarized macOS desktop app that bundled the Pepper backend, an embedded PostgreSQL + pgvector, and the React UI into a single self-contained `.app` running on the operator's MacBook. That framing made two assumptions that no longer hold:
+
+- **Single-device deployment.** Pepper is the operator's life assistant, not a desktop app. The operator needs Pepper from anywhere — phone on the move, laptop at a desk, future ambient surfaces — without a different agent on each device. A self-contained desktop app forces a synthesis problem (which device holds the canonical state? which one runs the agent?) that no version of "embedded Postgres on the desktop" answers cleanly.
+- **No mobile story.** The original plan deferred mobile indefinitely. Mobile is the surface where push-notification-driven, proactive behaviour is most valuable, and treating it as a v2 concern guaranteed Pepper would never be where it is needed most.
+
+The Q6 deep-walk in the [OpenJarvis calibration thread](https://www.notion.so/354fb736739081ae8834eb6be2d361c0) surfaced the same observation from a different angle: the right deployment shape for a single-operator, privacy-first agent is **server-heavy + thin clients**, with the network boundary held by a private mesh rather than a public endpoint. The detailed framing lives in the [Layer 3 redesign Notion thread](https://www.notion.so/354fb736739081279492cbaf25aa69b8).
+
+The four anchoring privacy / sovereignty / additive-memory / pluggable-subsystem principles, plus the fifth (compounding capability, [ADR-0002](0002-fifth-anchoring-principle-compounding-capability.md)), constrain what shape that posture can take. This ADR ratifies the constraints and the headline shape; the sub-decisions land as sibling ADRs (0012–0016).
+
+## Decision
+
+Layer 3 is re-scoped as **thin clients on a Tailscale-accessible Pepper server**. The headline decisions are:
+
+1. **Server-client protocol: FastAPI + long polling.** The same FastAPI orchestrator that already serves the local web UI becomes the canonical client surface. Long polling is preferred over WebSocket for resilience over flaky mobile connections and simpler reconnection semantics. Wire-level details land in ADR-0012.
+2. **Network boundary: Tailscale.** Mobile, desktop, and web clients reach the server over a private tailnet. The server has **no internet-exposed endpoint by default**. Tailscale device identity is the basis of authentication; auth specifics land in ADR-0014.
+3. **Clients: macOS desktop and mobile, both first-class thin clients.** The macOS shell remains a Swift / WKWebView wrapper around the existing React UI, with the embedded-PostgreSQL plan from `docs/MACOS_DESKTOP_APP_PLAN.md` retired. The mobile platform decision (Capacitor v0 wrapping the existing React UI vs. native vs. React Native) lands in ADR-0015. Voice and ambient surfaces remain on the wishlist.
+4. **Hosting posture: home server primary, operator-owned VPS as fallback.** The home server is the default deployment target — on-premises, Tailscale-accessible, no third party in the data path. A VPS path exists as an explicit escape hatch for travel scenarios, **only when the VPS is operator-owned** (e.g., a Hetzner box Jack rents). Managed / serverless hosts (Vercel, Fly.io) are ruled out because the platform operator would have root on a host that holds raw personal data. Sovereignty interpretation lands in ADR-0016; server hardening lands in ADR-0013.
+
+This ADR is the master decision; the six sibling ADRs (0011 through 0016) and the Epic 08 implementation sub-issues hang off it. The scope of this ADR is the **shape**, not the mechanism — concrete protocol fields, hardening checklists, auth tokens, and platform code all live in the sibling ADRs and downstream PRs.
+
+## Anchoring principles — preserved
+
+- **Privacy-first.** Raw personal data (email, messages, health, finance) stays on the server. Clients render and capture input; they do not store raw archives. The Tailscale boundary keeps the data path off the public internet.
+- **Local-first / sovereign.** Home server is the default; no managed cloud is in the data path. The VPS fallback is permitted only when operator-owned, so "no mandatory cloud services" is preserved (the VPS is still the operator's machine, just rented).
+- **Additive memory.** Memory and traces remain server-side, untouched by this decision. Clients are stateless render surfaces.
+- **Pluggable subsystems.** Subsystems do not move; they remain server-side and remain isolated from each other and from `agent/core.py`. The protocol is between clients and the server; it does not pierce subsystem boundaries.
+- **Compounding capability** ([ADR-0002](0002-fifth-anchoring-principle-compounding-capability.md)). The trace store, reflection runtime, and optimizer all run server-side. This decision puts more usage signal through a single canonical surface, which makes the trace stream richer, not poorer.
+
+## Consequences
+
+**Positive.**
+
+- One canonical agent runtime, multiple thin client surfaces. The synthesis problem ("which device is canonical?") is resolved by construction: the server is canonical.
+- Mobile becomes tractable. Push-notification-driven proactive behaviour — which is where Pepper's morning-brief / commitment-tracking value compounds — gets a real surface.
+- The Tailscale boundary is a stronger privacy invariant than localhost-bind. The current "[localhost](http://localhost)-bind enforces privacy" assumption (e.g., issue #34) is replaced by "tailnet membership + ACLs enforce privacy," which is verifiable independently of the operator's network configuration.
+- The `docker-compose.yml` deployment becomes the production shape, not a dev convenience. Fewer moving parts; one canonical topology.
+- All client surfaces consume the same FastAPI endpoints. New clients (voice, ambient) are additive; they don't fork the agent.
+
+**Negative.**
+
+- A server is now load-bearing. "Pepper works when the MacBook is closed" is no longer trivially true. Home-server uptime, Tailscale availability, and the VPS fallback path all become real concerns.
+- Mobile + desktop client work that was previously "v2" is now in the critical path for the next platform direction. ADR-0015 needs to land before any mobile code ships.
+- The earlier embedded-PostgreSQL macOS plan in [`docs/MACOS_DESKTOP_APP_PLAN.md`](../MACOS_DESKTOP_APP_PLAN.md) is retired. The Swift / WKWebView shell survives in the new posture, but the bundled-Postgres design and the auth flows that assumed local-only state need to be reframed against ADR-0014.
+- Server hardening expectations rise. A long-running, network-reachable Pepper is a different threat surface than a desktop app that only listens on `127.0.0.1`. ADR-0013 captures the concrete hardening checklist.
+
+**Neutral.**
+
+- Subsystem boundaries are unaffected. This decision reshapes Layer 3, not Layers 1 or 2.
+- The active-surface ranking from [ADR-0003](0003-layer-2-is-the-active-surface.md) (Layer 2 first) is unchanged. Layer 3 work tracked under Epic 08 runs in parallel with substrate work, but does not pre-empt it.
+- The `agents/` directory introduced by [ADR-0004](0004-introduce-agents-directory.md) is unaffected. Agents remain server-side processes, isolated from each other.
+
+**Follow-up work this ADR creates.**
+
+- ADR-0012 (long polling protocol design), ADR-0013 (server hardening checklist), ADR-0014 (auth: Tailscale device identity + per-device PIN), ADR-0015 (mobile platform decision), ADR-0016 (sovereignty interpretation: VPS-as-fallback only with operator-owned VPS) — all required before the corresponding Epic 08 sub-issues can ship.
+- The "[localhost](http://localhost)-bind enforces privacy" assumption in any in-flight UI / panel work needs to be migrated to a "Tailscale-bound + ACLs enforce privacy" assumption (tracked as a sub-issue under Epic 08).
+- The retirement of the embedded-PostgreSQL desktop direction propagates to `README.md`, `docs/ARCHITECTURE.md`, `docs/ROADMAP.md`, and `docs/MACOS_DESKTOP_APP_PLAN.md` — those updates land in this PR alongside the ADR.
+
+## Alternatives considered
+
+- **Status quo: keep the notarized macOS desktop app with embedded PostgreSQL.** Rejected — it answers "where does Pepper live on the operator's primary laptop?" but not "where does Pepper live for the operator?" Mobile is a year away under this plan, and synthesizing state across a phone and a desktop with embedded Postgres is a problem the plan does not solve.
+- **Self-hosted server with a public HTTPS endpoint instead of Tailscale.** Rejected — adds the operational cost of running a public service (TLS rotation, abuse handling, fail2ban, public-IP exposure) for no privacy gain. Tailscale gives mutual device authentication and a private network boundary with negligible operational overhead.
+- **WebSocket instead of long polling.** Rejected for v0 — long polling tolerates flaky mobile networks, NAT timeouts, and aggressive radio-power-down behaviour without complex reconnection logic. WebSocket can be revisited as an optimization once the long-polling path is in production and we have telemetry on real reconnection patterns.
+- **Managed-cloud fallback (Vercel / Fly.io / similar) for the VPS path.** Rejected — these put a third-party platform operator in root position on a host that holds raw personal data. Incompatible with the privacy / sovereignty principles. ADR-0016 ratifies this restriction explicitly.
+- **Mobile via React Native (or Swift + Kotlin native) for v0.** Deferred to ADR-0015. The leading recommendation under that ADR is **Capacitor v0** (a thin native wrapper around the existing React UI) to ship on the existing surface, with native re-platforming revisited only after 2–3 months of usage data justifies the doubled implementation cost.
+- **Defer Layer 3 work entirely until Q4 2026.** Rejected — the substrate-first sequencing in [ADR-0001](0001-resequence-around-oj-calibration.md) already pushes Knowledge / Health / Finance to Q4. Pushing Layer 3 with them would compound the "no mobile story" gap into a third quarter, and Layer 3 work does not contend with the substrate effort because the decisions sit in different files and surfaces.
+
+## References
+
+- [Layer 3 redesign — mobile thin clients on a Tailscale-accessible server](https://www.notion.so/354fb736739081279492cbaf25aa69b8) — the Notion thread that consolidated the headline decisions and open sub-questions this ADR ratifies.
+- [OpenJarvis calibration — lessons, challenges, shortest path](https://www.notion.so/354fb736739081ae8834eb6be2d361c0) — Q6 deep-walk that surfaced the thin-client + server-heavy posture.
+- [Agent Pepper hub](https://www.notion.so/353fb7367390806a88addf0430118d34) — Progress > "Next platform" row.
+- Epic 08: Layer 3 — Mobile + Desktop Thin Clients on Tailscale-Accessible Server (issue #70) — implementation epic.
+- Sub-decisions: ADR-0012 (long polling), ADR-0013 (server hardening), ADR-0014 (auth), ADR-0015 (mobile platform), ADR-0016 (sovereignty / VPS fallback).
+- Related: [ADR-0001](0001-resequence-around-oj-calibration.md) (substrate-first sequencing), [ADR-0002](0002-fifth-anchoring-principle-compounding-capability.md) (compounding capability), [ADR-0003](0003-layer-2-is-the-active-surface.md) (Layer 2 active surface), [ADR-0004](0004-introduce-agents-directory.md) (`agents/` directory).
+- [`docs/MACOS_DESKTOP_APP_PLAN.md`](../MACOS_DESKTOP_APP_PLAN.md) — historical context for the retired embedded-PostgreSQL desktop direction.
+- Source issue: #71.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -44,5 +44,6 @@ ADRs do not get deleted. Their numbers do not get reused.
 - [0003-layer-2-is-the-active-surface.md](0003-layer-2-is-the-active-surface.md) — Layer 2 (Intelligence) is the active surface
 - [0004-introduce-agents-directory.md](0004-introduce-agents-directory.md) — introduce `agents/` directory parallel to `subsystems/`
 - [0005-trace-schema.md](0005-trace-schema.md) — canonical `Trace` record (Epic 01)
+- [0011-layer-3-thin-clients-tailscale.md](0011-layer-3-thin-clients-tailscale.md) — Layer 3 master ADR: thin clients on a Tailscale-accessible server (Epic 08)
 
-The four foundational ADRs above (0001–0004) are tracked in [Epic 00: Foundations & ADRs](https://github.com/jacksteroo/Pepper/issues/9). ADR-0005 is the first decision record produced under [Epic 01: Trace Substrate](https://github.com/jacksteroo/Pepper/issues/17).
+The four foundational ADRs above (0001–0004) are tracked in Epic 00: Foundations & ADRs (issue #9). ADR-0005 is the first decision record produced under Epic 01: Trace Substrate (issue #17). ADR-0011 is the master ADR for Epic 08: Layer 3 — Mobile + Desktop Thin Clients on Tailscale-Accessible Server (issue #70); sibling ADRs 0012–0016 land under that epic.


### PR DESCRIPTION
## Summary

Master ADR for Epic 08 (issue #70). Closes #71.

Layer 3 (Presentation) is re-scoped from a self-contained notarized macOS desktop app with embedded PostgreSQL to **thin clients on a Tailscale-accessible Pepper server**. The four headline decisions:

- **Server-client protocol:** FastAPI + long polling — same FastAPI orchestrator that serves the local web UI today; long polling preferred over WebSocket for resilience over flaky mobile networks.
- **Network boundary:** Tailscale — clients reach the server over a private tailnet; no internet-exposed endpoint by default.
- **Clients:** macOS (Swift / WKWebView) and mobile (Capacitor v0 leading recommendation) both first-class thin clients. Embedded-PostgreSQL desktop direction retired.
- **Hosting:** home server primary, operator-owned VPS as fallback. Managed-cloud hosts (Vercel / Fly.io) ruled out.

The ADR ratifies the **shape**; sub-decisions land in sibling ADRs 0012 (long polling), 0013 (server hardening), 0014 (auth), 0015 (mobile platform), 0016 (sovereignty / VPS scope). Each of the four anchoring principles plus ADR-0002 (compounding capability) is preserved by the new posture; the ADR walks each one explicitly.

## What's in this PR

- \`docs/adr/0011-layer-3-thin-clients-tailscale.md\` — the ADR itself, status \`Proposed\`.
- \`docs/adr/README.md\` — index entry + epic pointer.
- \`docs/ROADMAP.md\` — adds ADR-0011 to the "Architectural decisions driving the current sequence" list.
- Codebase sweep retiring the embedded-PostgreSQL desktop framing in one place so the new direction lands consistently:
  - \`README.md\` — roadmap row replaced with the Layer 3 thin-client / Tailscale row pointing at Epic 08.
  - \`docs/ARCHITECTURE.md\` — Layer 3 description reframed; flags the embedded-PG plan as superseded.
  - \`docs/ROADMAP.md\` — "Next platform direction" + "Near-term auth/platform work" updated to reflect the Tailscale posture.
  - \`docs/MACOS_DESKTOP_APP_PLAN.md\` — \`Status: Superseded\` banner pointing at Epic 08 and ADR-0011; file retained as historical context.

The sweep is intentionally folded into this PR rather than landed separately so reviewers see the new direction documented, ratified, and propagated in one place.

## Test plan

- [ ] Read \`docs/adr/0011-...md\` end-to-end; confirm headline decisions match the Layer 3 redesign Notion thread and issue #71 scope.
- [ ] Confirm each of the four anchoring principles + ADR-0002 is addressed in the "Anchoring principles — preserved" section without daylight from the existing principle wording in CLAUDE.md / GUARDRAILS.md.
- [ ] Confirm sibling ADR placeholders (0012–0016) line up with the open Epic 08 sub-issues (#72–#76).
- [ ] Read the README/ARCHITECTURE/ROADMAP/MACOS_DESKTOP_APP_PLAN diffs; confirm the embedded-PostgreSQL framing no longer reads as the active plan anywhere.
- [ ] No code changes; CI lint should be a no-op.

## Out of scope

- Sibling ADRs 0012–0016 — separate PRs.
- Implementation work (long polling endpoints, Tailscale bootstrap, Capacitor wrapper, Swift shell rework) — separate PRs under Epic 08.
- The Notion hub's auto-rendered child-page list at the bottom — addressed separately via the Notion API (page re-parented out of the hub).