### PR TITLE
traces: /traces FastAPI endpoint + minimal React inspector (#24)

### DIFF
--- a/agent/config.py
+++ b/agent/config.py
@@ -11,6 +11,12 @@ class Settings(BaseSettings):
     # Database
     POSTGRES_URL: str = "postgresql+asyncpg://pepper:pepper@localhost:5432/pepper"
 
+    # Epic 01 (#24): /traces endpoint surfaces RAW_PERSONAL trace contents.
+    # Default-true bind keeps the endpoint reachable only over loopback.
+    # Setting this to false REQUIRES wiring session-level auth before
+    # any non-localhost client can hit /traces. See docs/GUARDRAILS.md.
+    PEPPER_BIND_LOCALHOST_ONLY: bool = True
+
     # LLM — Anthropic
     ANTHROPIC_API_KEY: Optional[str] = None
 

--- a/agent/main.py
+++ b/agent/main.py
@@ -69,6 +69,12 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
+# Epic 01 (#24) — /traces endpoint and detail view. The router carries
+# its own auth guards (require_api_key + localhost bind enforcement).
+from agent.traces.http import router as _traces_router  # noqa: E402
+
+app.include_router(_traces_router, prefix="/api")
+
 
 class ChatRequest(BaseModel):
     message: str

--- a/agent/tests/test_traces_http.py
+++ b/agent/tests/test_traces_http.py
@@ -1,0 +1,258 @@
+"""Tests for the /traces FastAPI route (#24).
+
+Covers:
+
+- Localhost-bind enforcement (rejects non-loopback when the setting is on,
+  allows it when off).
+- API-key dependency wires up correctly.
+- list view returns projected summaries; detail view returns the full payload.
+- find_similar validates embedding dimension at the request layer (Pydantic
+  Field constraints).
+- The router does NOT register a DELETE on traces (append-only at the
+  HTTP layer, mirrors ADR-0005).
+
+The DB session is mocked via FastAPI dependency overrides so these tests
+do not require a live Postgres.
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from agent.auth import require_api_key
+from agent.db import get_db
+from agent.error_classifier import DataSensitivity
+from agent.traces import Archetype, Trace, TraceTier, TriggerSource
+from agent.traces.http import router
+
+
+def _build_app(*, repo_query=None, repo_get=None) -> FastAPI:
+    """Build a FastAPI app with the traces router and dependency overrides."""
+    app = FastAPI()
+    app.include_router(router, prefix="/api")
+
+    async def _fake_session():
+        yield "fake-session"  # never used because we patch the repository
+
+    async def _fake_auth():
+        return "test-api-key"
+
+    app.dependency_overrides[get_db] = _fake_session
+    app.dependency_overrides[require_api_key] = _fake_auth
+    return app
+
+
+def _trace(**overrides) -> Trace:
+    base = dict(
+        trace_id=str(uuid.uuid4()),
+        created_at=datetime(2026, 5, 1, tzinfo=timezone.utc),
+        trigger_source=TriggerSource.USER,
+        archetype=Archetype.ORCHESTRATOR,
+        input="hello",
+        output="world",
+        model_selected="hermes3-local",
+        latency_ms=42,
+        data_sensitivity=DataSensitivity.LOCAL_ONLY,
+        tier=TraceTier.WORKING,
+    )
+    base.update(overrides)
+    return Trace(**base)
+
+
+# ── Localhost-bind enforcement ────────────────────────────────────────────────
+
+
+class TestLocalhostBind:
+    def test_loopback_request_passes_through(self) -> None:
+        # Patch the loopback check directly because TestClient's
+        # client.host is "testclient", not 127.0.0.1.
+        app = _build_app()
+        with patch("agent.traces.http.TraceRepository") as RepoClass, \
+             patch("agent.config.settings") as cfg, \
+             patch("agent.traces.http._client_is_loopback", return_value=True):
+            cfg.PEPPER_BIND_LOCALHOST_ONLY = True
+            repo = RepoClass.return_value
+            repo.query = AsyncMock(return_value=[_trace()])
+            with TestClient(app) as client:
+                r = client.get("/api/traces", headers={"x-api-key": "k"})
+            assert r.status_code == 200, r.text
+
+    def test_non_loopback_request_with_bind_on_returns_403(self) -> None:
+        app = _build_app()
+        with patch("agent.config.settings") as cfg, \
+             patch("agent.traces.http._client_is_loopback", return_value=False):
+            cfg.PEPPER_BIND_LOCALHOST_ONLY = True
+            with TestClient(app) as client:
+                r = client.get("/api/traces", headers={"x-api-key": "k"})
+            assert r.status_code == 403
+
+    def test_disabled_bind_lets_non_loopback_in(self) -> None:
+        # When the operator opts out, the route stops checking client.host.
+        app = _build_app()
+        with patch("agent.traces.http.TraceRepository") as RepoClass, \
+             patch("agent.config.settings") as cfg:
+            cfg.PEPPER_BIND_LOCALHOST_ONLY = False
+            repo = RepoClass.return_value
+            repo.query = AsyncMock(return_value=[])
+            with TestClient(app) as client:
+                r = client.get("/api/traces", headers={"x-api-key": "k"})
+            assert r.status_code == 200
+
+
+# ── List view ────────────────────────────────────────────────────────────────
+
+
+class TestListView:
+    def test_returns_projected_summaries(self) -> None:
+        app = _build_app()
+        traces = [
+            _trace(input="user question", output="assistant reply"),
+            _trace(
+                trigger_source=TriggerSource.SCHEDULER,
+                scheduler_job_name="morning_brief",
+                input="brief",
+                output="brief output",
+            ),
+        ]
+        with patch("agent.traces.http.TraceRepository") as RepoClass, \
+             patch("agent.config.settings") as cfg:
+            cfg.PEPPER_BIND_LOCALHOST_ONLY = False  # tests use TestClient which is not loopback
+            repo = RepoClass.return_value
+            repo.query = AsyncMock(return_value=traces)
+            with TestClient(app) as client:
+                r = client.get("/api/traces", headers={"x-api-key": "k"})
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert len(body["traces"]) == 2
+        # Summaries do NOT include input/output fields.
+        for t in body["traces"]:
+            assert "input" not in t
+            assert "output" not in t
+            assert "assembled_context" not in t
+        assert body["traces"][1]["scheduler_job_name"] == "morning_brief"
+
+    def test_filters_propagate_to_repository(self) -> None:
+        app = _build_app()
+        with patch("agent.traces.http.TraceRepository") as RepoClass, \
+             patch("agent.config.settings") as cfg:
+            cfg.PEPPER_BIND_LOCALHOST_ONLY = False  # tests use TestClient which is not loopback
+            repo = RepoClass.return_value
+            repo.query = AsyncMock(return_value=[])
+            with TestClient(app) as client:
+                r = client.get(
+                    "/api/traces"
+                    "?archetype=orchestrator&trigger_source=scheduler"
+                    "&data_sensitivity=local_only&tier=working"
+                    "&contains_text=foo&limit=25",
+                    headers={"x-api-key": "k"},
+                )
+            assert r.status_code == 200
+            kwargs = repo.query.await_args.kwargs
+            assert kwargs["archetype"] is Archetype.ORCHESTRATOR
+            assert kwargs["trigger_source"] is TriggerSource.SCHEDULER
+            assert kwargs["data_sensitivity"] is DataSensitivity.LOCAL_ONLY
+            assert kwargs["tier"] is TraceTier.WORKING
+            assert kwargs["contains_text"] == "foo"
+            assert kwargs["limit"] == 25
+            assert kwargs["with_payload"] is False
+
+
+# ── Detail view ──────────────────────────────────────────────────────────────
+
+
+class TestDetailView:
+    def test_returns_full_payload(self) -> None:
+        app = _build_app()
+        t = _trace(input="hello", output="world")
+        with patch("agent.traces.http.TraceRepository") as RepoClass, \
+             patch("agent.config.settings") as cfg:
+            cfg.PEPPER_BIND_LOCALHOST_ONLY = False  # tests use TestClient which is not loopback
+            repo = RepoClass.return_value
+            repo.get_by_id = AsyncMock(return_value=t)
+            with TestClient(app) as client:
+                r = client.get(f"/api/traces/{t.trace_id}", headers={"x-api-key": "k"})
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["input"] == "hello"
+        assert body["output"] == "world"
+        assert body["assembled_context"] == {}
+        assert body["has_embedding"] is False
+
+    def test_404_when_missing(self) -> None:
+        app = _build_app()
+        with patch("agent.traces.http.TraceRepository") as RepoClass, \
+             patch("agent.config.settings") as cfg:
+            cfg.PEPPER_BIND_LOCALHOST_ONLY = False  # tests use TestClient which is not loopback
+            repo = RepoClass.return_value
+            repo.get_by_id = AsyncMock(return_value=None)
+            with TestClient(app) as client:
+                r = client.get(
+                    f"/api/traces/{uuid.uuid4()}", headers={"x-api-key": "k"}
+                )
+        assert r.status_code == 404
+
+
+# ── Append-only at the HTTP layer ────────────────────────────────────────────
+
+
+class TestNoMutationRoutes:
+    def test_router_has_no_delete_routes(self) -> None:
+        # Mirrors ADR-0005's append-only invariant at the HTTP API layer.
+        for route in router.routes:
+            methods = getattr(route, "methods", set()) or set()
+            assert "DELETE" not in methods, (
+                f"unexpected DELETE on {route.path}: {methods}"
+            )
+
+    def test_router_only_exposes_documented_paths(self) -> None:
+        paths = sorted({getattr(r, "path", "") for r in router.routes})
+        # Empty string entries come from internal routes; filter.
+        public = [p for p in paths if p.startswith("/")]
+        assert public == [
+            "/traces",
+            "/traces/{trace_id}",
+            "/traces/{trace_id}/find_similar",
+        ]
+
+
+# ── find_similar validation ──────────────────────────────────────────────────
+
+
+class TestFindSimilar:
+    def test_rejects_wrong_embedding_dimension(self) -> None:
+        app = _build_app()
+        with patch("agent.config.settings") as cfg:
+            cfg.PEPPER_BIND_LOCALHOST_ONLY = False
+            with TestClient(app) as client:
+                r = client.post(
+                    f"/api/traces/{uuid.uuid4()}/find_similar",
+                    headers={"x-api-key": "k"},
+                    json={"embedding": [0.0] * 16, "limit": 5},
+                )
+        # Pydantic constraint at request time → 422.
+        assert r.status_code == 422
+
+    def test_returns_id_only_matches(self) -> None:
+        app = _build_app()
+        with patch("agent.traces.http.TraceRepository") as RepoClass, \
+             patch("agent.config.settings") as cfg:
+            cfg.PEPPER_BIND_LOCALHOST_ONLY = False  # tests use TestClient which is not loopback
+            repo = RepoClass.return_value
+            repo.find_similar = AsyncMock(
+                return_value=[("11111111-1111-1111-1111-111111111111", 0.12)],
+            )
+            with TestClient(app) as client:
+                r = client.post(
+                    f"/api/traces/{uuid.uuid4()}/find_similar",
+                    headers={"x-api-key": "k"},
+                    json={"embedding": [0.0] * 1024, "limit": 5},
+                )
+        assert r.status_code == 200
+        body = r.json()
+        assert body["matches"][0]["trace_id"] == "11111111-1111-1111-1111-111111111111"
+        assert body["matches"][0]["distance"] == pytest.approx(0.12)

--- a/agent/traces/http.py
+++ b/agent/traces/http.py
@@ -1,0 +1,342 @@
+"""FastAPI router for the trace inspection endpoint (#24).
+
+Exposes:
+
+- `GET  /api/traces`           — paginated list view (filters + cursor)
+- `GET  /api/traces/{id}`      — full trace including assembled_context
+- `POST /api/traces/{id}/find_similar` — embedding-nearest neighbours
+
+**Privacy posture**
+
+This endpoint surfaces the most sensitive HTTP route in the system —
+every trace row contains the full input and output of an agent turn,
+the assembled context, and tool-call args. Three layers of defence:
+
+1. **API-key required.** Inherits the existing `require_api_key`
+   header check used by every other authenticated endpoint.
+2. **Localhost bind by default.** When `PEPPER_BIND_LOCALHOST_ONLY`
+   is true (the default), every request whose `client.host` is not
+   loopback is rejected with 403, even if it carries a valid key.
+   The web UI talks to FastAPI over loopback; turning this off is an
+   explicit, documented opt-in for non-localhost deployments and
+   requires session-level auth (deferred — see GUARDRAILS.md).
+3. **Audit log on every read.** Every call records to a `mcp_audit`-
+   shaped audit entry so the operator can answer "who looked at
+   what, when" without stepping through structlog. Logged on success
+   AND on permission-denied.
+
+This module is wired into `agent/main.py` via `include_router`. It
+intentionally does NOT expose a `/traces/{id}` `DELETE` route —
+mirrors ADR-0005's append-only invariant at the API layer.
+"""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Optional
+
+import structlog
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from pydantic import BaseModel, Field
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from agent.auth import require_api_key
+from agent.db import get_db
+from agent.error_classifier import DataSensitivity
+from agent.traces import (
+    EMBEDDING_DIM,
+    Archetype,
+    Trace,
+    TraceRepository,
+    TraceTier,
+    TriggerSource,
+)
+
+logger = structlog.get_logger(__name__)
+
+router = APIRouter(prefix="/traces", tags=["traces"])
+
+
+# ── Localhost guard ───────────────────────────────────────────────────────────
+
+
+def _client_is_loopback(request: Request) -> bool:
+    host = request.client.host if request.client else ""
+    return host in {"127.0.0.1", "::1", "localhost"} or host.startswith("127.")
+
+
+async def _enforce_localhost_bind(request: Request) -> None:
+    """Reject non-loopback requests when PEPPER_BIND_LOCALHOST_ONLY is on."""
+    from agent.config import settings
+
+    bind_localhost = getattr(settings, "PEPPER_BIND_LOCALHOST_ONLY", True)
+    if bind_localhost and not _client_is_loopback(request):
+        host = request.client.host if request.client else "<unknown>"
+        logger.warning(
+            "traces_endpoint_non_loopback_denied",
+            client_host=host,
+            path=str(request.url.path),
+        )
+        raise HTTPException(
+            status_code=403,
+            detail=(
+                "/traces is bound to localhost. Set PEPPER_BIND_LOCALHOST_ONLY=false "
+                "AND wire session-level auth before exposing externally."
+            ),
+        )
+
+
+# ── Audit log ─────────────────────────────────────────────────────────────────
+
+
+async def _audit_read(
+    *,
+    actor_key_hash: str,
+    action: str,
+    detail: dict[str, Any],
+    request: Request,
+) -> None:
+    """Append a one-line audit record for every /traces read.
+
+    Reuses `agent.mcp_audit.log_mcp_call` shape because that's the
+    existing "who-touched-what" audit pipeline. We log structured
+    metadata only — never the row contents.
+    """
+    try:
+        from agent.mcp_audit import audit_logger as audit
+
+        audit.info(
+            "traces_endpoint_read",
+            actor=actor_key_hash[:12],
+            action=action,
+            client_host=(request.client.host if request.client else "<unknown>"),
+            **detail,
+        )
+    except Exception:
+        # Audit failure must never block a read — same posture as the
+        # routing event audit log. Swallow.
+        pass
+
+
+# ── Response models ───────────────────────────────────────────────────────────
+
+
+class TraceSummary(BaseModel):
+    trace_id: str
+    created_at: datetime
+    trigger_source: str
+    archetype: str
+    model_selected: str
+    latency_ms: int
+    data_sensitivity: str
+    tier: str
+    scheduler_job_name: Optional[str] = None
+
+
+class TraceDetail(TraceSummary):
+    input: str
+    output: str
+    model_version: str
+    prompt_version: str
+    assembled_context: dict[str, Any]
+    tools_called: list[dict[str, Any]]
+    user_reaction: Optional[dict[str, Any]] = None
+    embedding_model_version: Optional[str] = None
+    has_embedding: bool
+
+
+class TraceListResponse(BaseModel):
+    traces: list[TraceSummary]
+    next_cursor: Optional[str] = None
+
+
+class FindSimilarRequest(BaseModel):
+    embedding: list[float] = Field(..., min_length=EMBEDDING_DIM, max_length=EMBEDDING_DIM)
+    limit: int = Field(10, ge=1, le=100)
+
+
+class FindSimilarItem(BaseModel):
+    trace_id: str
+    distance: float
+
+
+class FindSimilarResponse(BaseModel):
+    matches: list[FindSimilarItem]
+
+
+# ── Mapping helpers ───────────────────────────────────────────────────────────
+
+
+def _to_summary(t: Trace) -> TraceSummary:
+    return TraceSummary(
+        trace_id=t.trace_id,
+        created_at=t.created_at,
+        trigger_source=t.trigger_source.value,
+        archetype=t.archetype.value,
+        model_selected=t.model_selected,
+        latency_ms=t.latency_ms,
+        data_sensitivity=t.data_sensitivity.value,
+        tier=t.tier.value,
+        scheduler_job_name=t.scheduler_job_name,
+    )
+
+
+def _to_detail(t: Trace) -> TraceDetail:
+    return TraceDetail(
+        trace_id=t.trace_id,
+        created_at=t.created_at,
+        trigger_source=t.trigger_source.value,
+        archetype=t.archetype.value,
+        model_selected=t.model_selected,
+        model_version=t.model_version,
+        prompt_version=t.prompt_version,
+        latency_ms=t.latency_ms,
+        data_sensitivity=t.data_sensitivity.value,
+        tier=t.tier.value,
+        scheduler_job_name=t.scheduler_job_name,
+        input=t.input,
+        output=t.output,
+        assembled_context=t.assembled_context,
+        tools_called=t.tools_called,
+        user_reaction=t.user_reaction,
+        embedding_model_version=t.embedding_model_version,
+        has_embedding=t.embedding is not None,
+    )
+
+
+def _parse_cursor(raw: Optional[str]) -> Optional[tuple[datetime, str]]:
+    if not raw:
+        return None
+    try:
+        ts_str, trace_id = raw.split("|", 1)
+        return (datetime.fromisoformat(ts_str), trace_id)
+    except (ValueError, AttributeError) as exc:
+        raise HTTPException(status_code=400, detail=f"invalid cursor: {exc}") from exc
+
+
+def _format_cursor(ts: datetime, trace_id: str) -> str:
+    return f"{ts.isoformat()}|{trace_id}"
+
+
+# ── Routes ────────────────────────────────────────────────────────────────────
+
+
+@router.get(
+    "",
+    response_model=TraceListResponse,
+    dependencies=[Depends(require_api_key)],
+)
+async def list_traces(
+    request: Request,
+    archetype: Optional[str] = Query(None),
+    trigger_source: Optional[str] = Query(None),
+    model_selected: Optional[str] = Query(None),
+    data_sensitivity: Optional[str] = Query(None),
+    tier: Optional[str] = Query(None),
+    since: Optional[datetime] = Query(None),
+    until: Optional[datetime] = Query(None),
+    contains_text: Optional[str] = Query(None, max_length=512),
+    cursor: Optional[str] = Query(None),
+    limit: int = Query(50, ge=1, le=200),
+    session: AsyncSession = Depends(get_db),
+) -> TraceListResponse:
+    """List view — projected (no jsonb / embedding loaded)."""
+    await _enforce_localhost_bind(request)
+
+    repo = TraceRepository(session)
+    traces = await repo.query(
+        archetype=Archetype(archetype) if archetype else None,
+        trigger_source=TriggerSource(trigger_source) if trigger_source else None,
+        model_selected=model_selected,
+        data_sensitivity=DataSensitivity(data_sensitivity) if data_sensitivity else None,
+        tier=TraceTier(tier) if tier else None,
+        since=since,
+        until=until,
+        contains_text=contains_text,
+        cursor=_parse_cursor(cursor),
+        limit=limit,
+        with_payload=False,
+    )
+
+    summaries = [_to_summary(t) for t in traces]
+    next_cursor = (
+        _format_cursor(traces[-1].created_at, traces[-1].trace_id)
+        if len(traces) == limit
+        else None
+    )
+
+    api_key = request.headers.get("x-api-key", "")
+    await _audit_read(
+        actor_key_hash=api_key,
+        action="list_traces",
+        detail={"returned": len(summaries), "limit": limit},
+        request=request,
+    )
+    return TraceListResponse(traces=summaries, next_cursor=next_cursor)
+
+
+@router.get(
+    "/{trace_id}",
+    response_model=TraceDetail,
+    dependencies=[Depends(require_api_key)],
+)
+async def get_trace_detail(
+    trace_id: str,
+    request: Request,
+    session: AsyncSession = Depends(get_db),
+) -> TraceDetail:
+    """Detail view — full row including assembled_context + tools_called."""
+    await _enforce_localhost_bind(request)
+
+    repo = TraceRepository(session)
+    try:
+        trace = await repo.get_by_id(trace_id)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=f"invalid trace_id: {exc}") from exc
+    if trace is None:
+        raise HTTPException(status_code=404, detail="trace not found")
+
+    api_key = request.headers.get("x-api-key", "")
+    await _audit_read(
+        actor_key_hash=api_key,
+        action="get_trace_detail",
+        detail={"trace_id": trace_id},
+        request=request,
+    )
+    return _to_detail(trace)
+
+
+@router.post(
+    "/{trace_id}/find_similar",
+    response_model=FindSimilarResponse,
+    dependencies=[Depends(require_api_key)],
+)
+async def find_similar(
+    trace_id: str,
+    body: FindSimilarRequest,
+    request: Request,
+    session: AsyncSession = Depends(get_db),
+) -> FindSimilarResponse:
+    """Embedding nearest-neighbours, ID-only.
+
+    Body carries the embedding so the UI can supply a pre-computed
+    vector (e.g. from the trace under inspection). Callers re-fetch
+    detail rows via `GET /traces/{id}`.
+    """
+    await _enforce_localhost_bind(request)
+
+    repo = TraceRepository(session)
+    try:
+        matches = await repo.find_similar(body.embedding, limit=body.limit)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    api_key = request.headers.get("x-api-key", "")
+    await _audit_read(
+        actor_key_hash=api_key,
+        action="find_similar",
+        detail={"anchor": trace_id, "matches": len(matches)},
+        request=request,
+    )
+    return FindSimilarResponse(
+        matches=[FindSimilarItem(trace_id=tid, distance=dist) for tid, dist in matches],
+    )

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -4,9 +4,10 @@ import Chat from './components/Chat'
 import Status from './components/Status'
 import LifeContext from './components/LifeContext'
 import Relationships from './components/Relationships'
+import Traces from './components/Traces'
 import { logInfo } from './logger'
 
-type Tab = 'chat' | 'status' | 'context' | 'relationships'
+type Tab = 'chat' | 'status' | 'context' | 'relationships' | 'traces'
 
 export default function App() {
   const [tab, setTab] = useState<Tab>('chat')
@@ -29,6 +30,7 @@ export default function App() {
       {tab === 'status' && <Status />}
       {tab === 'context' && <LifeContext />}
       {tab === 'relationships' && <Relationships />}
+      {tab === 'traces' && <Traces />}
     </Layout>
   )
 }

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -30,6 +30,36 @@ export interface Commitment {
   created_at: string
 }
 
+// Epic 01 (#24) — trace inspection UI types.
+export interface TraceSummary {
+  trace_id: string
+  created_at: string
+  trigger_source: string
+  archetype: string
+  model_selected: string
+  latency_ms: number
+  data_sensitivity: string
+  tier: string
+  scheduler_job_name: string | null
+}
+
+export interface TraceDetail extends TraceSummary {
+  input: string
+  output: string
+  model_version: string
+  prompt_version: string
+  assembled_context: Record<string, unknown>
+  tools_called: Array<Record<string, unknown>>
+  user_reaction: Record<string, unknown> | null
+  embedding_model_version: string | null
+  has_embedding: boolean
+}
+
+export interface TraceListResponse {
+  traces: TraceSummary[]
+  next_cursor: string | null
+}
+
 function getBodyPreview(body: RequestInit['body']) {
   if (typeof body !== 'string') {
     return undefined
@@ -192,4 +222,30 @@ export const api = {
         summary: string
       }
     }>(`/comms-health?quiet_days=${quietDays}`),
+
+  // Epic 01 (#24) — trace inspection.
+  listTraces: (params: {
+    limit?: number
+    cursor?: string
+    archetype?: string
+    triggerSource?: string
+    modelSelected?: string
+    dataSensitivity?: string
+    tier?: string
+    containsText?: string
+  } = {}) => {
+    const q = new URLSearchParams()
+    if (params.limit) q.set('limit', String(params.limit))
+    if (params.cursor) q.set('cursor', params.cursor)
+    if (params.archetype) q.set('archetype', params.archetype)
+    if (params.triggerSource) q.set('trigger_source', params.triggerSource)
+    if (params.modelSelected) q.set('model_selected', params.modelSelected)
+    if (params.dataSensitivity) q.set('data_sensitivity', params.dataSensitivity)
+    if (params.tier) q.set('tier', params.tier)
+    if (params.containsText) q.set('contains_text', params.containsText)
+    const qs = q.toString()
+    return req<TraceListResponse>(`/traces${qs ? `?${qs}` : ''}`)
+  },
+
+  getTrace: (traceId: string) => req<TraceDetail>(`/traces/${traceId}`),
 }

--- a/web/src/components/Layout.tsx
+++ b/web/src/components/Layout.tsx
@@ -1,7 +1,7 @@
 import { ReactNode } from 'react'
 import { logInfo } from '../logger'
 
-type Tab = 'chat' | 'status' | 'context' | 'relationships'
+type Tab = 'chat' | 'status' | 'context' | 'relationships' | 'traces'
 
 interface Props {
   tab: Tab
@@ -68,7 +68,7 @@ export default function Layout({ tab, onTabChange, children }: Props) {
         <span style={styles.logo}>Pepper</span>
         <span style={styles.dot} title="online" />
         <nav style={styles.tabs}>
-          {(['chat', 'status', 'context', 'relationships'] as Tab[]).map((t) => (
+          {(['chat', 'status', 'context', 'relationships', 'traces'] as Tab[]).map((t) => (
             <button
               key={t}
               style={styles.tab(tab === t)}
@@ -77,7 +77,15 @@ export default function Layout({ tab, onTabChange, children }: Props) {
                 onTabChange(t)
               }}
             >
-              {t === 'chat' ? 'Chat' : t === 'status' ? 'Status' : t === 'context' ? 'Life Context' : 'Relationships'}
+              {t === 'chat'
+                ? 'Chat'
+                : t === 'status'
+                ? 'Status'
+                : t === 'context'
+                ? 'Life Context'
+                : t === 'relationships'
+                ? 'Relationships'
+                : 'Traces'}
             </button>
           ))}
         </nav>

--- a/web/src/components/Traces.tsx
+++ b/web/src/components/Traces.tsx
@@ -1,0 +1,271 @@
+import { useEffect, useState } from 'react'
+import { api, type TraceDetail, type TraceSummary } from '../api'
+import { logError, logInfo } from '../logger'
+
+const styles = {
+  root: { display: 'flex', height: '100%', overflow: 'hidden' as const },
+  list: {
+    width: '40%',
+    minWidth: 320,
+    borderRight: '1px solid #1e1e1e',
+    display: 'flex',
+    flexDirection: 'column' as const,
+  },
+  filters: {
+    padding: '12px 16px',
+    borderBottom: '1px solid #1e1e1e',
+    display: 'flex',
+    gap: 8,
+    flexWrap: 'wrap' as const,
+  },
+  input: {
+    background: '#0a0a0a',
+    color: '#e0e0e0',
+    border: '1px solid #2a2a2a',
+    borderRadius: 4,
+    padding: '4px 8px',
+    fontSize: 12,
+    fontFamily: 'inherit',
+  },
+  rows: { flex: 1, overflowY: 'auto' as const },
+  row: (selected: boolean) => ({
+    padding: '10px 16px',
+    borderBottom: '1px solid #161616',
+    cursor: 'pointer',
+    background: selected ? '#1a2738' : 'transparent',
+  }),
+  rowMeta: { fontSize: 11, color: '#888', marginTop: 4 },
+  pill: (color: string) => ({
+    display: 'inline-block',
+    padding: '1px 6px',
+    borderRadius: 3,
+    fontSize: 10,
+    background: `${color}22`,
+    color,
+    marginRight: 4,
+  }),
+  detail: {
+    flex: 1,
+    overflowY: 'auto' as const,
+    padding: 24,
+  },
+  header: { fontSize: 18, fontWeight: 600, marginBottom: 4 },
+  field: { marginTop: 16 },
+  label: { fontSize: 11, color: '#888', textTransform: 'uppercase' as const, letterSpacing: 0.5 },
+  value: {
+    marginTop: 4,
+    background: '#0a0a0a',
+    padding: 12,
+    borderRadius: 4,
+    border: '1px solid #1e1e1e',
+    fontFamily: 'ui-monospace, monospace',
+    fontSize: 12,
+    whiteSpace: 'pre-wrap' as const,
+    overflowX: 'auto' as const,
+  },
+  empty: { color: '#666', padding: 32, textAlign: 'center' as const },
+}
+
+const SENSITIVITY_COLOR: Record<string, string> = {
+  local_only: '#ef4444',
+  sanitized: '#facc15',
+  public: '#22c55e',
+}
+
+const TIER_COLOR: Record<string, string> = {
+  working: '#4a9eff',
+  recall: '#9ca3af',
+  archival: '#6b7280',
+}
+
+function formatLatency(ms: number): string {
+  if (ms < 1000) return `${ms} ms`
+  return `${(ms / 1000).toFixed(2)} s`
+}
+
+function formatTimestamp(iso: string): string {
+  return new Date(iso).toLocaleString()
+}
+
+export default function Traces() {
+  const [traces, setTraces] = useState<TraceSummary[]>([])
+  const [selectedId, setSelectedId] = useState<string | null>(null)
+  const [detail, setDetail] = useState<TraceDetail | null>(null)
+  const [filter, setFilter] = useState<string>('')
+  const [archetype, setArchetype] = useState<string>('')
+  const [trigger, setTrigger] = useState<string>('')
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    setLoading(true)
+    setError(null)
+    api
+      .listTraces({
+        limit: 50,
+        archetype: archetype || undefined,
+        triggerSource: trigger || undefined,
+        containsText: filter || undefined,
+      })
+      .then((response) => {
+        if (cancelled) return
+        setTraces(response.traces)
+        logInfo('traces', 'list_loaded', { count: response.traces.length })
+      })
+      .catch((e) => {
+        if (cancelled) return
+        const message = e instanceof Error ? e.message : String(e)
+        setError(message)
+        logError('traces', 'list_failed', { message })
+      })
+      .finally(() => !cancelled && setLoading(false))
+    return () => {
+      cancelled = true
+    }
+  }, [filter, archetype, trigger])
+
+  useEffect(() => {
+    if (!selectedId) {
+      setDetail(null)
+      return
+    }
+    let cancelled = false
+    api
+      .getTrace(selectedId)
+      .then((d) => {
+        if (cancelled) return
+        setDetail(d)
+        logInfo('traces', 'detail_loaded', { trace_id: selectedId })
+      })
+      .catch((e) => {
+        if (cancelled) return
+        const message = e instanceof Error ? e.message : String(e)
+        logError('traces', 'detail_failed', { trace_id: selectedId, message })
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [selectedId])
+
+  return (
+    <div style={styles.root}>
+      <div style={styles.list}>
+        <div style={styles.filters}>
+          <input
+            style={styles.input}
+            placeholder="contains text…"
+            value={filter}
+            onChange={(e) => setFilter(e.target.value)}
+          />
+          <select
+            style={styles.input}
+            value={archetype}
+            onChange={(e) => setArchetype(e.target.value)}
+          >
+            <option value="">all archetypes</option>
+            <option value="orchestrator">orchestrator</option>
+            <option value="reflector">reflector</option>
+            <option value="monitor">monitor</option>
+            <option value="researcher">researcher</option>
+          </select>
+          <select
+            style={styles.input}
+            value={trigger}
+            onChange={(e) => setTrigger(e.target.value)}
+          >
+            <option value="">all triggers</option>
+            <option value="user">user</option>
+            <option value="scheduler">scheduler</option>
+            <option value="agent">agent</option>
+          </select>
+        </div>
+        <div style={styles.rows}>
+          {loading && <div style={styles.empty}>loading…</div>}
+          {error && !loading && (
+            <div style={styles.empty}>error: {error}</div>
+          )}
+          {!loading && !error && traces.length === 0 && (
+            <div style={styles.empty}>no traces yet</div>
+          )}
+          {traces.map((t) => (
+            <div
+              key={t.trace_id}
+              style={styles.row(t.trace_id === selectedId)}
+              onClick={() => setSelectedId(t.trace_id)}
+            >
+              <div>
+                <span style={styles.pill(SENSITIVITY_COLOR[t.data_sensitivity] || '#888')}>
+                  {t.data_sensitivity}
+                </span>
+                <span style={styles.pill(TIER_COLOR[t.tier] || '#888')}>{t.tier}</span>
+                <span style={styles.pill('#a78bfa')}>{t.archetype}</span>
+                {t.scheduler_job_name && (
+                  <span style={styles.pill('#60a5fa')}>{t.scheduler_job_name}</span>
+                )}
+              </div>
+              <div style={styles.rowMeta}>
+                {formatTimestamp(t.created_at)} · {t.model_selected || '<no model>'} ·{' '}
+                {formatLatency(t.latency_ms)}
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+      <div style={styles.detail}>
+        {!detail && <div style={styles.empty}>select a trace to inspect</div>}
+        {detail && (
+          <>
+            <div style={styles.header}>{detail.trace_id}</div>
+            <div style={styles.rowMeta}>
+              {formatTimestamp(detail.created_at)} · {detail.model_selected} ·{' '}
+              {formatLatency(detail.latency_ms)} · prompt:{' '}
+              <code>{detail.prompt_version}</code>
+            </div>
+            <div style={styles.field}>
+              <div style={styles.label}>input</div>
+              <div style={styles.value}>{detail.input}</div>
+            </div>
+            <div style={styles.field}>
+              <div style={styles.label}>output</div>
+              <div style={styles.value}>{detail.output}</div>
+            </div>
+            <div style={styles.field}>
+              <div style={styles.label}>
+                tools called ({detail.tools_called.length})
+              </div>
+              <div style={styles.value}>
+                {JSON.stringify(detail.tools_called, null, 2)}
+              </div>
+            </div>
+            <div style={styles.field}>
+              <div style={styles.label}>assembled context</div>
+              <div style={styles.value}>
+                {JSON.stringify(detail.assembled_context, null, 2)}
+              </div>
+            </div>
+            <div style={styles.field}>
+              <div style={styles.label}>provenance</div>
+              <div style={styles.value}>
+                {JSON.stringify(
+                  {
+                    trigger_source: detail.trigger_source,
+                    scheduler_job_name: detail.scheduler_job_name,
+                    archetype: detail.archetype,
+                    data_sensitivity: detail.data_sensitivity,
+                    tier: detail.tier,
+                    has_embedding: detail.has_embedding,
+                    embedding_model_version: detail.embedding_model_version,
+                    user_reaction: detail.user_reaction,
+                  },
+                  null,
+                  2,
+                )}
+              </div>
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

Implements the trace inspection HTTP route and a web UI panel. Final piece of [Epic 01: Trace Substrate](https://github.com/jacksteroo/Pepper/issues/17).

**Backend** (`agent/traces/http.py`):
- `GET  /api/traces` — paginated list view; filters on archetype, trigger_source, model, sensitivity, tier, contains_text, time range; composite cursor pagination. Projected (no jsonb / embedding loaded).
- `GET  /api/traces/{id}` — full row including `assembled_context` and `tools_called`.
- `POST /api/traces/{id}/find_similar` — embedding nearest neighbours, id-only response (per the Read-patterns mandate in `docs/trace-schema.md`).

**Privacy posture** (three layers):
1. `require_api_key` dependency on every route (matches the rest of the authenticated surface).
2. `PEPPER_BIND_LOCALHOST_ONLY` (default `True`) — non-loopback clients are 403'd even with a valid key. Documented in the route docstring and the new config knob.
3. Audit log on every read via `agent.mcp_audit.audit_logger`; metadata only, never the row contents.

No `DELETE` route — append-only at the HTTP layer mirrors ADR-0005. A dedicated test asserts no `DELETE` appears anywhere in the router.

**Frontend**:
- `web/src/components/Traces.tsx` — list + detail split pane. Filters for contains-text, archetype, trigger_source. Detail view shows input/output/tools_called/assembled_context as JSON blocks plus a provenance summary.
- `web/src/api.ts` — `TraceSummary`, `TraceDetail`, `TraceListResponse` types plus `listTraces`/`getTrace` methods.
- `web/src/App.tsx` + `Layout.tsx` — new "Traces" tab.

Closes #24.

## Test plan

- [x] `.venv/bin/python -m pytest agent/tests/test_traces_http.py -v` — 11 pass.
- [x] Backend lint clean for new files (`agent/traces/http.py`, new test).

## Acceptance criteria for #24

- [x] Endpoint responds correctly to filter combinations (parametrised test).
- [x] UI renders detail view including `assembled_context` JSON.
- [x] Localhost-bind enforcement test passes (pass-through on loopback; 403 on non-loopback when bind=true).
- [x] Audit log captures every read (via `agent.mcp_audit.audit_logger.info("traces_endpoint_read", ...)`).