### PR TITLE
traces: wire scheduler trigger_source + reflector_trigger NOTIFY (#23)

### DIFF
--- a/agent/scheduler.py
+++ b/agent/scheduler.py
@@ -3,6 +3,12 @@
 Manages timed jobs: morning brief, commitment check, weekly review, and memory
 compression. All content-generation jobs now route through pepper.chat() with
 heavy=True so the skill system guides the response — no hand-rolled formatters.
+
+Epic 01 (#23): every `pepper.chat()` call from this module carries
+`trigger_source=TriggerSource.SCHEDULER` plus the job name, so #22's trace
+emitter records the turn under the correct provenance. A separate
+`reflector_trigger` Postgres NOTIFY fires once per day at 23:55 — #39's
+reflector LISTENs on that channel.
 """
 
 import structlog
@@ -10,9 +16,17 @@ from datetime import datetime, timedelta, timezone
 from zoneinfo import ZoneInfo
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from apscheduler.triggers.cron import CronTrigger
+from sqlalchemy import text
 from agent.briefs import CommitmentExtractor
 from agent.commitment_followup import CommitmentFollowup
 from agent.models import AuditLog
+from agent.traces import TriggerSource
+
+# Postgres NOTIFY channel used to signal end-of-day to the reflector
+# process (#39). The payload is intentionally signal-only — no trace
+# contents — so the LISTEN client can never interpret the channel as
+# a content sink.
+REFLECTOR_TRIGGER_CHANNEL = "reflector_trigger"
 
 logger = structlog.get_logger()
 
@@ -76,6 +90,15 @@ class PepperScheduler:
             id="commitment_followup",
             replace_existing=True,
         )
+        # Epic 01 (#23): end-of-day signal for the reflector (#39). Fires
+        # one Postgres NOTIFY on the documented channel at 23:55. Payload
+        # is signal-only — the channel is not a content sink.
+        self._scheduler.add_job(
+            self.fire_reflector_trigger,
+            CronTrigger(hour=23, minute=55),
+            id="reflector_trigger",
+            replace_existing=True,
+        )
         self._scheduler.start()
         logger.info("scheduler_started", jobs=[j.id for j in self._scheduler.get_jobs()])
 
@@ -104,6 +127,8 @@ class PepperScheduler:
             session_id=session_id,
             heavy=True,
             isolated=True,
+            trigger_source=TriggerSource.SCHEDULER,
+            scheduler_job_name="morning_brief",
         )
 
         # Guaranteed persistence: save here rather than relying on the model to
@@ -168,6 +193,8 @@ class PepperScheduler:
             session_id=session_id,
             heavy=True,
             isolated=True,
+            trigger_source=TriggerSource.SCHEDULER,
+            scheduler_job_name="commitment_check",
         )
 
         await self._send(response)
@@ -193,6 +220,8 @@ class PepperScheduler:
             session_id=session_id,
             heavy=True,
             isolated=True,
+            trigger_source=TriggerSource.SCHEDULER,
+            scheduler_job_name="weekly_review",
         )
 
         # Guaranteed persistence: save here rather than relying on the model to
@@ -241,6 +270,46 @@ class PepperScheduler:
         await self._audit("commitment_followup", f"{len(due)} items")
         logger.info("commitment_followup_sent", count=len(due))
         return message
+
+    async def fire_reflector_trigger(self) -> bool:
+        """Fire the end-of-day Postgres NOTIFY for the reflector (#39).
+
+        Payload format: `<YYYY-MM-DD>` in the local timezone — a fixed,
+        signal-only string. The reflector LISTENs on this channel and
+        kicks off its daily window query. Trace contents are NEVER
+        included in the payload. Returns True on success, False on
+        error (job is best-effort and never raises).
+        """
+        if self.pepper.db_factory is None:
+            logger.info("reflector_trigger_skipped", reason="no_db_factory")
+            return False
+        tz = ZoneInfo(self.config.TIMEZONE)
+        payload = datetime.now(tz).strftime("%Y-%m-%d")
+        try:
+            async with self.pepper.db_factory() as session:
+                # NOTIFY needs literal SQL — no bind parameters allowed
+                # in NOTIFY's payload position. The payload is a fixed-
+                # format date string we generated ourselves; no user
+                # input flows into this SQL.
+                escaped = payload.replace("'", "''")
+                await session.execute(
+                    text(f"NOTIFY {REFLECTOR_TRIGGER_CHANNEL}, '{escaped}'"),
+                )
+                await session.commit()
+            logger.info(
+                "reflector_trigger_fired",
+                channel=REFLECTOR_TRIGGER_CHANNEL,
+                payload=payload,
+            )
+            await self._audit("reflector_trigger", payload)
+            return True
+        except Exception as exc:
+            logger.warning(
+                "reflector_trigger_failed",
+                error_type=type(exc).__name__,
+                error=str(exc)[:200],
+            )
+            return False
 
     def get_status(self) -> dict:
         return {

--- a/agent/tests/test_scheduler_trace_emission.py
+++ b/agent/tests/test_scheduler_trace_emission.py
@@ -1,0 +1,160 @@
+"""Tests for #23 — scheduler-side trace emission and the
+`reflector_trigger` Postgres NOTIFY signal.
+
+Each scheduled job that calls `pepper.chat()` must pass
+`trigger_source=TriggerSource.SCHEDULER` and the corresponding
+`scheduler_job_name`. The `reflector_trigger` job fires a
+NOTIFY on the documented channel with a date-only payload.
+"""
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from agent.scheduler import REFLECTOR_TRIGGER_CHANNEL, PepperScheduler
+from agent.traces import TriggerSource
+
+
+def _make_config():
+    config = MagicMock()
+    config.TIMEZONE = "UTC"
+    config.MORNING_BRIEF_HOUR = 8
+    config.MORNING_BRIEF_MINUTE = 0
+    config.WEEKLY_REVIEW_DAY = "sun"
+    config.WEEKLY_REVIEW_HOUR = 18
+    return config
+
+
+def _make_pepper(*, with_db: bool = True):
+    pepper = MagicMock()
+    pepper.chat = AsyncMock(return_value="response text")
+    pepper.memory = MagicMock()
+    pepper.memory.save_to_recall = AsyncMock()
+    pepper.memory.search_recall = AsyncMock(return_value=[])
+
+    if with_db:
+        executed_sql: list[str] = []
+
+        @asynccontextmanager
+        async def _session_ctx():
+            sess = MagicMock()
+
+            async def _execute(stmt):
+                executed_sql.append(getattr(stmt, "text", str(stmt)))
+                return MagicMock()
+
+            sess.execute = AsyncMock(side_effect=_execute)
+            sess.commit = AsyncMock()
+            sess.add = MagicMock()
+            yield sess
+
+        pepper.db_factory = _session_ctx
+        pepper._executed_sql = executed_sql
+    else:
+        pepper.db_factory = None
+
+    return pepper
+
+
+class TestSchedulerJobsCarryTriggerSource:
+    @pytest.mark.asyncio
+    async def test_morning_brief_emits_scheduler_trace(self) -> None:
+        pepper = _make_pepper()
+        sch = PepperScheduler(pepper, _make_config())
+        await sch.generate_morning_brief()
+        pepper.chat.assert_awaited_once()
+        kwargs = pepper.chat.await_args.kwargs
+        assert kwargs["trigger_source"] is TriggerSource.SCHEDULER
+        assert kwargs["scheduler_job_name"] == "morning_brief"
+        assert kwargs["isolated"] is True
+
+    @pytest.mark.asyncio
+    async def test_weekly_review_emits_scheduler_trace(self) -> None:
+        pepper = _make_pepper()
+        sch = PepperScheduler(pepper, _make_config())
+        await sch.generate_weekly_review()
+        pepper.chat.assert_awaited_once()
+        kwargs = pepper.chat.await_args.kwargs
+        assert kwargs["trigger_source"] is TriggerSource.SCHEDULER
+        assert kwargs["scheduler_job_name"] == "weekly_review"
+
+    @pytest.mark.asyncio
+    async def test_commitment_check_emits_scheduler_trace_when_items_open(
+        self,
+    ) -> None:
+        pepper = _make_pepper()
+        # Force at least one open commitment so the chat path runs.
+        pepper.memory.search_recall = AsyncMock(
+            return_value=[
+                {
+                    "content": "COMMITMENT: ship the trace substrate",
+                    "created_at": "2025-01-01T00:00:00+00:00",
+                },
+            ],
+        )
+        sch = PepperScheduler(pepper, _make_config())
+        await sch.check_commitments()
+        pepper.chat.assert_awaited_once()
+        kwargs = pepper.chat.await_args.kwargs
+        assert kwargs["trigger_source"] is TriggerSource.SCHEDULER
+        assert kwargs["scheduler_job_name"] == "commitment_check"
+
+    @pytest.mark.asyncio
+    async def test_commitment_check_skips_chat_when_no_open_items(
+        self,
+    ) -> None:
+        # The no-open-items short-circuit predates Epic 01 — verify it
+        # still doesn't emit a (rogue) trace by calling chat at all.
+        pepper = _make_pepper()
+        pepper.memory.search_recall = AsyncMock(return_value=[])
+        sch = PepperScheduler(pepper, _make_config())
+        await sch.check_commitments()
+        pepper.chat.assert_not_awaited()
+
+
+class TestReflectorTrigger:
+    @pytest.mark.asyncio
+    async def test_fires_notify_on_documented_channel(self) -> None:
+        pepper = _make_pepper(with_db=True)
+        sch = PepperScheduler(pepper, _make_config())
+        ok = await sch.fire_reflector_trigger()
+        assert ok is True
+        # Exactly one SQL statement was executed: the NOTIFY.
+        assert len(pepper._executed_sql) == 1
+        sql = pepper._executed_sql[0]
+        assert sql.startswith(f"NOTIFY {REFLECTOR_TRIGGER_CHANNEL}")
+        # Payload is signal-only (a date string), never trace contents.
+        # Just confirm there's no jsonb / SELECT / trace text in there.
+        assert "trace" not in sql.lower()
+        assert "SELECT" not in sql
+
+    @pytest.mark.asyncio
+    async def test_skipped_when_db_factory_missing(self) -> None:
+        pepper = _make_pepper(with_db=False)
+        sch = PepperScheduler(pepper, _make_config())
+        ok = await sch.fire_reflector_trigger()
+        assert ok is False  # graceful skip, no raise
+
+    @pytest.mark.asyncio
+    async def test_failure_does_not_raise(self) -> None:
+        pepper = _make_pepper(with_db=True)
+        # Replace db_factory with one whose session.execute raises.
+        @asynccontextmanager
+        async def _broken():
+            sess = MagicMock()
+            sess.execute = AsyncMock(side_effect=RuntimeError("DB down"))
+            sess.commit = AsyncMock()
+            sess.add = MagicMock()
+            yield sess
+
+        pepper.db_factory = _broken
+        sch = PepperScheduler(pepper, _make_config())
+        ok = await sch.fire_reflector_trigger()
+        assert ok is False  # fail-soft
+
+    def test_channel_name_is_documented_constant(self) -> None:
+        # ADR-0005 / #23 spec name. If anyone renames the channel they
+        # must update both the scheduler and the reflector LISTEN side.
+        assert REFLECTOR_TRIGGER_CHANNEL == "reflector_trigger"


### PR DESCRIPTION
## Summary

- Each scheduler job that calls `pepper.chat()` now passes `trigger_source=TriggerSource.SCHEDULER` and `scheduler_job_name=<job>` so [#22](https://github.com/jacksteroo/Pepper/issues/22)'s emitter records every scheduled turn under the correct provenance. Three jobs touched: `morning_brief`, `commitment_check`, `weekly_review`.
- New `reflector_trigger` job at 23:55 daily fires a Postgres `NOTIFY reflector_trigger, '<YYYY-MM-DD>'`. The payload is signal-only (a date string in the local timezone) — never trace contents. The reflector process from [#39](https://github.com/jacksteroo/Pepper/issues/39) LISTENs on this channel. Fail-soft.
- `REFLECTOR_TRIGGER_CHANNEL` is a module constant so the LISTEN side and NOTIFY side cannot drift.

Closes #23.

## Test plan

- [x] `.venv/bin/python -m pytest agent/tests/test_scheduler_trace_emission.py -v` — 8 pass.
- [x] `.venv/bin/python -m ruff check agent/scheduler.py agent/tests/test_scheduler_trace_emission.py` clean.

## Acceptance criteria for #23

- [x] All three existing scheduled chat jobs emit traces with `trigger_source=scheduler` and the right job name.
- [x] `reflector_trigger` NOTIFY fires once per day (cron at 23:55 in `config.TIMEZONE`).
- [x] Existing scheduler tests still pass.