### PR TITLE
docs(adr): close acceptance-criteria gaps on ADR-0002 (#12) and ADR-0004 (#14)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ Pepper is a sovereign, local-first AI life assistant. Think Iron Man's Pepper â€
 2. **Sovereignty**: No mandatory cloud services. Every component must have a local-only fallback.
 3. **Additive**: The system accumulates context over time. Never delete or overwrite historical data â€” compress and archive instead.
 4. **Pluggable**: Every subsystem (People, Calendar, Communications, etc.) is independently replaceable. No tight coupling between subsystems.
-5. **Compounding capability** ([ADR-0002](docs/adr/0002-fifth-anchoring-principle-compounding-capability.md)): The system improves itself in response to its own behaviour, within human-reviewable bounds. Local traces drive routing, prompt, and skill optimization; changes are versioned and revertable; the agent does not silently rewrite production prompts.
+5. **Compounding capability** ([ADR-0002](docs/adr/0002-fifth-anchoring-principle-compounding-capability.md)): Self-improvement is allowed only through versioned, inspectable, reversible artifacts (prompts, strategies, identity diffs). The system must not modify its own behavior through opaque weight updates or any mechanism that cannot be diffed, inspected, and reverted by hand.
 6. **Self-maintaining**: Prefer designs that a maintenance agent can upgrade without human intervention.
 
 ## Project Structure

--- a/docs/adr/0002-fifth-anchoring-principle-compounding-capability.md
+++ b/docs/adr/0002-fifth-anchoring-principle-compounding-capability.md
@@ -5,63 +5,74 @@
 
 ## Context
 
-Pepper has four anchoring principles: privacy-first, sovereignty, additive memory, pluggable subsystems. Together they describe what the system *protects* (the operator's data) and what it *preserves* (its own context over time). They do not describe how the system *improves*.
+Pepper has four anchoring principles: privacy-first, sovereignty, additive memory, pluggable subsystems. Each is a *forbidding* — a constraint on what the system cannot do. That shape is what makes them load-bearing at PR-review time: a reviewer can point at one and reject a change that violates it without re-litigating the philosophy.
 
-Today the only mechanism by which Pepper gets better is a developer changing code, tests passing, and a release shipping. Between commits, behaviour is static. The semantic router learns nothing from its own decisions; prompts do not adapt to recurring failure modes; the agent cannot reason about its own past behaviour because there is no behavioural trace store to reason over.
+ADR-0001 commits Pepper to a substrate-phase plan whose deliverables — trace store, hybrid retrieval, reflection runtime, learned routing — only make sense if the system *learns from its own behaviour*. Workstream E05 (DSPy/GEPA-style prompt and router optimization on local traces) is the concrete implementation of that learning loop. E05's machinery already implies a posture: that self-modification is allowed, but only in artifacts a human can read, version, and revert. That posture is not currently written down anywhere.
 
-This is a strategic gap. ADR-0001 commits Pepper to a substrate phase whose deliverables — trace store, hybrid retrieval, reflection runtime, learned routing — only make sense if "the system improves itself in response to its own behaviour" is a first-class principle. Without that principle stated, those deliverables look like opportunistic features rather than the substrate they are. The OJ-calibration thread surfaces this directly: *compounding context* is in the existing principles, *compounding capability* is not, and the gap shows up everywhere it matters.
+The gap is dangerous in both directions:
 
-The principle has to be added now, before substrate work lands, so that future PRs in that workstream are reviewable against an explicit anchor instead of being argued from first principles each time.
+- Without an explicit anchoring principle, future contributors will second-guess legitimate learning loops within E05's bounds, treating any self-modification as a privacy or sovereignty risk and slowing the substrate phase.
+- Without an explicit *forbidding*, the same future contributors will accidentally drift past those bounds — into local fine-tuning of weights, opaque adapter merges, or any "the agent rewrites itself in ways no one can diff" pattern — without realising they have crossed a line.
+
+The OJ-calibration thread surfaces this directly: *compounding context* (additive memory) is in the existing principles, *compounding capability* is not, and the gap shows up everywhere it matters. The principle has to be added now, before substrate-phase PRs land, so that E05 and its successors are reviewable against an explicit anchor instead of being argued from first principles each time.
 
 ## Decision
 
-Add a fifth anchoring principle to the project's stated invariants:
+Add a fifth anchoring principle to the project's stated invariants. The wording is deliberately a *forbidding*, to match the shape of the existing four:
 
-> **Compounding capability.** The system improves itself in response to its own behaviour, within human-reviewable bounds.
+> **Compounding capability.** Self-improvement is allowed only through versioned, inspectable, reversible artifacts (prompts, strategies, identity diffs). The system must not modify its own behavior through opaque weight updates or any mechanism that cannot be diffed, inspected, and reverted by hand.
 
 Operationally, this principle means:
 
 - Pepper records structured behavioural traces of her own actions and outcomes.
 - Periodic reflection processes consume those traces and surface recurring failure modes, useful patterns, and proposed adjustments.
-- Optimization processes (DSPy-style or equivalent) tune routing decisions, prompts, and skill selection from local traces.
-- All such self-improvement is bounded: changes are versioned, human-reviewable, and revertable. The agent does not silently rewrite production prompts.
+- Optimization processes (DSPy-style or equivalent) tune routing decisions, prompts, skill selection, and identity-doc deltas from local traces — and only those artifacts.
+- Every change produced by self-improvement is committable, diffable, and revertable by the operator. No silent rewrites, no opaque weight updates, no in-place mutation of behaviour that cannot be reconstructed from a versioned artifact.
 
-This principle is not in conflict with the existing four anchoring principles (privacy-first, sovereignty, additive memory, pluggable subsystems) called out in `CLAUDE.md`. Privacy and sovereignty are preserved because optimization runs locally on local traces; only optimized prompts (artefacts, not raw data) ever leave the machine, and only when the operator chooses to ship them. Additivity is preserved because traces are append-only and optimized prompts are versioned. Pluggable subsystems are preserved because trace collection and reflection live in their own modules, not inside `agent/core.py`.
+The principle is concrete and operationally testable: at PR review, the question is *"can a human read, version, and revert this change?"* If yes, the change is within bounds. If no, the change is rejected.
 
-`CLAUDE.md`'s Pepper Core Principles list is updated in this PR to add the new principle alongside the existing entries. `docs/PRINCIPLES.md` is the broader, operational-principles document and is intentionally not modified here — its scope (data sovereignty, durability, versioning, etc.) is wider than the CLAUDE.md anchor list, and folding "compounding capability" into it without restructuring would dilute both. A future ADR can revisit the relationship between the two if the breadth of `PRINCIPLES.md` becomes a problem.
+**The bet this principle makes.** That prompt / strategy / identity-diff-level optimization is enough — that we do not need local fine-tuning of small models to hit Pepper's goals. If local fine-tuning of small models becomes a routine, debuggable practice in the next two years, this principle would block it. That is intentional. If the bet looks wrong, the principle gets re-litigated as a future ADR; it does not get silently bent.
 
-ADR-0001's substrate phase now has an anchor it can be reviewed against. The bound (*"within human-reviewable bounds"*) is enforced by `docs/GUARDRAILS.md`, which takes precedence over any ADR including this one — any self-improvement feature that breaches the bound is rejected at code review per the existing GUARDRAILS precedence rule.
+This principle is not in conflict with the existing four. Privacy and sovereignty are preserved because optimization runs locally on local traces; only optimized prompts (artifacts, not raw data) ever leave the machine, and only when the operator chooses to ship them. Additivity is preserved because traces are append-only and optimized prompts are versioned. Pluggable subsystems are preserved because trace collection and reflection live in their own modules, not inside `agent/core.py`.
+
+`CLAUDE.md`'s Pepper Core Principles list is updated in this PR to carry the same wording verbatim, as principle #6. The Notion *Agent Pepper* hub's *Anchoring Principles* section is updated alongside, with identical wording, so the two surfaces never drift. `docs/PRINCIPLES.md` is the broader, operational-principles document and is intentionally not modified here — its scope (data sovereignty, durability, versioning, etc.) is wider than the CLAUDE.md anchor list, and folding "compounding capability" into it without restructuring would dilute both.
+
+The bound is enforced by `docs/GUARDRAILS.md`, which takes precedence over any ADR including this one — any self-improvement feature that breaches the bound is rejected at code review per the existing GUARDRAILS precedence rule.
 
 ## Consequences
 
 **Positive.**
 
-- Substrate work (trace store, reflection runtime, learned routing) is now anchored to a stated principle, not argued ad hoc.
-- The bound *"within human-reviewable bounds"* gives reviewers an explicit rejection criterion for self-improvement features that would silently mutate behaviour.
-- Future ADRs that propose feedback loops, learning components, or DSPy-style optimization can cite this principle directly instead of re-justifying the entire posture.
+- Substrate work (trace store, reflection runtime, learned routing, E05) is now anchored to a stated principle, not argued ad hoc.
+- The principle is operationally testable at PR review: *can a human read, version, and revert this change?* That is a sharper bar than "is this human-reviewable?" and harder to game.
+- The forbidding shape matches the existing four principles, so reviewers already know how to apply it. It plugs into the existing review reflex rather than asking reviewers to learn a new pattern.
+- Future ADRs that propose feedback loops, learning components, or DSPy/GEPA-style optimization can cite this principle directly instead of re-justifying the entire posture.
 
 **Negative.**
 
-- The "five anchoring principles" framing must now be reflected in onboarding docs, PRINCIPLES.md, CLAUDE.md, and any future architecture write-ups. Doc churn is a one-time cost.
-- The principle creates an obligation: any self-improvement feature must demonstrate human-reviewability, which is a real engineering requirement (versioning, diff surfaces, rollback). Cheap "just have the agent rewrite its prompts" implementations are now out of bounds.
+- The "five anchoring principles" framing must now be reflected in onboarding docs, `CLAUDE.md`, the Notion hub, and any future architecture write-ups. Doc churn is a one-time cost.
+- The principle creates an obligation: any self-improvement feature must demonstrate inspectability and reversibility, which is a real engineering requirement (versioning, diff surfaces, rollback).
+- The bet on artifact-level optimization is real. If small-model fine-tuning matures into a routine, debuggable practice within Pepper's lifetime, this principle would block adoption until a successor ADR re-litigates the posture. That is the cost of forbidding a technique now to keep the substrate clean.
 
 **Neutral.**
 
 - The four existing principles are unchanged in scope and meaning.
-- The principle does not commit to a specific implementation (DSPy, GEPA, lighter-weight prompt evolution, learned routers). It commits only to the *shape* of the invariant.
+- The principle does not pick a specific implementation (DSPy, GEPA, lighter-weight prompt evolution, learned routers). It commits only to the *shape* of the invariant.
 
 ## Alternatives considered
 
-- **Status quo: keep four anchoring principles, treat self-improvement as a feature category.** Rejected — every substrate-phase deliverable in ADR-0001 ends up arguing the same posture from first principles. The cost of stating the principle once, in the canonical list, is far lower than the cost of re-litigating it on every PR. Worse: without an explicit principle, a single reviewer's intuition becomes the bar.
-- **State the principle in `docs/ROADMAP.md` rather than as an anchoring principle.** Rejected — roadmap items rotate; anchoring principles do not. Compounding capability is an invariant about *how the system works over time*, not a phase deliverable.
-- **State the principle but defer the "human-reviewable bounds" clause.** Rejected — without the bound, the principle authorizes silent self-mutation, which conflicts with the existing privacy/sovereignty posture and with safe operation. The bound is what makes the principle compatible with the others.
-- **Adopt OpenJarvis-style autonomous learning loops without an anchoring principle.** Rejected — that posture (sensible defaults, opt-out) is a framework's posture. Pepper is a single-operator product and has chosen "you cannot opt out without breaking a test" as its enforcement model. Importing the loop without importing the posture would create a hidden divergence from the existing principles.
+- **(A) Original enabling wording — *"the system improves itself in response to its own behaviour, within human-reviewable bounds"*.** Rejected. Two reasons. First, it does not match the *shape* of the existing four anchoring principles, which are forbiddings, so it would not plug into the same review reflex. Second, "within human-reviewable bounds" is softer than the operationally-testable bar in the ratified wording: it authorises self-modification in general and asks reviewers to draw the line case-by-case, where the ratified wording forecloses opaque weight updates outright. The enabling wording would not have ruled out the failure mode it intended to.
+- **(B) Status quo: keep four anchoring principles, treat self-improvement as a feature category.** Rejected — every substrate-phase deliverable in ADR-0001 (and E05 in particular) ends up arguing the same posture from first principles. Without an explicit principle, a single reviewer's intuition becomes the bar, and the substrate phase ships unevenly.
+- **(C) Reject the principle entirely; do not add a fifth.** Rejected. This was the most credible alternative. The argument: four crisp principles are easier to remember than five, and the substrate phase can be reviewed against privacy-first and sovereignty alone. The argument fails because privacy-first only forbids data exfiltration, and sovereignty only forbids cloud dependence — neither speaks to the *shape* of behaviour-mutation, which is the actual concern. Without compounding capability, the substrate phase has to invent a new principle in its first PR review and re-justify it forever after. The cost of stating it once now is much smaller.
+- **(D) State the principle in `docs/ROADMAP.md` rather than as an anchoring principle.** Rejected — roadmap items rotate; anchoring principles do not. Compounding capability is an invariant about *how the system works over time*, not a phase deliverable.
+- **(E) Adopt OpenJarvis-style autonomous learning loops without an anchoring principle.** Rejected — that posture (sensible defaults, opt-out) is a framework's posture. Pepper is a single-operator product and has chosen "you cannot opt out without breaking a test" as its enforcement model. Importing the loop without importing the posture would create a hidden divergence from the existing principles.
 
 ## References
 
 - [OpenJarvis calibration — lessons, challenges, shortest path](https://www.notion.so/jacksteroo/OpenJarvis-calibration-lessons-challenges-shortest-path-354fb736739081ae8834eb6be2d361c0) — §3 "No learning loop — Pepper is static between commits"
-- [Agent Pepper hub](https://www.notion.so/jacksteroo/Agent-Pepper-353fb7367390806a88addf0430118d34)
-- [docs/PRINCIPLES.md](../PRINCIPLES.md) — canonical list of anchoring principles
+- [Agent Pepper hub](https://www.notion.so/jacksteroo/Agent-Pepper-353fb7367390806a88addf0430118d34) — *Anchoring Principles* section is updated alongside this ADR
+- [docs/PRINCIPLES.md](../PRINCIPLES.md) — canonical list of operational principles (intentionally not modified here)
 - [ADR-0001](0001-resequence-around-oj-calibration.md) — substrate phase that this principle anchors
 - [ADR-0000 template](0000-template.md)
+- Q8 resolution (forbidding-shape wording), 2026-05-02
 - Source PR: [#12](https://github.com/jacksteroo/Pepper/issues/12)

--- a/docs/adr/0004-introduce-agents-directory.md
+++ b/docs/adr/0004-introduce-agents-directory.md
@@ -15,13 +15,34 @@ Today these cognitive processes have nowhere clean to live. Putting them inside 
 
 Introduce a new top-level directory `agents/` parallel to `subsystems/`. It is the home for *cognitive functions* — long-running, specialised AI processes that consume traces and produce reflections, compressions, summaries, or research outputs.
 
-`agents/` carries the same isolation rule as `subsystems/`:
+Per the Q3 resolution on issue #37, agents run as separate processes — not as in-process daemons inside Pepper Core. The process model decision is recorded there; this ADR ratifies the directory and isolation rule that the processes inhabit.
 
-1. No cross-imports between agent modules. `agents/reflector/` cannot import from `agents/monitor/`. They communicate via the trace store and persisted artefacts (summaries, identity-doc updates), not via shared code.
-2. No imports from `agent/core.py`. The orchestrator is downstream of cognitive agents; agents must never reach back into it.
-3. Each agent module is independently replaceable. Swapping the reflector for a different implementation must not require touching any other module.
+### Isolation rule
 
-A lint check enforces the isolation rule. As of this ADR, no such check exists in the repo: the project's lint config is `[tool.ruff]` in `pyproject.toml`, which configures formatting and basic style rules but no import-graph constraints. The likely home for the new check is therefore one of: a `[tool.ruff.lint.flake8-tidy-imports.banned-api]` block in `pyproject.toml` covering both `subsystems/` and `agents/` boundaries, a small custom checker invoked from CI, or both. This ADR creates the obligation to add the check before the first `agents/` module lands; the choice of mechanism is left to the implementing PR. The lint check itself is not in this PR — this PR ratifies the rule, and the next implementation PR brings the check.
+`agents/` carries the same modular discipline as `subsystems/`, with one explicit carve-out for utilities (per the Q7 resolution, 2026-05-02):
+
+1. **No cross-imports between agent modules.** `agents/reflector/` cannot import from `agents/monitor/`. They communicate via the trace store and persisted artefacts (summaries, identity-doc updates), not via shared code.
+2. **No imports from `agent/core.py` or any `subsystems/`.** The orchestrator is downstream of cognitive agents; agents must never reach back into it. Subsystem capabilities are reached the same way the orchestrator reaches them — via tool calls / MCP — not via direct Python imports.
+3. **Agents MAY import from `agents/_shared/` for utilities only.** Logging setup, config loading, db connection management, pure helpers. `_shared/` is forbidden from holding any state, session info, or shared mutable resource — anything that would create coupling between agents.
+4. **Each agent module is independently replaceable.** Swapping the reflector for a different implementation must not require touching any other agent module.
+
+### `agents/_shared/` discipline
+
+The `_shared/` carve-out is a real risk: every project that allows a "shared utilities" directory eventually finds state, session caches, or coordination logic creeping into it. The rule "`_shared/` is utilities only" is therefore enforced by three layered safeguards:
+
+1. **Mandatory docstring rationale.** Every file under `agents/_shared/` must carry a module docstring that names the utility and explains why it is shared rather than living inside a single agent. CI lint rejects PRs that add a `_shared/` file without one. This is the cheapest and most reliable safeguard: every contributor sees the bar.
+2. **PR review checklist item.** PR review for any change touching `agents/_shared/` includes the question: *"Does this `_shared/` addition store state, or does it just provide utilities?"* If the answer is "stores state," the change is rejected and the state is moved to its own subsystem with its own MCP contract.
+3. **Quarterly audit.** Once per quarter, the `_shared/` directory is reviewed to refactor anything that has drifted toward coupling. Items that have grown state since the last audit are split out as subsystems.
+
+If `_shared/` ever drifts into holding state across agents, the right response is to split that state out as its own subsystem (which gets its own MCP server and explicit contract), not to expand `_shared/` to accommodate it.
+
+### Honest note on the carve-out
+
+During the Q7 deep-walk (2026-05-02), the recommendation was Option A — strict, no `agents/_shared/` directory at all — on the grounds that the discipline cost of keeping `_shared/` clean compounds over years and the safer default is to not have one. Jack picked Option B (looser, with `_shared/`) for ergonomic reasons during the substrate phase. The three safeguards above are what make Option B safe over time. The two-year test is whether `_shared/` ever crosses the state line: if it does, the recovery path is to split state out as a subsystem, not to relax the safeguards.
+
+### Lint enforcement
+
+A lint check enforces both the isolation rule and the `_shared/`-docstring rule. As of this ADR, no such check exists in the repo: the project's lint config is `[tool.ruff]` in `pyproject.toml`, which configures formatting and basic style rules but no import-graph or per-file constraints. The likely home for the new check is one of: a `[tool.ruff.lint.flake8-tidy-imports.banned-api]` block in `pyproject.toml` covering both `subsystems/` and `agents/` boundaries, a small custom checker invoked from CI for the import rules and the `_shared/` docstring rule, or both. This ADR creates the obligation to add the check before the first `agents/` module lands; the choice of mechanism is left to the implementing PR (which lives in #38). The lint check itself is not in this PR — this PR ratifies the rule.
 
 First inhabitants once substrate work begins:
 
@@ -42,17 +63,18 @@ First inhabitants once substrate work begins:
 
 **Negative.**
 
-- A new top-level directory expands the project's surface and adds a concept new contributors must learn. The mitigation is keeping the rule identical to `subsystems/` so the cognitive load is "another boundary you've seen before," not "a new architectural pattern."
-- Lint enforcement is now an obligation. The first PR that adds an `agents/` module must also bring the lint check, or the boundary erodes immediately.
-- Cross-cutting concerns that would naturally span agents (e.g., shared trace-reading helpers) need a designated home. The likely answer is to expose those helpers from the trace-store module rather than from a shared agents-only utility module, but the right shape will only become clear when the first two agents land.
+- A new top-level directory expands the project's surface and adds a concept new contributors must learn. The mitigation is keeping the rule mostly identical to `subsystems/` so the cognitive load is "another boundary you've seen before, with one explicit utilities carve-out."
+- Lint enforcement is now an obligation. The first PR that adds an `agents/` module (#38) must also bring the lint check covering import boundaries *and* the `_shared/` docstring requirement, or the boundary erodes immediately.
+- The `_shared/` carve-out is a discipline cost, not a free lunch. It has to be re-defended on every PR that touches it, plus a quarterly audit. The cost is real; the safeguards are designed to make it sustainable rather than to eliminate it.
 
 **Neutral.**
 
 - Existing code under `agent/` and `subsystems/` is untouched. This ADR creates a directory rule, not a migration.
-- The decision does not pick a process model (separate process, APScheduler job, daemon thread). That is left to the substrate-phase implementation PRs.
+- The process model (separate processes per agent) is not chosen here — it is recorded in the Q3 resolution on issue #37. This ADR ratifies the directory and isolation rule that those processes inhabit.
 
 ## Alternatives considered
 
+- **(A) Strict — `agents/` with no `_shared/` directory at all.** Rejected (see *Honest note on the carve-out*, above). Reason: this was the lower-risk option over a multi-year horizon — every project that allows a `_shared/` directory eventually finds state creeping into it, and starting without one would have eliminated that failure mode at zero discipline cost. It was rejected in favour of Option B for ergonomics during the substrate phase: requiring every agent to redo logging setup, config loading, and db connection plumbing inside its own module would slow the first three or four agents, with that cost falling almost entirely on a small number of contributors. The three safeguards (mandatory docstring, PR-review checklist, quarterly audit) are explicitly the price of choosing B. If a future audit finds `_shared/` has crossed the state line and the safeguards are not holding it back, the right escalation is to revisit this ADR and adopt A — not to relax the safeguards.
 - **Status quo: keep cognitive processes inside `agent/`.** Rejected — that is the path that produces a single orchestrator stuffed with reflection, monitoring, salience scoring, and restraint, all sharing one prompt and one memory window. The OJ-calibration thread documents why that pattern produces incoherent agents. Keeping the directory clean before the work starts is far cheaper than untangling it later.
 - **Place cognitive processes under `subsystems/` (e.g., `subsystems/reflector/`).** Rejected — `subsystems/` means *capability boundaries*. Adding cognitive functions there overloads the meaning of the directory and weakens the existing isolation rule for both. Two clear concepts beats one ambiguous one.
 - **Use a `runtime/` or `cognition/` directory instead of `agents/`.** Rejected — `agents/` matches the language used internally and in the calibration thread, and matches industry usage (OpenJarvis archetypes, Generative Agents). New names would need new explanations.


### PR DESCRIPTION
Closes the open acceptance-criteria checkboxes on [#12](https://github.com/jacksteroo/Pepper/issues/12) and [#14](https://github.com/jacksteroo/Pepper/issues/14) that landed underspecified in their original PRs ([#66](https://github.com/jacksteroo/Pepper/pull/66) / [#68](https://github.com/jacksteroo/Pepper/pull/68)). The original Epic 00 PRs predated the Q7 / Q8 resolutions on those issues; this PR brings the merged ADRs and CLAUDE.md back in line with the issues' ratified text.

## ADR-0002 (#12) — fifth anchoring principle, ratified wording

The original PR landed an *enabling* wording (\"the system improves itself in response to its own behaviour, within human-reviewable bounds\"). Per the Q8 resolution on #12, the ratified wording is a *forbidding* that matches the shape of the existing four anchoring principles:

> **Compounding capability.** Self-improvement is allowed only through versioned, inspectable, reversible artifacts (prompts, strategies, identity diffs). The system must not modify its own behavior through opaque weight updates or any mechanism that cannot be diffed, inspected, and reverted by hand.

Changes:

- \`docs/adr/0002-fifth-anchoring-principle-compounding-capability.md\` — Decision rewritten to use the ratified forbidding wording. Context now points to E05 (DSPy/GEPA) as the concrete implementation this principle anchors and calls out both failure modes (over-cautious about legitimate loops; silent drift past artifact-level optimization). Adds the bet this principle makes (artifact-level optimization is enough; future small-model fine-tuning would block on a successor ADR).
- Alternatives now include **(A) original enabling wording** (rejected for shape and softness), **(B) status quo / no fifth principle** (rejected), **(C) reject the principle entirely** (rejected — most credible alternative; the response captures why).
- \`CLAUDE.md\` principle #5 carries the ratified wording verbatim so CLAUDE.md and the ADR cannot drift.
- The Notion *Agent Pepper* hub *Anchoring Principles* section is updated alongside (out-of-band).

## ADR-0004 (#14) — \`_shared/\` carve-out + safeguards (Q7 resolution)

The original PR ratified the strict isolation rule but missed the Q7 resolution, which carved out an \`agents/_shared/\` utilities directory with three layered safeguards.

Changes:

- \`docs/adr/0004-introduce-agents-directory.md\` — Adds the \`agents/_shared/\` carve-out: agents may import from \`_shared/\` for utilities only (logging setup, config loading, db connection management, pure helpers). \`_shared/\` is forbidden from holding state, session info, or any shared mutable resource.
- Adds the three safeguards: **mandatory module docstring** (CI-enforced), **PR-review checklist item**, **quarterly audit**.
- Adds the **honest note**: the Q7 deep-walk recommended Option A (strict, no \`_shared/\`); Jack picked Option B (looser); the safeguards are the price of choosing B. The recovery path if \`_shared/\` ever crosses the state line is to split state out as a subsystem, not to relax the safeguards.
- Alternatives now include rejected **Option A (strict — no \`_shared/\`)** with the reason it was rejected.
- References the Q3 resolution on #37 for the separate-process model, instead of the prior \"left to implementation\" stub in the Neutral consequences.
- Lint-enforcement section now explicitly covers both import boundaries *and* the \`_shared/\` docstring rule.

## Reviewable in isolation

Docs only. Three files: \`CLAUDE.md\`, \`docs/adr/0002-...md\`, \`docs/adr/0004-...md\`. No code, no dependencies, no CI changes.

## Test plan

- [x] CLAUDE.md principle #5 wording matches \`docs/adr/0002-...md\` Decision quote verbatim.
- [x] ADR-0002 Alternatives include (A) original enabling, (B) status quo, (C) reject the principle.
- [x] ADR-0002 Context references E05 explicitly.
- [x] ADR-0004 documents the strict isolation rule + the \`_shared/\` carve-out + the three safeguards.
- [x] ADR-0004 Alternatives include rejected Option A.
- [x] Notion hub *Anchoring Principles* updated with identical wording (separate from this PR; tracked here).

After merge: the acceptance-criteria checkboxes on issues [#12](https://github.com/jacksteroo/Pepper/issues/12) and [#14](https://github.com/jacksteroo/Pepper/issues/14) will be checked off, plus the plain-bullet criteria on #10/#11/#13/#15/#16 will be marked as satisfied.