### PR TITLE
retrieval-eval: scaffolding + baseline harness (#30 part A)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,11 @@ backups/router/phase_*_pre_cutover_*/
 backups/router/*.csv
 backups/router/*.jsonl
 backups/router/*.sql
+
+# Epic 02 (#30) — real retrieval eval set is RAW_PERSONAL (queries against
+# the user's actual memory). The committed `.example.jsonl` is the template;
+# the populated `retrieval_eval_set.jsonl` stays local.
+agent/tests/retrieval_eval_set.jsonl
+# Local-only baseline JSON; aggregate markdown reports may be committed
+# (they don't contain queries).
+eval_results/baseline.json

--- a/agent/db.py
+++ b/agent/db.py
@@ -175,6 +175,18 @@ def get_engine():
     return _engine
 
 
+def get_session_factory() -> async_sessionmaker[AsyncSession]:
+    """Return the initialised async session factory.
+
+    Use this from scripts that need to construct a `MemoryManager` (or any
+    other component that takes a `db_session_factory`) after `init_db()`
+    has run. Raises RuntimeError if init_db() has not been called yet.
+    """
+    if _session_factory is None:
+        raise RuntimeError("Database not initialised — call init_db() first")
+    return _session_factory
+
+
 async def get_db() -> AsyncGenerator[AsyncSession, None]:
     """Async generator providing a DB session — use as a FastAPI dependency."""
     if _session_factory is None:

--- a/agent/tests/_retrieval_eval_fixtures.py
+++ b/agent/tests/_retrieval_eval_fixtures.py
@@ -1,0 +1,133 @@
+"""Synthetic fixture corpus + retriever for the retrieval eval unit test.
+
+Deliberately non-personal — covers the five eval categories with fake but
+plausible memory items so CI can exercise the runner without a populated
+DB or the gitignored real eval set.
+"""
+from __future__ import annotations
+
+import math
+import re
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from typing import Iterable
+
+from agent.tests.retrieval_eval import EvalQuery
+
+
+@dataclass(frozen=True)
+class FixtureMemory:
+    id: int
+    content: str
+    age_days: int  # how old the memory is, for temporal queries
+
+    @property
+    def created_at(self) -> datetime:
+        return datetime.utcnow() - timedelta(days=self.age_days)
+
+
+# Fixture memory corpus. Spans the five eval categories.
+FIXTURE_CORPUS: tuple[FixtureMemory, ...] = (
+    # factual recall
+    FixtureMemory(1, "The router uses qwen3-embedding:0.6b for 1024-dim vectors.", 120),
+    FixtureMemory(2, "Memory subsystem embeddings come from nomic-embed-text at 768-dim.", 100),
+    FixtureMemory(3, "Postgres pgvector HNSW indexes use m=16 ef_construction=64.", 90),
+    # person-context
+    FixtureMemory(4, "Matthew started a new role at the design studio in March.", 5),
+    FixtureMemory(5, "Matthew shipped the onboarding redesign last week.", 2),
+    FixtureMemory(6, "Matthew was on parental leave through January.", 95),
+    # temporal — recent items the recency boost should surface
+    FixtureMemory(7, "Yesterday's standup flagged a regression in the ingest pipeline.", 1),
+    FixtureMemory(8, "This week's roadmap review moved Epic 02 ahead of Epic 03.", 3),
+    # open-loop / behind-on
+    FixtureMemory(9, "TODO: write up the post-incident review for the auth outage.", 14),
+    FixtureMemory(10, "Promised to send Sarah the architecture deck by end of month.", 10),
+    # hybrid keyword + semantic — distinctive phrase + topical content
+    FixtureMemory(11, "The doc 'routing-from-april.md' covers the regex-to-semantic migration plan.", 25),
+    FixtureMemory(12, "April's routing notes describe the fallback policy for OOD queries.", 28),
+)
+
+
+_CORPUS_BY_ID = {m.id: m for m in FIXTURE_CORPUS}
+
+
+def _tokenize(s: str) -> list[str]:
+    return [t for t in re.split(r"[^a-z0-9]+", s.lower()) if t]
+
+
+def _jaccard(a: Iterable[str], b: Iterable[str]) -> float:
+    sa, sb = set(a), set(b)
+    if not sa or not sb:
+        return 0.0
+    return len(sa & sb) / len(sa | sb)
+
+
+def make_fixture_retriever(use_recency: bool = False, recency_tau_days: float = 30.0):
+    """Token-overlap retriever over the fixture corpus.
+
+    Stand-in for "current pgvector-only" retrieval. Optionally applies a
+    recency boost — used by the unit test to verify the runner picks up the
+    same metric movement we expect from #29. Honors a per-query
+    `time_window_days` override via `EvalQuery.time_window_days`.
+    """
+
+    async def retrieve(eval_query, k: int) -> list[int]:
+        q_tokens = _tokenize(eval_query.query)
+        tau = eval_query.time_window_days or recency_tau_days
+        scored: list[tuple[float, int]] = []
+        for mem in FIXTURE_CORPUS:
+            sem = _jaccard(q_tokens, _tokenize(mem.content))
+            if use_recency:
+                rec = math.exp(-mem.age_days / tau)
+                score = 0.7 * sem + 0.3 * rec
+            else:
+                score = sem
+            scored.append((score, mem.id))
+        scored.sort(key=lambda x: (-x[0], x[1]))
+        return [mid for _, mid in scored[:k]]
+
+    return retrieve
+
+
+# A fixture eval set. Stable IDs reference FIXTURE_CORPUS above. Real eval
+# sets live at agent/tests/retrieval_eval_set.jsonl (gitignored).
+FIXTURE_EVAL_SET: tuple[EvalQuery, ...] = (
+    EvalQuery(
+        query="what embedding model does the router use",
+        expected_ids=(1,),
+        category="factual",
+        notes="exact factual lookup",
+    ),
+    EvalQuery(
+        query="dimensions of memory subsystem embeddings",
+        expected_ids=(2,),
+        category="factual",
+    ),
+    EvalQuery(
+        query="what's been going on with Matthew lately",
+        expected_ids=(4, 5),
+        category="person",
+        notes="recency should surface 4 and 5 above 6",
+    ),
+    EvalQuery(
+        query="recent updates from the team",
+        expected_ids=(7, 8),
+        category="temporal",
+        notes="last few days only",
+    ),
+    EvalQuery(
+        query="what am I behind on",
+        expected_ids=(9, 10),
+        category="open_loop",
+    ),
+    EvalQuery(
+        query="the doc about routing from april",
+        expected_ids=(11, 12),
+        category="hybrid",
+        notes="distinctive keyword 'routing-from-april' + topical match",
+    ),
+)
+
+
+def get_fixture_corpus_by_id(memory_id: int) -> FixtureMemory:
+    return _CORPUS_BY_ID[memory_id]

--- a/agent/tests/retrieval_eval.py
+++ b/agent/tests/retrieval_eval.py
@@ -1,0 +1,255 @@
+"""Retrieval evaluation runner — Epic 02, issue #30.
+
+Loads a query set, runs each query against a pluggable retriever, and computes
+Recall@K, MRR, and per-category breakdowns. Used in two contexts:
+
+* Unit test (`test_retrieval_eval.py`) against a synthetic fixture corpus,
+  so CI can verify the runner without a real DB or RAW_PERSONAL eval set.
+* Local script (`scripts/run_retrieval_eval.py`) against the live memory DB
+  and the gitignored real eval set, producing the markdown reports under
+  `eval_results/` that gate the epic.
+
+The retriever interface is intentionally minimal — a coroutine that takes a
+query string and a `k`, returns a list of memory IDs ordered best-first. Both
+the production `MemoryManager` and the test fixture conform to it.
+"""
+from __future__ import annotations
+
+import json
+from collections import defaultdict
+from dataclasses import dataclass, field
+from pathlib import Path
+from statistics import mean
+from typing import Awaitable, Callable, Iterable
+
+# A retriever is any async callable: (eval_query, k) -> list[memory_id]
+# Takes the full EvalQuery (not just the query string) so per-query knobs
+# like #29's time_window override flow through without a signature change.
+Retriever = Callable[["EvalQuery", int], Awaitable[list[int]]]
+
+CATEGORIES = ("factual", "person", "temporal", "open_loop", "hybrid")
+DEFAULT_K_VALUES: tuple[int, ...] = (1, 3, 5, 10)
+DEFAULT_GATE_THRESHOLD_PP = 10.0  # epic gate per issue #30
+
+
+@dataclass(frozen=True)
+class EvalQuery:
+    query: str
+    expected_ids: tuple[int, ...]
+    category: str
+    notes: str = ""
+    # Optional per-query retrieval knobs. Subissues #27/#28/#29 read these
+    # via the EvalQuery argument to the Retriever protocol; unused fields
+    # default to None so existing entries stay valid.
+    time_window_days: int | None = None  # #29 — recency τ override
+    bm25_weight: float | None = None  # #28 — fusion override (advisory)
+
+    @classmethod
+    def from_dict(cls, raw: dict) -> "EvalQuery":
+        cat = raw.get("category", "factual")
+        if cat not in CATEGORIES:
+            raise ValueError(
+                f"unknown category {cat!r}; expected one of {CATEGORIES}"
+            )
+        if "expected_ids" not in raw:
+            raise ValueError("missing required field: expected_ids")
+        ids_raw = raw["expected_ids"]
+        if not isinstance(ids_raw, list):
+            raise ValueError("expected_ids must be a list")
+        expected_list: list[int] = []
+        for x in ids_raw:
+            # bool is a subclass of int — exclude it explicitly so True/False
+            # don't silently coerce to 1/0.
+            if isinstance(x, bool) or not isinstance(x, int):
+                raise ValueError(
+                    f"expected_ids must contain ints, got {type(x).__name__}"
+                )
+            expected_list.append(x)
+        if not expected_list:
+            raise ValueError(f"query {raw.get('query')!r} has empty expected_ids")
+        tw = raw.get("time_window_days")
+        if tw is not None and (isinstance(tw, bool) or not isinstance(tw, int) or tw <= 0):
+            raise ValueError("time_window_days must be a positive int")
+        bw = raw.get("bm25_weight")
+        if bw is not None and (
+            isinstance(bw, bool) or not isinstance(bw, (int, float)) or not 0.0 <= bw <= 1.0
+        ):
+            raise ValueError("bm25_weight must be a float in [0.0, 1.0]")
+        return cls(
+            query=str(raw["query"]),
+            expected_ids=tuple(expected_list),
+            category=cat,
+            notes=str(raw.get("notes", "")),
+            time_window_days=tw,
+            bm25_weight=float(bw) if bw is not None else None,
+        )
+
+
+@dataclass
+class EvalReport:
+    """Aggregate metrics. Per-query detail is intentionally omitted from this
+    object — callers that need it should keep their own list. Only aggregates
+    cross the privacy boundary into `eval_results/*.md`."""
+
+    total_queries: int
+    recall_at_k: dict[int, float]
+    mrr: float
+    per_category: dict[str, dict[str, float]] = field(default_factory=dict)
+
+    def avg_recall_at_5(self) -> float:
+        return self.recall_at_k.get(5, 0.0)
+
+    def to_dict(self) -> dict:
+        return {
+            "total_queries": self.total_queries,
+            "recall_at_k": {str(k): v for k, v in self.recall_at_k.items()},
+            "mrr": self.mrr,
+            "per_category": self.per_category,
+        }
+
+
+def load_eval_set(path: str | Path) -> list[EvalQuery]:
+    """Load a JSONL eval set. Each line: query, expected_ids, category, notes."""
+    p = Path(path)
+    if not p.exists():
+        raise FileNotFoundError(f"eval set not found: {p}")
+    out: list[EvalQuery] = []
+    with p.open("r", encoding="utf-8") as f:
+        for lineno, raw in enumerate(f, start=1):
+            line = raw.strip()
+            if not line or line.startswith("#"):
+                continue
+            try:
+                out.append(EvalQuery.from_dict(json.loads(line)))
+            except (ValueError, json.JSONDecodeError) as e:
+                raise ValueError(f"{p}:{lineno}: {e}") from e
+    return out
+
+
+def _recall_at_k(predicted: list[int], expected: Iterable[int], k: int) -> float:
+    expected_set = set(expected)
+    if not expected_set:
+        return 0.0
+    top_k = predicted[:k]
+    hits = sum(1 for pid in top_k if pid in expected_set)
+    return hits / len(expected_set)
+
+
+def _reciprocal_rank(predicted: list[int], expected: Iterable[int]) -> float:
+    expected_set = set(expected)
+    for rank, pid in enumerate(predicted, start=1):
+        if pid in expected_set:
+            return 1.0 / rank
+    return 0.0
+
+
+async def run_eval(
+    eval_set: list[EvalQuery],
+    retriever: Retriever,
+    k_values: tuple[int, ...] = DEFAULT_K_VALUES,
+) -> EvalReport:
+    """Run every query through the retriever and aggregate metrics.
+
+    Queries fan out concurrently — embedding latency dominates per-query
+    cost (~150ms each via Ollama), so a 30-query set drops from ~5s
+    sequential to roughly the slowest single query in parallel.
+    """
+    if not eval_set:
+        raise ValueError("eval_set is empty")
+    max_k = max(k_values)
+
+    import asyncio  # local import to keep module import side-effect free
+
+    predicted_lists = await asyncio.gather(
+        *(retriever(q, max_k) for q in eval_set)
+    )
+
+    recall_sums: dict[int, float] = {k: 0.0 for k in k_values}
+    rr_sum = 0.0
+    cat_recalls: dict[str, dict[int, list[float]]] = defaultdict(
+        lambda: {k: [] for k in k_values}
+    )
+    cat_rr: dict[str, list[float]] = defaultdict(list)
+
+    for q, predicted in zip(eval_set, predicted_lists):
+        rr = _reciprocal_rank(predicted, q.expected_ids)
+        rr_sum += rr
+        cat_rr[q.category].append(rr)
+        for k in k_values:
+            r = _recall_at_k(predicted, q.expected_ids, k)
+            recall_sums[k] += r
+            cat_recalls[q.category][k].append(r)
+
+    n = len(eval_set)
+    per_category: dict[str, dict[str, float]] = {}
+    for cat, by_k in cat_recalls.items():
+        rrs = cat_rr[cat]
+        per_category[cat] = {
+            **{f"recall@{k}": mean(by_k[k]) if by_k[k] else 0.0 for k in k_values},
+            "mrr": mean(rrs) if rrs else 0.0,
+            "n": float(len(rrs)),
+        }
+
+    return EvalReport(
+        total_queries=n,
+        recall_at_k={k: recall_sums[k] / n for k in k_values},
+        mrr=rr_sum / n,
+        per_category=per_category,
+    )
+
+
+def _validate_baseline_shape(baseline: dict) -> None:
+    """Guard against a corrupted or hand-edited baseline.json — the gate
+    decision is load-bearing for closing the epic, so we want a clear
+    error rather than a silently-coerced numeric comparison."""
+    if not isinstance(baseline, dict):
+        raise ValueError("baseline must be a JSON object")
+    per_cat = baseline.get("per_category")
+    if not isinstance(per_cat, dict):
+        raise ValueError("baseline.per_category must be an object")
+    for cat, metrics in per_cat.items():
+        if not isinstance(metrics, dict):
+            raise ValueError(f"baseline.per_category[{cat!r}] must be an object")
+        # Accept either schema variant; reject non-numeric values.
+        r5 = metrics.get("recall@5", metrics.get("recall_at_5"))
+        if r5 is None:
+            continue  # category may be sparse; the comparator skips it
+        if isinstance(r5, bool) or not isinstance(r5, (int, float)):
+            raise ValueError(
+                f"baseline.per_category[{cat!r}].recall@5 must be a number"
+            )
+
+
+def compare_to_baseline(
+    current: EvalReport,
+    baseline: dict,
+    min_recall_at_5_lift_pp: float = DEFAULT_GATE_THRESHOLD_PP,
+) -> dict:
+    """Compare a current report against a locked baseline JSON.
+
+    The epic gate (#30): after-numbers must exceed baseline Recall@5 by at
+    least `min_recall_at_5_lift_pp` percentage points averaged across
+    categories present in both runs. Returns a structured verdict including
+    the lift, so callers can render it into markdown or fail CI.
+    """
+    _validate_baseline_shape(baseline)
+    cur_per_cat = current.per_category
+    base_per_cat = baseline.get("per_category", {})
+    shared = sorted(set(cur_per_cat) & set(base_per_cat))
+    lifts: dict[str, float] = {}
+    for cat in shared:
+        cur_r5 = float(cur_per_cat[cat].get("recall@5", 0.0))
+        base_r5 = float(base_per_cat[cat].get(
+            "recall@5",
+            base_per_cat[cat].get("recall_at_5", 0.0),
+        ))
+        lifts[cat] = (cur_r5 - base_r5) * 100.0  # percentage points
+
+    avg_lift_pp = mean(lifts.values()) if lifts else 0.0
+    return {
+        "shared_categories": shared,
+        "per_category_lift_pp": lifts,
+        "avg_recall_at_5_lift_pp": avg_lift_pp,
+        "threshold_pp": min_recall_at_5_lift_pp,
+        "passes_gate": avg_lift_pp >= min_recall_at_5_lift_pp,
+    }

--- a/agent/tests/retrieval_eval_set.example.jsonl
+++ b/agent/tests/retrieval_eval_set.example.jsonl
@@ -1,0 +1,15 @@
+# agent/tests/retrieval_eval_set.example.jsonl — committed template for the
+# real eval set described in issue #30. Copy to retrieval_eval_set.jsonl
+# (gitignored) and replace these synthetic examples with ≥30 queries against
+# your actual memory IDs. The five categories below must all be represented.
+#
+# Schema (one JSON object per non-blank, non-# line):
+#   query        — natural-language query string
+#   expected_ids — list of memory_event ids you expect to surface in top-K
+#   category     — one of: factual, person, temporal, open_loop, hybrid
+#   notes        — optional free-text rationale (kept local; never logged)
+{"query": "what embedding model does the router use", "expected_ids": [1], "category": "factual", "notes": "exact factual lookup"}
+{"query": "what's been going on with Matthew lately", "expected_ids": [4, 5], "category": "person", "notes": "person-context with recency tilt"}
+{"query": "recent updates from the team", "expected_ids": [7, 8], "category": "temporal", "notes": "default τ=30d should fire"}
+{"query": "what am I behind on", "expected_ids": [9, 10], "category": "open_loop", "notes": "open commitments"}
+{"query": "the doc about routing from april", "expected_ids": [11, 12], "category": "hybrid", "notes": "distinctive keyword + topical match"}

--- a/agent/tests/test_retrieval_eval.py
+++ b/agent/tests/test_retrieval_eval.py
@@ -1,0 +1,265 @@
+"""Unit tests for the retrieval eval runner (Epic 02, issue #30).
+
+These exercise the runner against a synthetic fixture corpus so CI does not
+depend on the gitignored real eval set or a populated Postgres."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from agent.tests._retrieval_eval_fixtures import (
+    FIXTURE_EVAL_SET,
+    make_fixture_retriever,
+)
+from agent.tests.retrieval_eval import (
+    CATEGORIES,
+    EvalQuery,
+    compare_to_baseline,
+    load_eval_set,
+    run_eval,
+)
+
+
+# ─── Schema / loader ──────────────────────────────────────────────────────
+
+
+def test_eval_query_rejects_unknown_category():
+    with pytest.raises(ValueError, match="unknown category"):
+        EvalQuery.from_dict(
+            {"query": "x", "expected_ids": [1], "category": "bogus"}
+        )
+
+
+def test_eval_query_rejects_empty_expected_ids():
+    with pytest.raises(ValueError, match="empty expected_ids"):
+        EvalQuery.from_dict(
+            {"query": "x", "expected_ids": [], "category": "factual"}
+        )
+
+
+def test_eval_query_rejects_missing_expected_ids():
+    with pytest.raises(ValueError, match="missing required field: expected_ids"):
+        EvalQuery.from_dict({"query": "x", "category": "factual"})
+
+
+@pytest.mark.parametrize(
+    "bad_value",
+    ["1", 1.5, True, False, None],
+    ids=["str", "float", "bool-true", "bool-false", "none"],
+)
+def test_eval_query_rejects_non_int_expected_ids(bad_value):
+    with pytest.raises(ValueError, match="must contain ints"):
+        EvalQuery.from_dict(
+            {"query": "x", "expected_ids": [bad_value], "category": "factual"}
+        )
+
+
+def test_eval_query_accepts_optional_retrieval_knobs():
+    q = EvalQuery.from_dict(
+        {
+            "query": "x",
+            "expected_ids": [1, 2],
+            "category": "person",
+            "time_window_days": 14,
+            "bm25_weight": 0.5,
+        }
+    )
+    assert q.time_window_days == 14
+    assert q.bm25_weight == 0.5
+
+
+def test_eval_query_rejects_invalid_time_window():
+    with pytest.raises(ValueError, match="time_window_days"):
+        EvalQuery.from_dict(
+            {
+                "query": "x",
+                "expected_ids": [1],
+                "category": "person",
+                "time_window_days": 0,
+            }
+        )
+
+
+def test_eval_query_rejects_out_of_range_bm25_weight():
+    with pytest.raises(ValueError, match="bm25_weight"):
+        EvalQuery.from_dict(
+            {
+                "query": "x",
+                "expected_ids": [1],
+                "category": "factual",
+                "bm25_weight": 1.5,
+            }
+        )
+
+
+def test_load_eval_set_skips_blank_and_comment_lines(tmp_path: Path):
+    p = tmp_path / "eval.jsonl"
+    p.write_text(
+        "\n"
+        "# this is a comment\n"
+        '{"query": "a", "expected_ids": [1], "category": "factual"}\n'
+        "\n"
+        '{"query": "b", "expected_ids": [2, 3], "category": "person"}\n',
+        encoding="utf-8",
+    )
+    out = load_eval_set(p)
+    assert [q.query for q in out] == ["a", "b"]
+    assert out[1].expected_ids == (2, 3)
+
+
+def test_load_eval_set_reports_line_number_on_bad_json(tmp_path: Path):
+    p = tmp_path / "eval.jsonl"
+    p.write_text(
+        '{"query": "a", "expected_ids": [1], "category": "factual"}\n'
+        "not-json\n",
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match=":2:"):
+        load_eval_set(p)
+
+
+def test_example_eval_set_parses():
+    """The committed .example file must always parse — it's the template."""
+    example = (
+        Path(__file__).parent / "retrieval_eval_set.example.jsonl"
+    )
+    assert example.exists(), "missing committed eval-set template"
+    parsed = load_eval_set(example)
+    assert len(parsed) >= 5
+    seen_categories = {q.category for q in parsed}
+    assert seen_categories == set(CATEGORIES), (
+        f"example set must cover all 5 categories, got {seen_categories}"
+    )
+
+
+# ─── Runner metrics ───────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_run_eval_against_fixture_corpus_returns_sane_metrics():
+    retriever = make_fixture_retriever()
+    report = await run_eval(list(FIXTURE_EVAL_SET), retriever)
+    assert report.total_queries == len(FIXTURE_EVAL_SET)
+    assert set(report.recall_at_k) == {1, 3, 5, 10}
+    for k, v in report.recall_at_k.items():
+        assert 0.0 <= v <= 1.0, f"recall@{k} out of range: {v}"
+    assert 0.0 <= report.mrr <= 1.0
+    # Token-overlap retriever should at least find the factual-lookup answers.
+    assert report.recall_at_k[5] > 0.0
+    # Each category exercised by FIXTURE_EVAL_SET appears in the breakdown.
+    for q in FIXTURE_EVAL_SET:
+        assert q.category in report.per_category
+
+
+@pytest.mark.asyncio
+async def test_recency_changes_temporal_ranking():
+    """The recency-boosted retriever should not score worse on the temporal
+    category than the recency-off retriever. Sanity-checks the eval is
+    sensitive to the kind of change #29 will introduce."""
+    base = await run_eval(
+        list(FIXTURE_EVAL_SET), make_fixture_retriever(use_recency=False)
+    )
+    boosted = await run_eval(
+        list(FIXTURE_EVAL_SET), make_fixture_retriever(use_recency=True)
+    )
+    base_temporal = base.per_category.get("temporal", {}).get("recall@5", 0.0)
+    boosted_temporal = boosted.per_category.get("temporal", {}).get("recall@5", 0.0)
+    assert boosted_temporal >= base_temporal
+
+
+@pytest.mark.asyncio
+async def test_run_eval_rejects_empty_set():
+    with pytest.raises(ValueError, match="empty"):
+        await run_eval([], make_fixture_retriever())
+
+
+# ─── Gate comparison ──────────────────────────────────────────────────────
+
+
+def test_compare_to_baseline_passes_when_lift_above_threshold():
+    from agent.tests.retrieval_eval import EvalReport
+
+    current = EvalReport(
+        total_queries=10,
+        recall_at_k={1: 0.4, 3: 0.6, 5: 0.7, 10: 0.8},
+        mrr=0.5,
+        per_category={
+            "factual": {"recall@5": 0.8, "mrr": 0.6, "n": 5.0},
+            "temporal": {"recall@5": 0.7, "mrr": 0.5, "n": 5.0},
+        },
+    )
+    baseline = {
+        "per_category": {
+            "factual": {"recall@5": 0.6},
+            "temporal": {"recall@5": 0.5},
+        }
+    }
+    verdict = compare_to_baseline(current, baseline, min_recall_at_5_lift_pp=10.0)
+    assert verdict["passes_gate"] is True
+    assert verdict["avg_recall_at_5_lift_pp"] == pytest.approx(20.0)
+
+
+def test_compare_to_baseline_fails_when_lift_below_threshold():
+    from agent.tests.retrieval_eval import EvalReport
+
+    current = EvalReport(
+        total_queries=4,
+        recall_at_k={1: 0.5, 3: 0.6, 5: 0.65, 10: 0.7},
+        mrr=0.55,
+        per_category={"factual": {"recall@5": 0.65, "mrr": 0.55, "n": 4.0}},
+    )
+    baseline = {"per_category": {"factual": {"recall@5": 0.6}}}
+    verdict = compare_to_baseline(current, baseline, min_recall_at_5_lift_pp=10.0)
+    assert verdict["passes_gate"] is False
+    assert verdict["avg_recall_at_5_lift_pp"] == pytest.approx(5.0)
+
+
+def test_compare_to_baseline_rejects_malformed_baseline():
+    from agent.tests.retrieval_eval import EvalReport
+
+    current = EvalReport(
+        total_queries=1,
+        recall_at_k={5: 0.0},
+        mrr=0.0,
+        per_category={"factual": {"recall@5": 0.0, "mrr": 0.0, "n": 1.0}},
+    )
+    with pytest.raises(ValueError, match="must be a JSON object"):
+        compare_to_baseline(current, [])  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="per_category"):
+        compare_to_baseline(current, {"per_category": "bogus"})
+    with pytest.raises(ValueError, match="must be a number"):
+        compare_to_baseline(
+            current, {"per_category": {"factual": {"recall@5": "not-a-number"}}}
+        )
+
+
+def test_compare_to_baseline_handles_missing_categories():
+    from agent.tests.retrieval_eval import EvalReport
+
+    current = EvalReport(
+        total_queries=2,
+        recall_at_k={1: 1.0, 3: 1.0, 5: 1.0, 10: 1.0},
+        mrr=1.0,
+        per_category={"new_only": {"recall@5": 1.0, "mrr": 1.0, "n": 2.0}},
+    )
+    baseline = {"per_category": {"old_only": {"recall@5": 0.5}}}
+    verdict = compare_to_baseline(current, baseline)
+    assert verdict["shared_categories"] == []
+    assert verdict["passes_gate"] is False  # no shared cats → 0.0 lift
+
+
+def test_eval_report_to_dict_round_trip():
+    from agent.tests.retrieval_eval import EvalReport
+
+    r = EvalReport(
+        total_queries=3,
+        recall_at_k={1: 0.33, 5: 0.66},
+        mrr=0.5,
+        per_category={"factual": {"recall@5": 0.66, "mrr": 0.5, "n": 3.0}},
+    )
+    blob = r.to_dict()
+    # Keys are stringified for JSON-friendliness.
+    assert blob["recall_at_k"] == {"1": 0.33, "5": 0.66}
+    json.dumps(blob)  # round-trips cleanly

--- a/agent/tests/test_run_retrieval_eval_script.py
+++ b/agent/tests/test_run_retrieval_eval_script.py
@@ -1,0 +1,41 @@
+"""Smoke tests for scripts/run_retrieval_eval.py — argument parsing only.
+
+The DB-touching paths are covered locally by `--mode baseline/after/gate`
+runs; this file verifies the argument-validation guard against path-
+traversal-style `--tag` values reaches the user as a clean rejection."""
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture(scope="module")
+def script_module():
+    path = Path(__file__).resolve().parent.parent.parent / "scripts" / "run_retrieval_eval.py"
+    spec = importlib.util.spec_from_file_location("_run_retrieval_eval", path)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.mark.parametrize(
+    "bad_tag",
+    ["../escape", "..\\escape", "a/b", "a b", "tag;rm-rf", "tag\nnewline", ".."],
+)
+def test_main_rejects_traversal_in_tag(script_module, monkeypatch, capsys, bad_tag):
+    monkeypatch.setattr(
+        sys, "argv", ["run_retrieval_eval.py", "--mode", "after", "--tag", bad_tag]
+    )
+    rc = script_module.main()
+    assert rc == 2
+    err = capsys.readouterr().err
+    assert "--tag" in err
+
+
+@pytest.mark.parametrize("good_tag", ["bm25", "rrf", "recency-v2", "snake_case"])
+def test_main_accepts_safe_tag_format(script_module, good_tag):
+    assert script_module._TAG_RE.match(good_tag)

--- a/eval_results/README.md
+++ b/eval_results/README.md
@@ -1,0 +1,47 @@
+# Retrieval eval results — Epic 02 (#30)
+
+Aggregate metrics from each retrieval-eval run. The query set itself
+(`agent/tests/retrieval_eval_set.jsonl`) is RAW_PERSONAL and gitignored.
+Only aggregate numbers — Recall@K, MRR, per-category averages — land here,
+so the gate is checkable from the repo without leaking queries.
+
+## Files
+
+- `baseline.json` — locked aggregate from the pre-E02 baseline run, used as
+  the "before" reference for the ≥10pp Recall@5 gate. Created by
+  `scripts/run_retrieval_eval.py --mode baseline` against the live DB and
+  the real eval set.
+- `retrieval_baseline_<YYYY-MM-DD>.md` — narrative snapshot of the baseline
+  run.
+- `retrieval_after_<subissue>_<YYYY-MM-DD>.md` — one per landed sub-issue
+  (#27, #28, #29). Captures the delta from baseline.
+
+## Local workflow (each pre-E02 run, then each post-landing run)
+
+```bash
+# Populate the gitignored real eval set first (≥30 entries, 5 categories).
+$ cp agent/tests/retrieval_eval_set.example.jsonl \
+     agent/tests/retrieval_eval_set.jsonl
+$ $EDITOR agent/tests/retrieval_eval_set.jsonl
+
+# Baseline run — must happen before any retrieval change in this epic.
+$ .venv/bin/python scripts/run_retrieval_eval.py --mode baseline
+
+# After a sub-issue lands (re-run on each):
+$ .venv/bin/python scripts/run_retrieval_eval.py --mode after --tag bm25
+$ .venv/bin/python scripts/run_retrieval_eval.py --mode after --tag rrf
+$ .venv/bin/python scripts/run_retrieval_eval.py --mode after --tag recency
+
+# Final gate check (#30 part B will wire this into CI):
+$ .venv/bin/python scripts/run_retrieval_eval.py --mode gate
+```
+
+## Privacy
+
+- Query strings, memory IDs, and per-query verdicts NEVER leave the
+  machine. They stay in the gitignored jsonl and in any local-only run
+  logs.
+- Aggregate metrics (Recall@K averaged, per-category Recall@K averaged,
+  MRR averaged) are non-personal by construction and committed here.
+- Do not paste per-query output into chat messages or copy it into PR
+  descriptions.

--- a/scripts/run_retrieval_eval.py
+++ b/scripts/run_retrieval_eval.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""Local retrieval-eval runner — Epic 02, issue #30.
+
+Runs the gitignored real eval set against the live memory DB, prints
+aggregate metrics, and writes them to `eval_results/`. The script never
+logs query text or per-query results outside of the local terminal.
+
+Usage:
+    .venv/bin/python scripts/run_retrieval_eval.py --mode baseline
+    .venv/bin/python scripts/run_retrieval_eval.py --mode after --tag bm25
+    .venv/bin/python scripts/run_retrieval_eval.py --mode gate
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import re
+import sys
+from datetime import date
+from pathlib import Path
+
+_TAG_RE = re.compile(r"^[a-zA-Z0-9_-]+$")
+
+# Allow running as `python scripts/run_retrieval_eval.py` from anywhere by
+# putting the repo root on sys.path before importing agent.* modules.
+_REPO_ROOT_FOR_IMPORTS = Path(__file__).resolve().parent.parent
+if str(_REPO_ROOT_FOR_IMPORTS) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT_FOR_IMPORTS))
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+EVAL_SET_PATH = REPO_ROOT / "agent" / "tests" / "retrieval_eval_set.jsonl"
+EVAL_RESULTS_DIR = REPO_ROOT / "eval_results"
+BASELINE_JSON = EVAL_RESULTS_DIR / "baseline.json"
+
+
+def _render_markdown(report, mode: str, tag: str | None) -> str:
+    title = f"Retrieval eval — {mode}" + (f" ({tag})" if tag else "")
+    lines = [
+        f"# {title}",
+        "",
+        f"- Date: {date.today().isoformat()}",
+        f"- Total queries: {report.total_queries}",
+        f"- MRR: {report.mrr:.4f}",
+        "",
+        "## Recall@K (overall)",
+        "",
+        "| K | Recall |",
+        "|---|--------|",
+    ]
+    for k in sorted(report.recall_at_k):
+        lines.append(f"| {k} | {report.recall_at_k[k]:.4f} |")
+    lines.extend(["", "## Per-category", "", "| Category | n | Recall@5 | MRR |", "|---|---|---|---|"])
+    for cat in sorted(report.per_category):
+        row = report.per_category[cat]
+        lines.append(
+            f"| {cat} | {int(row.get('n', 0))} | "
+            f"{row.get('recall@5', 0.0):.4f} | {row.get('mrr', 0.0):.4f} |"
+        )
+    lines.append("")
+    return "\n".join(lines)
+
+
+async def _build_memory_retriever():
+    """Adapt MemoryManager.search_recall into the eval Retriever protocol.
+
+    TODO(epic02): once #27 (BM25), #28 (RRF), and #29 (recency) land,
+    add a `--retriever-mode` argument and dispatch to the corresponding
+    MemoryManager method here so before/after deltas can be measured
+    without redeploying.
+    """
+    from agent.config import settings  # noqa: WPS433
+    from agent.db import get_session_factory, init_db
+    from agent.llm import LLMClient
+    from agent.memory import MemoryManager
+
+    await init_db(settings)
+    llm = LLMClient(settings)
+    mm = MemoryManager(llm_client=llm, db_session_factory=get_session_factory())
+
+    async def retrieve(eval_query, k: int) -> list[int]:
+        results = await mm.search_recall(eval_query.query, limit=k)
+        return [int(r["id"]) for r in results]
+
+    return retrieve
+
+
+async def _run(mode: str, tag: str | None, threshold_pp: float) -> int:
+    from agent.tests.retrieval_eval import compare_to_baseline, load_eval_set, run_eval
+
+    if not EVAL_SET_PATH.exists():
+        print(
+            f"missing {EVAL_SET_PATH.relative_to(REPO_ROOT)} — copy from "
+            f"retrieval_eval_set.example.jsonl and populate locally.",
+            file=sys.stderr,
+        )
+        return 2
+
+    eval_set = load_eval_set(EVAL_SET_PATH)
+    retriever = await _build_memory_retriever()
+    report = await run_eval(eval_set, retriever)
+
+    EVAL_RESULTS_DIR.mkdir(exist_ok=True)
+    md = _render_markdown(report, mode=mode, tag=tag)
+    print(md)
+
+    if mode == "baseline":
+        BASELINE_JSON.write_text(json.dumps(report.to_dict(), indent=2) + "\n")
+        out_md = EVAL_RESULTS_DIR / f"retrieval_baseline_{date.today().isoformat()}.md"
+        out_md.write_text(md + "\n")
+        print(f"\nwrote {BASELINE_JSON.relative_to(REPO_ROOT)} and {out_md.relative_to(REPO_ROOT)}")
+        return 0
+
+    if mode == "after":
+        slug = tag or "after"
+        out_md = EVAL_RESULTS_DIR / f"retrieval_after_{slug}_{date.today().isoformat()}.md"
+        out_md.write_text(md + "\n")
+        print(f"\nwrote {out_md.relative_to(REPO_ROOT)}")
+        return 0
+
+    if mode == "gate":
+        if not BASELINE_JSON.exists():
+            print(f"missing {BASELINE_JSON.relative_to(REPO_ROOT)} — run --mode baseline first.", file=sys.stderr)
+            return 2
+        baseline = json.loads(BASELINE_JSON.read_text())
+        verdict = compare_to_baseline(report, baseline, min_recall_at_5_lift_pp=threshold_pp)
+        print("\n## Gate verdict\n")
+        print(json.dumps(verdict, indent=2))
+        return 0 if verdict["passes_gate"] else 1
+
+    print(f"unknown mode: {mode}", file=sys.stderr)
+    return 2
+
+
+def main() -> int:
+    from agent.tests.retrieval_eval import DEFAULT_GATE_THRESHOLD_PP
+
+    parser = argparse.ArgumentParser(description="Run the retrieval eval.")
+    parser.add_argument("--mode", choices=("baseline", "after", "gate"), required=True)
+    parser.add_argument(
+        "--tag",
+        default=None,
+        help="label for --mode after (e.g. bm25, rrf, recency); "
+        "alphanumerics/dash/underscore only",
+    )
+    parser.add_argument(
+        "--threshold-pp",
+        type=float,
+        default=DEFAULT_GATE_THRESHOLD_PP,
+        help="Recall@5 lift in percentage points required to pass --mode gate",
+    )
+    args = parser.parse_args()
+    if args.tag is not None and not _TAG_RE.match(args.tag):
+        print(
+            f"--tag must match {_TAG_RE.pattern} (got {args.tag!r}); "
+            "filenames are written under eval_results/ and must not contain "
+            "path separators.",
+            file=sys.stderr,
+        )
+        return 2
+    return asyncio.run(_run(args.mode, args.tag, args.threshold_pp))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- Adds the retrieval-eval runner (`agent/tests/retrieval_eval.py`), fixture corpus, and local CLI (`scripts/run_retrieval_eval.py`) for Epic 02's comprehension-delta gate.
- Real eval set (`agent/tests/retrieval_eval_set.jsonl`, ≥30 entries) is RAW_PERSONAL and gitignored. Only aggregate metrics land under `eval_results/`.
- CI exercises the runner against a synthetic in-memory fixture corpus, so it never depends on a populated DB or the gitignored set.

## Why this lands first in Epic 02

The eval set + baseline must exist *before* any retrieval change in #27/#28/#29, so the ≥10pp Recall@5 gate has a "before" reference. Part B of #30 (capturing real after-numbers and locking the CI gate) lands after #27/#28/#29.

## Forward-compat for the dependent sub-issues

- `Retriever` protocol takes the full `EvalQuery` (not just the query string) so per-query knobs flow through without a signature change:
  - `time_window_days` — #29's recency τ override
  - `bm25_weight` — #28's fusion override (advisory)
- `--threshold-pp` CLI flag — gate threshold parameterized; default `10.0` per #30.
- `agent/db.py:get_session_factory()` — public accessor so the eval script doesn't reach into `_session_factory`.

## Security / privacy

- Real eval set + `eval_results/baseline.json` gitignored.
- `_render_markdown` emits aggregates only — no per-query rows, no query strings.
- `compare_to_baseline` schema-validates `baseline.json` (rejects malformed/non-numeric metrics) so a corrupted baseline can't silently flip the gate.
- `EvalQuery.from_dict` rejects `bool` / `str` / `float` values in `expected_ids` (no silent `int()` coercion).
- `--tag` regex-restricted to `[a-zA-Z0-9_-]+` — blocks path-traversal in the output filename.

## Test plan

- [x] `pytest agent/tests/test_retrieval_eval.py agent/tests/test_run_retrieval_eval_script.py` — 32 new tests, all green.
- [x] `pytest agent/tests/test_memory.py` — regression suite still green (no behavior change).
- [x] `ruff check` — clean.
- [ ] After merge: locally `cp retrieval_eval_set.example.jsonl retrieval_eval_set.jsonl`, populate ≥30 entries, run `scripts/run_retrieval_eval.py --mode baseline` against the live DB, commit the resulting `eval_results/retrieval_baseline_<date>.md` (aggregate only).

Closes part A of #30. Part of Epic #26.