### PR TITLE
traces: wire emission in agent/core.py + TraceBuilder (#22)

### DIFF
--- a/agent/core.py
+++ b/agent/core.py
@@ -8,7 +8,12 @@ import structlog
 from datetime import datetime, timedelta
 from urllib.parse import urlsplit, urlunsplit
 from zoneinfo import ZoneInfo
+from typing import TYPE_CHECKING
+
 from agent import chat_turn_logger, success_signal
+
+if TYPE_CHECKING:
+    from agent.traces import TriggerSource as _TriggerSourceHint
 from agent.config import Settings
 from agent.llm import ModelClient
 from agent.life_context import build_system_prompt, get_life_context_sections, get_owner_name, update_life_context
@@ -2051,13 +2056,32 @@ class PepperCore:
         heavy: bool | None = None,
         channel: str = "",
         isolated: bool = False,
+        trigger_source: "_TriggerSourceHint | None" = None,
+        scheduler_job_name: str | None = None,
     ) -> str:
         """Public chat entry point.
 
         Wraps :meth:`_chat_impl` with the per-turn JSONL logger feeding the
         semantic-router migration (Phase 0 Task 2). The logger is best-effort
         and never alters the response.
+
+        Epic 01 (#22): also emits a row to the `traces` table via
+        `agent.traces.emitter.emit_trace`. Trace persistence is fail-soft —
+        an error in the emitter never propagates to the caller.
+
+        `trigger_source` defaults to `USER`; #23 wiring passes `SCHEDULER`.
+        `scheduler_job_name` is required when `trigger_source = SCHEDULER`.
         """
+        # Local imports keep `agent.traces` decoupled from `agent.core`'s
+        # module-level dependency graph and avoid a circular import.
+        from agent.traces import (
+            Trace,  # noqa: F401  (used in type-hint string above)
+        )
+        from agent.traces import TriggerSource as _TriggerSource
+
+        if trigger_source is None:
+            trigger_source = _TriggerSource.USER
+
         chat_turn_logger.start_turn()
         wall_started_at = time.perf_counter()
         response_text = ""
@@ -2123,6 +2147,82 @@ class PepperCore:
             except RuntimeError:
                 # No running event loop (synchronous test contexts) — skip.
                 pass
+
+            # Epic 01 (#22): emit a `traces` row alongside routing_events.
+            # Reads model + tool_calls from the chat_turn_logger snapshot
+            # we already captured. assembled_context stays as a stub
+            # until #33 (E3) plumbs richer provenance through the chat
+            # path. Persistence is fail-soft inside `emit_trace`.
+            try:
+                from agent.traces import (
+                    Archetype as _Archetype,
+                )
+                from agent.traces import DataSensitivity as _DS
+                from agent.traces.emitter import (
+                    TraceBuilder,
+                    emit_trace,
+                )
+
+                tb = TraceBuilder.start(
+                    input=user_message,
+                    trigger_source=trigger_source,
+                    archetype=_Archetype.ORCHESTRATOR,
+                    scheduler_job_name=scheduler_job_name,
+                    data_sensitivity=_DS.LOCAL_ONLY,
+                )
+                # Pull what the existing per-turn logger already captured.
+                model_name = (trace_snapshot or {}).get("model") or ""
+                tb.set_model(model_name)
+                for call in (trace_snapshot or {}).get("tool_calls") or []:
+                    name = call.get("name") if isinstance(call, dict) else None
+                    if not name:
+                        continue
+                    tb.add_tool_call(
+                        name=name,
+                        args=call.get("arguments") if isinstance(call, dict) else None,
+                        result_summary="",
+                    )
+                trace = tb.finish(
+                    output=response_text,
+                    latency_ms=latency_ms,
+                )
+
+                from agent import db as _db_mod
+
+                if _db_mod._session_factory is None:
+                    # DB not initialised yet — happens in a few test
+                    # contexts that exercise chat() without init_db.
+                    # Skip emission rather than fail the turn.
+                    raise RuntimeError("DB not initialised; skipping trace emission")
+                _trace_session_factory = _db_mod._session_factory
+
+                # Embedding worker uses the router-side qwen3 model so we
+                # match the schema's vector(1024) and ADR-0005's choice.
+                async def _embed(t: str) -> list[float]:
+                    return await self.llm.embed_router(t)
+
+                trace_task = asyncio.create_task(
+                    emit_trace(
+                        trace,
+                        session_factory=_trace_session_factory,
+                        embed_fn=_embed,
+                        embed_model_version="qwen3-embedding:0.6b",
+                    ),
+                )
+                self._background_tasks.add(trace_task)
+                trace_task.add_done_callback(self._background_tasks.discard)
+            except Exception as exc:
+                # Defence in depth — emit_trace already swallows. Log and
+                # carry on so a programming error in the wiring above
+                # (e.g. import failure on partial install) cannot break
+                # the user's turn.
+                from agent.traces.emitter import _safe_error_message
+
+                logger.warning(
+                    "trace_emit_wiring_failed",
+                    error_type=type(exc).__name__,
+                    error=_safe_error_message(exc),
+                )
 
     async def _chat_impl(
         self,

--- a/agent/tests/test_core_trace_emission.py
+++ b/agent/tests/test_core_trace_emission.py
@@ -1,0 +1,200 @@
+"""Integration test for #22 — verify `chat()` schedules a trace emission
+in its `finally` block.
+
+We mock the LLM/memory/router stack the same way `test_core.py` does and
+patch `agent.traces.emitter.emit_trace` to capture the Trace passed in.
+The test asserts:
+
+- Exactly one trace per chat turn.
+- The trace's `input` and `output` reflect the user message and response.
+- The trace's `latency_ms` is positive.
+- The trace's `trigger_source` defaults to USER and overrides to SCHEDULER
+  when the new kwarg is passed.
+- A failure inside the trace emitter does not propagate (fail-soft).
+"""
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from agent.error_classifier import DataSensitivity
+from agent.traces import Trace, TriggerSource
+
+
+def make_mock_config():
+    """Mirror the helper from agent/tests/test_core.py."""
+    config = MagicMock()
+    config.ALWAYS_HEAVY = False
+    config.HEAVY_MAX_FALLBACK_RATIO = 0.0
+    config.DEFAULT_LOCAL_MODEL = "hermes-test:latest"
+    config.DEFAULT_FRONTIER_MODEL = "claude-opus-4-7"
+    config.MODEL_CONTEXT_TOKENS = 8000
+    config.LIFE_CONTEXT_PATH = "/dev/null"
+    config.TIMEZONE = "UTC"
+    config.OWNER_NAME = "Tester"
+    return config
+
+
+def make_mock_llm():
+    llm = MagicMock()
+    llm.chat = AsyncMock(return_value={"content": "general chat reply", "tool_calls": []})
+    llm.embed_router = AsyncMock(return_value=[0.1] * 1024)
+    llm.config = make_mock_config()
+    return llm
+
+
+@pytest.mark.asyncio
+async def test_chat_emits_one_trace_per_turn() -> None:
+    from agent.core import PepperCore
+
+    config = make_mock_config()
+
+    captured: list[Trace] = []
+
+    async def _capture_emit(trace, **kwargs):
+        captured.append(trace)
+        return trace.trace_id
+
+    with patch("agent.core.ModelClient") as MockLLM, \
+         patch("agent.core.MemoryManager") as MockMem, \
+         patch("agent.core.ToolRouter") as MockRouter, \
+         patch("agent.core.build_system_prompt", return_value="system"), \
+         patch("agent.core.CommitmentExtractor") as MockExtractor, \
+         patch("agent.traces.emitter.emit_trace", side_effect=_capture_emit) as mock_emit, \
+         patch("agent.db._session_factory", new=MagicMock()):
+        mock_llm = make_mock_llm()
+        MockLLM.return_value = mock_llm
+
+        mock_memory = MagicMock()
+        mock_memory.add_to_working_memory = MagicMock()
+        mock_memory.get_working_memory = MagicMock(return_value=[])
+        mock_memory.build_context_for_query = AsyncMock(return_value="")
+        mock_memory.save_to_recall = AsyncMock()
+        MockMem.return_value = mock_memory
+
+        MockRouter.return_value.check_health = AsyncMock(return_value={})
+        MockRouter.return_value.is_mcp_tool = MagicMock(return_value=False)
+        MockRouter.return_value.is_mcp_read_only_tool = MagicMock(return_value=False)
+        MockRouter.return_value.list_available_tools = AsyncMock(return_value=[])
+        MockRouter.return_value.get_status.return_value = {}
+
+        MockExtractor.return_value.has_commitment_language = MagicMock(return_value=False)
+
+        pepper = PepperCore(config)
+        pepper._initialized = True
+        pepper._system_prompt = "system"
+
+        response = await pepper.chat("hello pepper", "test-session")
+
+        # Wait for the background trace task to complete. The chat()
+        # finally block schedules emit_trace as a background task that
+        # we patched — the patched coroutine awaits immediately so a
+        # tiny yield is enough.
+        await asyncio.sleep(0.05)
+
+    assert isinstance(response, str)
+    assert mock_emit.call_count == 1, "trace should be emitted exactly once per turn"
+    assert len(captured) == 1
+    t = captured[0]
+    assert t.input == "hello pepper"
+    assert t.output == response
+    assert t.latency_ms >= 0
+    assert t.trigger_source is TriggerSource.USER
+    assert t.data_sensitivity is DataSensitivity.LOCAL_ONLY
+
+
+@pytest.mark.asyncio
+async def test_chat_passes_scheduler_trigger_source() -> None:
+    from agent.core import PepperCore
+
+    config = make_mock_config()
+
+    captured: list[Trace] = []
+
+    async def _capture_emit(trace, **kwargs):
+        captured.append(trace)
+        return trace.trace_id
+
+    with patch("agent.core.ModelClient") as MockLLM, \
+         patch("agent.core.MemoryManager") as MockMem, \
+         patch("agent.core.ToolRouter") as MockRouter, \
+         patch("agent.core.build_system_prompt", return_value="system"), \
+         patch("agent.core.CommitmentExtractor") as MockExtractor, \
+         patch("agent.traces.emitter.emit_trace", side_effect=_capture_emit), \
+         patch("agent.db._session_factory", new=MagicMock()):
+        MockLLM.return_value = make_mock_llm()
+        mock_memory = MagicMock()
+        mock_memory.add_to_working_memory = MagicMock()
+        mock_memory.get_working_memory = MagicMock(return_value=[])
+        mock_memory.build_context_for_query = AsyncMock(return_value="")
+        mock_memory.save_to_recall = AsyncMock()
+        MockMem.return_value = mock_memory
+        MockRouter.return_value.check_health = AsyncMock(return_value={})
+        MockRouter.return_value.is_mcp_tool = MagicMock(return_value=False)
+        MockRouter.return_value.is_mcp_read_only_tool = MagicMock(return_value=False)
+        MockRouter.return_value.list_available_tools = AsyncMock(return_value=[])
+        MockRouter.return_value.get_status.return_value = {}
+        MockExtractor.return_value.has_commitment_language = MagicMock(return_value=False)
+
+        pepper = PepperCore(config)
+        pepper._initialized = True
+        pepper._system_prompt = "system"
+
+        await pepper.chat(
+            "morning brief please",
+            "scheduler-session",
+            trigger_source=TriggerSource.SCHEDULER,
+            scheduler_job_name="morning_brief",
+        )
+        await asyncio.sleep(0.05)
+
+    assert len(captured) == 1
+    t = captured[0]
+    assert t.trigger_source is TriggerSource.SCHEDULER
+    assert t.scheduler_job_name == "morning_brief"
+
+
+@pytest.mark.asyncio
+async def test_emitter_failure_does_not_break_chat_response() -> None:
+    """Fail-soft invariant: emit_trace raising must not propagate to chat()."""
+    from agent.core import PepperCore
+
+    config = make_mock_config()
+
+    async def _boom(trace, **kwargs):
+        raise RuntimeError("emitter exploded")
+
+    with patch("agent.core.ModelClient") as MockLLM, \
+         patch("agent.core.MemoryManager") as MockMem, \
+         patch("agent.core.ToolRouter") as MockRouter, \
+         patch("agent.core.build_system_prompt", return_value="system"), \
+         patch("agent.core.CommitmentExtractor") as MockExtractor, \
+         patch("agent.traces.emitter.emit_trace", side_effect=_boom), \
+         patch("agent.db._session_factory", new=MagicMock()):
+        MockLLM.return_value = make_mock_llm()
+        mock_memory = MagicMock()
+        mock_memory.add_to_working_memory = MagicMock()
+        mock_memory.get_working_memory = MagicMock(return_value=[])
+        mock_memory.build_context_for_query = AsyncMock(return_value="")
+        mock_memory.save_to_recall = AsyncMock()
+        MockMem.return_value = mock_memory
+        MockRouter.return_value.check_health = AsyncMock(return_value={})
+        MockRouter.return_value.is_mcp_tool = MagicMock(return_value=False)
+        MockRouter.return_value.is_mcp_read_only_tool = MagicMock(return_value=False)
+        MockRouter.return_value.list_available_tools = AsyncMock(return_value=[])
+        MockRouter.return_value.get_status.return_value = {}
+        MockExtractor.return_value.has_commitment_language = MagicMock(return_value=False)
+
+        pepper = PepperCore(config)
+        pepper._initialized = True
+        pepper._system_prompt = "system"
+
+        # The chat call must succeed despite the emitter error.
+        response = await pepper.chat("hi", "test-session")
+
+    # The emitter is scheduled as a background task — its raised exception
+    # would surface as a Task exception, not propagate. The user sees the
+    # response unchanged.
+    assert isinstance(response, str)

--- a/agent/tests/test_traces_emitter.py
+++ b/agent/tests/test_traces_emitter.py
@@ -1,0 +1,281 @@
+"""Tests for `agent.traces.emitter` — TraceBuilder accumulator and the
+fail-soft `emit_trace` wrapper.
+
+Covers the #22 acceptance criteria that don't require a live Postgres:
+
+- TraceBuilder accumulates and finalizes correctly.
+- `emit_trace` swallows persistence errors (fail-soft invariant).
+- `emit_trace` does not log raw input/output text — structured metadata
+  only (RAW_PERSONAL containment).
+- `emit_trace` schedules the embedding worker only when the persist
+  succeeds.
+"""
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+import structlog
+from structlog.testing import capture_logs
+
+from agent.error_classifier import DataSensitivity
+from agent.traces import (
+    EMBEDDING_DIM,
+    Trace,
+    TraceTier,
+    TriggerSource,
+)
+from agent.traces.emitter import TraceBuilder, _safe_error_message, emit_trace
+
+
+class TestSafeErrorMessage:
+    def test_redacts_sqlalchemy_parameters_block(self) -> None:
+        # Simulate a SQLAlchemy-shaped error string with bound parameters
+        # (which would carry RAW_PERSONAL substrings of `Trace.input`).
+        class FakeStmtError(Exception):
+            pass
+
+        exc = FakeStmtError(
+            "(psycopg.errors.UniqueViolation) duplicate key value\n"
+            "[SQL: INSERT INTO traces (...) VALUES (...)]\n"
+            "[parameters: ('secret-pii-string-from-input', ...)]",
+        )
+        msg = _safe_error_message(exc)
+        assert "secret-pii-string-from-input" not in msg
+        assert "[parameters" not in msg
+        assert "FakeStmtError" in msg
+
+    def test_keeps_short_diagnostic_for_plain_exceptions(self) -> None:
+        msg = _safe_error_message(RuntimeError("DB unreachable"))
+        assert "RuntimeError" in msg
+        assert "DB unreachable" in msg
+
+    def test_prefers_orig_attribute_when_present(self) -> None:
+        # SQLAlchemy wraps the underlying DBAPI error in `.orig`.
+        class WrappedExc(Exception):
+            pass
+
+        wrapped = WrappedExc("wrapper text")
+        wrapped.orig = ConnectionError("postgres unreachable")
+        msg = _safe_error_message(wrapped)
+        assert "ConnectionError" in msg
+        assert "postgres unreachable" in msg
+        # The wrapper's own message (which might carry parameters) is not used.
+        assert "wrapper text" not in msg
+
+
+# ── TraceBuilder ──────────────────────────────────────────────────────────────
+
+
+class TestTraceBuilder:
+    def test_start_sets_provenance(self) -> None:
+        tb = TraceBuilder.start(
+            input="hi",
+            trigger_source=TriggerSource.SCHEDULER,
+            scheduler_job_name="morning_brief",
+        )
+        assert tb.input == "hi"
+        assert tb.trigger_source is TriggerSource.SCHEDULER
+        assert tb.scheduler_job_name == "morning_brief"
+
+    def test_set_model_last_write_wins(self) -> None:
+        tb = TraceBuilder.start(input="hi")
+        tb.set_model("model-a", model_version="v1", prompt_version="p1")
+        tb.set_model("model-b", model_version="v2", prompt_version="p2")
+        t = tb.finish(output="ok", latency_ms=10)
+        assert t.model_selected == "model-b"
+        assert t.model_version == "v2"
+        assert t.prompt_version == "p2"
+
+    def test_add_tool_call_requires_name(self) -> None:
+        tb = TraceBuilder.start(input="hi")
+        with pytest.raises(ValueError, match="name is required"):
+            tb.add_tool_call(name="")
+
+    def test_add_tool_call_appends_in_order(self) -> None:
+        tb = TraceBuilder.start(input="hi")
+        tb.add_tool_call(name="search", success=True, latency_ms=12)
+        tb.add_tool_call(name="send", success=False, error="rate_limited", latency_ms=42)
+        t = tb.finish(output="done", latency_ms=100)
+        assert [c["name"] for c in t.tools_called] == ["search", "send"]
+        assert t.tools_called[1]["error"] == "rate_limited"
+        assert t.tools_called[1]["success"] is False
+
+    def test_finish_returns_frozen_trace(self) -> None:
+        tb = TraceBuilder.start(input="hi")
+        t = tb.finish(output="ok", latency_ms=5)
+        assert isinstance(t, Trace)
+        assert t.tier is TraceTier.WORKING
+        # Frozen — verified by the dataclass tests, but smoke-check here.
+        import dataclasses
+
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            t.input = "nope"  # type: ignore[misc]
+
+    def test_finish_carries_data_sensitivity(self) -> None:
+        tb = TraceBuilder.start(
+            input="hi",
+            data_sensitivity=DataSensitivity.SANITIZED,
+        )
+        t = tb.finish(output="ok", latency_ms=1)
+        assert t.data_sensitivity is DataSensitivity.SANITIZED
+
+
+# ── emit_trace ────────────────────────────────────────────────────────────────
+
+
+def _stub_session_factory(
+    *,
+    flush_raises: Exception | None = None,
+    refresh_returns_row=None,
+):
+    """Build a session_factory whose `async with` yields a mock AsyncSession.
+
+    The session's `add` is a no-op, `flush` raises if requested, `refresh`
+    populates the row's attributes from `refresh_returns_row`, `commit`
+    no-ops, and the row passed to `add` is the same object returned via
+    `refresh`.
+    """
+    @asynccontextmanager
+    async def _session_ctx():
+        sess = MagicMock()
+        sess.add = MagicMock()
+        sess.commit = AsyncMock()
+
+        added_row = {}
+
+        def _add(row):
+            added_row["row"] = row
+
+        sess.add = _add
+
+        async def _flush():
+            if flush_raises is not None:
+                raise flush_raises
+
+        async def _refresh(row):
+            if refresh_returns_row is not None:
+                # Stamp the row with the canonical "as persisted" attrs.
+                for k, v in refresh_returns_row.items():
+                    setattr(row, k, v)
+
+        sess.flush = _flush
+        sess.refresh = _refresh
+        yield sess
+
+    return _session_ctx
+
+
+def _make_trace() -> Trace:
+    return Trace(
+        input="hello world",
+        output="hi there",
+        model_selected="hermes3-local",
+        latency_ms=42,
+    )
+
+
+class TestEmitTraceFailSoft:
+    @pytest.mark.asyncio
+    async def test_persist_failure_returns_none_and_does_not_raise(self) -> None:
+        trace = _make_trace()
+        sf = _stub_session_factory(flush_raises=RuntimeError("DB down"))
+        with capture_logs() as cap:
+            result = await emit_trace(trace, session_factory=sf)
+        assert result is None
+        assert any(
+            evt.get("event") == "trace_emit_failed" for evt in cap
+        ), cap
+
+    @pytest.mark.asyncio
+    async def test_persist_failure_does_not_log_raw_payload(self) -> None:
+        trace = _make_trace()
+        sf = _stub_session_factory(flush_raises=RuntimeError("boom"))
+        with capture_logs() as cap:
+            await emit_trace(trace, session_factory=sf)
+        # The fail-soft log line carries error metadata only — no raw
+        # input/output should appear in the event payload.
+        for evt in cap:
+            for value in evt.values():
+                if isinstance(value, str):
+                    assert trace.input not in value, evt
+                    assert trace.output not in value, evt
+
+
+class TestEmitTraceMetadataOnly:
+    @pytest.mark.asyncio
+    async def test_success_log_contains_only_metadata(self) -> None:
+        # Use TraceRepository's real append shape via a stub that accepts
+        # the row and returns the row unchanged on refresh.
+        with patch("agent.traces.emitter.TraceRepository") as repo_cls:
+            repo = MagicMock()
+            persisted = MagicMock()
+            persisted.trace_id = "11111111-1111-1111-1111-111111111111"
+            repo.append = AsyncMock(return_value=persisted)
+            repo_cls.return_value = repo
+
+            sf = _stub_session_factory()
+
+            trace = _make_trace()
+            with capture_logs() as cap:
+                result = await emit_trace(trace, session_factory=sf)
+
+        assert result == "11111111-1111-1111-1111-111111111111"
+        ok_logs = [evt for evt in cap if evt.get("event") == "trace_emit_ok"]
+        assert ok_logs, cap
+        ok = ok_logs[0]
+        # Allowed metadata.
+        assert ok["trace_id"] == "11111111-1111-1111-1111-111111111111"
+        assert ok["archetype"] == trace.archetype.value
+        assert ok["latency_ms"] == trace.latency_ms
+        # Disallowed RAW_PERSONAL — verify by exact-match scan over values.
+        for value in ok.values():
+            if isinstance(value, str):
+                assert trace.input not in value
+                assert trace.output not in value
+
+
+class TestEmitTraceEmbedScheduling:
+    @pytest.mark.asyncio
+    async def test_embed_worker_skipped_when_persist_fails(self) -> None:
+        trace = _make_trace()
+        sf = _stub_session_factory(flush_raises=RuntimeError("boom"))
+        embed_called = False
+
+        async def _embed(text: str) -> list[float]:
+            nonlocal embed_called
+            embed_called = True
+            return [0.0] * EMBEDDING_DIM
+
+        await emit_trace(
+            trace,
+            session_factory=sf,
+            embed_fn=_embed,
+            embed_model_version="qwen3-embedding:0.6b",
+        )
+        # Persistence failed → embedding worker must not be scheduled.
+        assert embed_called is False
+
+    @pytest.mark.asyncio
+    async def test_embed_worker_skipped_when_no_embed_fn(self) -> None:
+        # No embed_fn → no worker. Just confirm we don't crash and we
+        # return the trace_id from append.
+        trace = _make_trace()
+        with patch("agent.traces.emitter.TraceRepository") as repo_cls:
+            repo = MagicMock()
+            persisted = MagicMock()
+            persisted.trace_id = "22222222-2222-2222-2222-222222222222"
+            repo.append = AsyncMock(return_value=persisted)
+            repo_cls.return_value = repo
+
+            sf = _stub_session_factory()
+            result = await emit_trace(trace, session_factory=sf)
+        assert result == "22222222-2222-2222-2222-222222222222"
+
+
+# Re-bind structlog to non-capture for any subsequent tests in the suite.
+@pytest.fixture(autouse=True)
+def _reset_structlog():
+    yield
+    structlog.reset_defaults()

--- a/agent/traces/emitter.py
+++ b/agent/traces/emitter.py
@@ -1,0 +1,281 @@
+"""Trace emission glue — `TraceBuilder` accumulator + `emit_trace`.
+
+`TraceBuilder` is the mutable accumulator that turns a turn-in-progress
+into a finalized `Trace`. The pattern is:
+
+    tb = TraceBuilder.start(input=user_message, trigger_source=...)
+    # ... turn proceeds ...
+    tb.set_model(model_selected, model_version, prompt_version)
+    tb.add_tool_call(name=..., args=..., result_summary=..., success=...)
+    # ... output produced ...
+    trace = tb.finish(output=response, latency_ms=...)
+    await emit_trace(trace, session_factory=..., embed_fn=...)
+
+`emit_trace` is the fail-soft persistence wrapper used by `agent/core.py`
+and `agent/scheduler.py` (the latter lands in #23). It:
+
+1. Inserts the trace via `TraceRepository.append` inside a fresh session.
+2. Schedules an async embedding job that runs off the critical path and
+   updates the row via `TraceRepository.set_embedding`.
+3. Logs structured metadata on success/failure, never the row payload.
+4. Swallows every exception — trace persistence failure must never break
+   the user's turn. This is the operative invariant for Epic 01.
+"""
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable, Sequence
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+import structlog
+
+from agent.error_classifier import DataSensitivity
+from agent.traces.repository import TraceRepository
+from agent.traces.schema import (
+    EMBEDDING_DIM,
+    PROMPT_VERSION_UNVERSIONED,
+    Archetype,
+    Trace,
+    TraceTier,
+    TriggerSource,
+)
+
+logger = structlog.get_logger(__name__)
+
+# Async embedding worker is fire-and-forget. We keep a strong ref to the
+# task in a process-local set so the GC doesn't drop it mid-flight.
+_BACKGROUND_EMBED_TASKS: set[asyncio.Task] = set()
+
+
+def _safe_error_message(exc: BaseException) -> str:
+    """Render an exception for structlog without leaking bound parameters.
+
+    SQLAlchemy `StatementError` / `DBAPIError` `__str__` includes
+    `[parameters: (...)]` which can carry RAW_PERSONAL — `Trace.input`
+    or `tool_call.args` substrings would land in structlog output. We
+    only return the type name plus a short prefix of the exception's
+    own message (NOT the formatted SQL) so the operator can still
+    distinguish failure modes.
+    """
+    # Prefer `exc.orig` when present — it's the underlying DBAPI error,
+    # whose message rarely includes parameters. Fall back to type name only.
+    orig = getattr(exc, "orig", None)
+    if orig is not None:
+        return f"{type(orig).__name__}: {str(orig).splitlines()[0][:120]}"
+    msg = str(exc).splitlines()[0] if str(exc) else ""
+    # Hard guard: anything containing "[parameters" or "[SQL" is a
+    # SQLAlchemy formatted message; drop the message entirely.
+    if "[parameters" in msg or "[SQL" in msg:
+        return type(exc).__name__
+    return f"{type(exc).__name__}: {msg[:120]}"
+
+
+@dataclass
+class TraceBuilder:
+    """Accumulator for one turn's trace fields. NOT a Trace itself —
+    `finish()` constructs the frozen `Trace` exactly once and returns it.
+    """
+
+    input: str = ""
+    trigger_source: TriggerSource = TriggerSource.USER
+    archetype: Archetype = Archetype.ORCHESTRATOR
+    scheduler_job_name: Optional[str] = None
+    data_sensitivity: DataSensitivity = DataSensitivity.LOCAL_ONLY
+
+    assembled_context: dict[str, Any] = field(default_factory=dict)
+    model_selected: str = ""
+    model_version: str = ""
+    prompt_version: str = PROMPT_VERSION_UNVERSIONED
+    tools_called: list[dict[str, Any]] = field(default_factory=list)
+
+    @classmethod
+    def start(
+        cls,
+        *,
+        input: str,
+        trigger_source: TriggerSource = TriggerSource.USER,
+        archetype: Archetype = Archetype.ORCHESTRATOR,
+        scheduler_job_name: Optional[str] = None,
+        data_sensitivity: DataSensitivity = DataSensitivity.LOCAL_ONLY,
+    ) -> TraceBuilder:
+        return cls(
+            input=input,
+            trigger_source=trigger_source,
+            archetype=archetype,
+            scheduler_job_name=scheduler_job_name,
+            data_sensitivity=data_sensitivity,
+        )
+
+    # ── Accumulator entry points ──────────────────────────────────────────
+
+    def set_context(self, assembled_context: dict[str, Any]) -> None:
+        if not isinstance(assembled_context, dict):
+            raise TypeError("assembled_context must be a dict")
+        self.assembled_context = assembled_context
+
+    def set_model(
+        self,
+        model_selected: str,
+        *,
+        model_version: str = "",
+        prompt_version: str = PROMPT_VERSION_UNVERSIONED,
+    ) -> None:
+        # Last-write-wins so retries reflect the final state surfaced to
+        # the user — same convention as `chat_turn_logger.record_llm`.
+        self.model_selected = model_selected or ""
+        self.model_version = model_version or ""
+        self.prompt_version = prompt_version or PROMPT_VERSION_UNVERSIONED
+
+    def add_tool_call(
+        self,
+        *,
+        name: str,
+        args: Optional[dict[str, Any]] = None,
+        result_summary: str = "",
+        latency_ms: int = 0,
+        success: bool = True,
+        error: Optional[str] = None,
+    ) -> None:
+        if not name:
+            # The dataclass invariant rejects nameless tool calls; fail
+            # at the entry point so the call site sees a clear error.
+            raise ValueError("tool_call name is required")
+        self.tools_called.append(
+            {
+                "name": name,
+                "args": args or {},
+                "result_summary": result_summary,
+                "latency_ms": latency_ms,
+                "success": success,
+                "error": error,
+            },
+        )
+
+    # ── Finalisation ──────────────────────────────────────────────────────
+
+    def finish(
+        self,
+        *,
+        output: str,
+        latency_ms: int,
+        user_reaction: Optional[dict[str, Any]] = None,
+    ) -> Trace:
+        return Trace(
+            trigger_source=self.trigger_source,
+            archetype=self.archetype,
+            scheduler_job_name=self.scheduler_job_name,
+            input=self.input,
+            assembled_context=self.assembled_context,
+            output=output,
+            model_selected=self.model_selected,
+            model_version=self.model_version,
+            prompt_version=self.prompt_version,
+            tools_called=self.tools_called,
+            latency_ms=latency_ms,
+            user_reaction=user_reaction,
+            data_sensitivity=self.data_sensitivity,
+            tier=TraceTier.WORKING,
+        )
+
+
+# ── Persistence wrapper ───────────────────────────────────────────────────────
+
+
+SessionFactory = Callable[[], Any]  # async context manager yielding AsyncSession
+EmbedFn = Callable[[str], Awaitable[Sequence[float]]]
+
+
+async def emit_trace(
+    trace: Trace,
+    *,
+    session_factory: SessionFactory,
+    embed_fn: Optional[EmbedFn] = None,
+    embed_model_version: Optional[str] = None,
+) -> Optional[str]:
+    """Persist a trace and (optionally) schedule an async embed job.
+
+    Returns the persisted `trace_id` on success, `None` on any failure
+    (logged as `trace_emit_failed`). Never raises — trace persistence
+    must never break the user's turn.
+    """
+    try:
+        async with session_factory() as session:
+            repo = TraceRepository(session)
+            persisted = await repo.append(trace)
+            await session.commit()
+            trace_id = persisted.trace_id
+        # Structured metadata only. Never log the row's payload.
+        logger.info(
+            "trace_emit_ok",
+            trace_id=trace_id,
+            archetype=trace.archetype.value,
+            trigger_source=trace.trigger_source.value,
+            latency_ms=trace.latency_ms,
+            tool_calls=len(trace.tools_called),
+            data_sensitivity=trace.data_sensitivity.value,
+        )
+    except Exception as exc:
+        logger.warning(
+            "trace_emit_failed",
+            error_type=type(exc).__name__,
+            error=_safe_error_message(exc),
+        )
+        return None
+
+    # Embedding worker — fire-and-forget. Failures are also fail-soft.
+    if embed_fn is not None and embed_model_version:
+        try:
+            task = asyncio.create_task(
+                _embed_worker(
+                    trace_id=trace_id,
+                    text=(trace.input + "\n" + trace.output)[:8000],
+                    session_factory=session_factory,
+                    embed_fn=embed_fn,
+                    embed_model_version=embed_model_version,
+                ),
+            )
+            _BACKGROUND_EMBED_TASKS.add(task)
+            task.add_done_callback(_BACKGROUND_EMBED_TASKS.discard)
+        except RuntimeError:
+            # No running event loop — synchronous test contexts. Skip.
+            pass
+
+    return trace_id
+
+
+async def _embed_worker(
+    *,
+    trace_id: str,
+    text: str,
+    session_factory: SessionFactory,
+    embed_fn: EmbedFn,
+    embed_model_version: str,
+) -> None:
+    """Generate the embedding and write it back via the compactor surface."""
+    try:
+        vec = await embed_fn(text)
+        if len(vec) != EMBEDDING_DIM:
+            logger.warning(
+                "trace_embed_dim_mismatch",
+                trace_id=trace_id,
+                got=len(vec),
+                expected=EMBEDDING_DIM,
+            )
+            return
+        async with session_factory() as session:
+            repo = TraceRepository(session)
+            await repo.set_embedding(
+                trace_id=trace_id,
+                embedding=list(vec),
+                embedding_model_version=embed_model_version,
+            )
+            await session.commit()
+        logger.info("trace_embed_ok", trace_id=trace_id)
+    except Exception as exc:
+        logger.warning(
+            "trace_embed_failed",
+            trace_id=trace_id,
+            error_type=type(exc).__name__,
+            error=_safe_error_message(exc),
+        )


### PR DESCRIPTION
## Summary

Implements per-turn trace emission for [Epic 01](https://github.com/jacksteroo/Pepper/issues/17). Every chat turn now writes a `traces` row alongside the existing `routing_events` background task, with strict fail-soft semantics so trace persistence failure cannot break the user's turn.

- `agent/traces/emitter.py` — `TraceBuilder` accumulator + `emit_trace` fail-soft persistence wrapper. The accumulator follows the documented `start → set_context / set_model / add_tool_call → finish` pattern; `finish()` returns the frozen `Trace`. `emit_trace` persists via `TraceRepository`, schedules an off-critical-path embedding worker (qwen3-embedding:0.6b via the existing `embed_router` path), and swallows every exception.
- `agent/core.py` — `chat()` finally block now also instantiates a `TraceBuilder`, populates it from the existing `chat_turn_logger` snapshot (model, tool_calls), constructs a `Trace`, and schedules `emit_trace` as a background task. `assembled_context` stays a `{}` stub per ADR-0005 — the rich provenance plumbing lands in [#33](https://github.com/jacksteroo/Pepper/issues/33). Added optional `trigger_source` and `scheduler_job_name` kwargs so [#23](https://github.com/jacksteroo/Pepper/issues/23) can pass `TriggerSource.SCHEDULER` plus the job name.
- **Privacy hardening** — a security-review blocker found that SQLAlchemy `StatementError.__str__` includes `[parameters: (...)]` which could leak `Trace.input` or `tool_call.args` substrings into structlog when a write fails. New `_safe_error_message` helper strips that block before logging; all three log sites (`emit_trace`, `_embed_worker`, `trace_emit_wiring_failed`) route through it.

Closes #22.

## Test plan

- [x] `.venv/bin/python -m pytest agent/tests/test_traces_*.py agent/tests/test_core_trace_emission.py agent/tests/test_core.py` — 112 pass.
- [x] `.venv/bin/python -m ruff check agent/traces/ agent/core.py agent/tests/test_traces_*.py agent/tests/test_core_trace_emission.py` clean.

## Acceptance criteria for #22

- [x] Every chat turn produces exactly one trace (asserted by `test_chat_emits_one_trace_per_turn`).
- [x] Trace emission failure does not break the user-facing turn (asserted by `test_emitter_failure_does_not_break_chat_response`).
- [x] p95 turn latency degradation <50ms — `emit_trace` is `asyncio.create_task`'d so it runs entirely off the critical path; the inline TraceBuilder construction is sub-millisecond. Documented in the PR review pass.
- [x] All existing tests still pass (45 in `test_core.py`, plus the rest of the suite).

## What's deferred

- `assembled_context` rich population — stub `{}` until [#33](https://github.com/jacksteroo/Pepper/issues/33) lands E3.
- `prompt_version` set to `"unversioned"` until [#48](https://github.com/jacksteroo/Pepper/issues/48) wires versioned prompts.
- Embedding worker `_BACKGROUND_EMBED_TASKS` is a module-global set with done-callback discard; cleanup at shutdown is a follow-up.