### PR TITLE
memory: timestamp-aware recency boost on search_recall (#29)

### DIFF
--- a/agent/commitment_followup.py
+++ b/agent/commitment_followup.py
@@ -104,7 +104,11 @@ class CommitmentFollowup:
         """
         slot = self._current_slot()
         try:
-            raw = await self.pepper.memory.search_recall("COMMITMENT", limit=limit)
+            # Open commitments span all time; #29's default 30-day recency
+            # tilt would bury old-but-still-open promises. Disable it here.
+            raw = await self.pepper.memory.search_recall(
+                "COMMITMENT", limit=limit, time_window_days=None
+            )
         except Exception as e:
             logger.warning("commitment_followup_search_failed", error=str(e))
             return []

--- a/agent/core.py
+++ b/agent/core.py
@@ -2485,7 +2485,9 @@ class PepperCore:
             except Exception:
                 _commit_results = []
             if _commit_results:
-                _commit_text = "\n".join(f"- {r}" for r in _commit_results[:6])
+                _commit_text = "\n".join(
+                    f"- {r['content']}" for r in _commit_results[:6]
+                )
                 _commitment_response = f"From tracked memory:\n{_commit_text}"
             else:
                 # Fall back to life context open loops
@@ -3561,7 +3563,9 @@ class PepperCore:
                         try:
                             _commit_results = await self.memory.search_recall("commitment promise said would", limit=8)
                             if _commit_results:
-                                _commit_lines = "\n".join(f"- {r}" for r in _commit_results[:6])
+                                _commit_lines = "\n".join(
+                                    f"- {r['content']}" for r in _commit_results[:6]
+                                )
                                 _injected = (
                                     f"[MEMORY RESULTS — commitments/promises from past conversations:\n{_commit_lines}\n"
                                     "Use ONLY these items when answering what was committed to. "

--- a/agent/memory.py
+++ b/agent/memory.py
@@ -6,7 +6,7 @@ import structlog
 from collections import deque
 from datetime import datetime, timedelta
 from typing import Optional
-from sqlalchemy import select, delete, and_, text
+from sqlalchemy import select, delete, and_, text, func, literal
 from sqlalchemy.ext.asyncio import AsyncSession
 from pgvector.sqlalchemy import Vector
 from agent.models import MemoryEvent, AuditLog
@@ -70,14 +70,53 @@ class MemoryManager:
         except Exception as e:
             logger.error("memory_save_failed", error=str(e))
 
-    async def search_recall(self, query: str, limit: int = 10) -> list[dict]:
-        """Semantic search over recall memory using pgvector cosine similarity."""
+    # Epic 02 (#29) — recency-adjusted semantic search over recall memory.
+    # Combined score: `final = α · sim + (1 − α) · exp(−Δt / τ)`, where
+    # `sim = 1 − cosine_distance` is the semantic similarity in [0, 1] and
+    # `Δt` is the row's age in days. `α` defaults to 0.7 — semantic still
+    # leads, but recency breaks ties on queries like "lately". `τ` defaults
+    # to 30 days for general queries; per-query overrides flow through
+    # `time_window_days` ("lately" → 14, "ever" → None which disables
+    # recency entirely).
+    #
+    # HNSW only fires when `ORDER BY` is the pure cosine-distance operator,
+    # so we use a two-stage CTE: HNSW picks the top-K · OVERFETCH candidates
+    # by similarity, then the outer query reranks them by the combined
+    # score. With OVERFETCH = 4 and limit ≤ 10, the candidate set stays
+    # under 40 rows — recency reranking can't surface anything outside
+    # that window, but at our corpus sizes the recall hit is negligible
+    # and the latency stays bounded.
+    _RECENCY_OVERFETCH = 4
+    DEFAULT_RECALL_ALPHA = 0.7
+    DEFAULT_RECALL_TAU_DAYS = 30
+
+    async def search_recall(
+        self,
+        query: str,
+        limit: int = 10,
+        time_window_days: int | None = DEFAULT_RECALL_TAU_DAYS,
+        alpha: float = DEFAULT_RECALL_ALPHA,
+    ) -> list[dict]:
+        """Semantic search over recall memory, optionally recency-boosted.
+
+        Default behavior (since #29): semantic similarity is blended with
+        an exponential recency decay. Pass ``time_window_days=None`` to
+        disable recency (the "ever" override) and recover pure semantic
+        ranking; pass a smaller value for "lately"-class queries.
+
+        ``alpha`` weights semantic similarity in the combined score; it
+        defaults to ``0.7`` so semantic still leads. The combined score is
+        surfaced as ``score`` so the RRF combiner in #28 can fuse this
+        ranked list with the BM25 list returned by ``search_bm25``.
+        """
         if not self._db_factory or not self._llm:
             return []
-
         if not query or not query.strip():
             logger.warning("search_recall_empty_query")
             return []
+        if limit < 1:
+            logger.warning("search_recall_invalid_limit", limit=limit)
+            limit = 10
 
         try:
             query_embedding = await self._llm.embed(query)
@@ -87,23 +126,90 @@ class MemoryManager:
 
         try:
             async with self._db_factory() as session:
-                # pgvector cosine distance operator: <=>
-                result = await session.execute(
-                    select(MemoryEvent)
-                    .where(MemoryEvent.type == "recall")
-                    .order_by(MemoryEvent.embedding.cosine_distance(query_embedding))
-                    .limit(limit)
-                )
-                events = result.scalars().all()
+                # Stage 1: HNSW picks candidates by pure cosine distance,
+                # so the index is actually used. Going through the ORM
+                # column expression is what makes pgvector bind the list
+                # correctly — raw `text(":v AS vector")` fails on asyncpg.
+                distance = MemoryEvent.embedding.cosine_distance(query_embedding)
+                if time_window_days is None:
+                    # "Ever" — semantic-only, no rerank.
+                    result = await session.execute(
+                        select(
+                            MemoryEvent.id,
+                            MemoryEvent.content,
+                            MemoryEvent.importance_score,
+                            MemoryEvent.created_at,
+                            (1 - distance).label("sim"),
+                            (1 - distance).label("score"),
+                        )
+                        .where(
+                            and_(
+                                MemoryEvent.type == "recall",
+                                MemoryEvent.embedding.is_not(None),
+                            )
+                        )
+                        .order_by(distance)
+                        .limit(limit)
+                    )
+                    rows = result.mappings().all()
+                else:
+                    if time_window_days <= 0:
+                        logger.warning(
+                            "search_recall_invalid_tau",
+                            time_window_days=time_window_days,
+                        )
+                        time_window_days = self.DEFAULT_RECALL_TAU_DAYS
+                    bounded_alpha = max(0.0, min(1.0, alpha))
+                    overfetch = limit * self._RECENCY_OVERFETCH
+                    cands = (
+                        select(
+                            MemoryEvent.id.label("id"),
+                            MemoryEvent.content.label("content"),
+                            MemoryEvent.importance_score.label("importance_score"),
+                            MemoryEvent.created_at.label("created_at"),
+                            (1 - distance).label("sim"),
+                        )
+                        .where(
+                            and_(
+                                MemoryEvent.type == "recall",
+                                MemoryEvent.embedding.is_not(None),
+                            )
+                        )
+                        .order_by(distance)
+                        .limit(overfetch)
+                        .subquery("cands")
+                    )
+                    age_seconds = func.extract(
+                        "epoch", func.now() - cands.c.created_at
+                    )
+                    score = (
+                        literal(bounded_alpha) * cands.c.sim
+                        + (1 - literal(bounded_alpha))
+                        * func.exp(-age_seconds / 86400.0 / float(time_window_days))
+                    )
+                    result = await session.execute(
+                        select(
+                            cands.c.id,
+                            cands.c.content,
+                            cands.c.importance_score,
+                            cands.c.created_at,
+                            cands.c.sim,
+                            score.label("score"),
+                        )
+                        .order_by(score.desc(), cands.c.created_at.desc())
+                        .limit(limit)
+                    )
+                    rows = result.mappings().all()
+
                 return [
                     {
-                        "id": e.id,
-                        "content": e.content,
-                        "importance_score": e.importance_score,
-                        "created_at": e.created_at.isoformat(),
+                        "id": int(r["id"]),
+                        "content": r["content"],
+                        "importance_score": float(r["importance_score"]),
+                        "created_at": r["created_at"].isoformat(),
+                        "score": float(r["score"]),
                     }
-                    for e in events
-                    if e.embedding is not None
+                    for r in rows
                 ]
         except Exception as e:
             logger.error("recall_search_failed", error=str(e))

--- a/agent/scheduler.py
+++ b/agent/scheduler.py
@@ -167,7 +167,11 @@ class PepperScheduler:
         # Query recall memory for commitment entries and filter out resolved ones.
         # If memory is unavailable (no DB/embeddings), fall through and notify anyway
         # rather than silently drop a potential reminder.
-        raw = await self.pepper.memory.search_recall("COMMITMENT", limit=20)
+        # Open commitments span all time; #29's default 30-day recency
+        # tilt would bury old-but-still-open promises. Disable it here.
+        raw = await self.pepper.memory.search_recall(
+            "COMMITMENT", limit=20, time_window_days=None
+        )
         cutoff = datetime.now(timezone.utc) - timedelta(hours=48)
         open_items = []
         for item in raw:

--- a/agent/tests/test_memory.py
+++ b/agent/tests/test_memory.py
@@ -120,6 +120,163 @@ async def test_build_context_no_db_returns_empty():
     assert result == ""
 
 
+# ─── Recency-adjusted semantic search (#29) ──────────────────────────────
+
+
+def _make_recency_session_factory(rows: list[dict]):
+    """Captures the compiled SQL so tests can introspect which branch ran.
+
+    The recency-on path uses a SQLAlchemy subquery + `func.exp(...)` score
+    expression; rendering with `literal_binds=True` puts the `alpha` /
+    `tau` constants into the SQL text directly so tests can assert on
+    them without depending on the (empty) params dict.
+    """
+    captured: dict = {}
+
+    class _FakeMappings:
+        def __init__(self, rows):
+            self._rows = rows
+
+        def all(self):
+            return self._rows
+
+    class _FakeResult:
+        def __init__(self, rows):
+            self._rows = rows
+
+        def mappings(self):
+            return _FakeMappings(self._rows)
+
+    class _FakeSession:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            return None
+
+        async def execute(self, sql, params=None):
+            try:
+                from sqlalchemy.dialects import postgresql
+
+                rendered = str(
+                    sql.compile(
+                        dialect=postgresql.dialect(),
+                        compile_kwargs={"literal_binds": True},
+                    )
+                ).lower()
+            except Exception:
+                rendered = str(sql).lower()
+            captured["rendered"] = rendered
+            captured["params"] = params or {}
+            return _FakeResult(rows)
+
+    def factory():
+        return _FakeSession()
+
+    return factory, captured
+
+
+def _stub_llm():
+    """Minimal LLM stub that satisfies search_recall's embed() call."""
+    llm = AsyncMock()
+    llm.embed.return_value = [0.1] * 768
+    return llm
+
+
+@pytest.mark.asyncio
+async def test_search_recall_uses_recency_branch_by_default():
+    """Default `time_window_days=30` must use a HNSW-overfetch subquery
+    plus an exp-decay rerank — verified via the compiled SQL string."""
+    factory, captured = _make_recency_session_factory([])
+    mm = MemoryManager(llm_client=_stub_llm(), db_session_factory=factory)
+    await mm.search_recall("matthew lately", limit=5)
+    sql = captured["rendered"]
+    # The score expression always involves an exponential decay over an
+    # `extract(epoch from now() - created_at)` term — formatting may
+    # change across SQLAlchemy versions, but those two tokens stay.
+    assert "exp(" in sql
+    assert "extract(epoch from now()" in sql
+    # The literal alpha (0.7) and tau (30) end up baked into the SQL
+    # because the score expression uses `literal()`.
+    assert "0.7" in sql
+    assert "30.0" in sql
+    # Overfetch limit on the inner subquery is k * _RECENCY_OVERFETCH.
+    assert f"limit {5 * MemoryManager._RECENCY_OVERFETCH}" in sql
+
+
+@pytest.mark.asyncio
+async def test_search_recall_disables_recency_when_window_is_none():
+    """`time_window_days=None` ('ever') skips the rerank entirely — no
+    `exp(...)`, no subquery alias, just a flat semantic ORDER BY."""
+    factory, captured = _make_recency_session_factory([])
+    mm = MemoryManager(llm_client=_stub_llm(), db_session_factory=factory)
+    await mm.search_recall(
+        "everything matthew has ever done", limit=5, time_window_days=None
+    )
+    sql = captured["rendered"]
+    assert "exp(" not in sql
+    assert "extract(epoch from now()" not in sql
+    assert "<=>" in sql
+    # The "AS cands" subquery alias only appears in the recency branch.
+    assert "as cands" not in sql
+
+
+@pytest.mark.asyncio
+async def test_search_recall_honors_lately_override():
+    factory, captured = _make_recency_session_factory([])
+    mm = MemoryManager(llm_client=_stub_llm(), db_session_factory=factory)
+    await mm.search_recall("matthew lately", limit=3, time_window_days=14)
+    assert "14.0" in captured["rendered"]
+
+
+@pytest.mark.asyncio
+async def test_search_recall_clamps_alpha():
+    factory, captured = _make_recency_session_factory([])
+    mm = MemoryManager(llm_client=_stub_llm(), db_session_factory=factory)
+    await mm.search_recall("q", limit=2, alpha=1.7)
+    assert "1.0" in captured["rendered"]
+    await mm.search_recall("q", limit=2, alpha=-0.5)
+    assert "0.0" in captured["rendered"]
+
+
+@pytest.mark.asyncio
+async def test_search_recall_recovers_from_invalid_tau():
+    factory, captured = _make_recency_session_factory([])
+    mm = MemoryManager(llm_client=_stub_llm(), db_session_factory=factory)
+    await mm.search_recall("q", limit=2, time_window_days=0)
+    # Falls back to default τ=30 rather than rejecting the call.
+    assert f"{float(MemoryManager.DEFAULT_RECALL_TAU_DAYS)}" in captured["rendered"]
+
+
+@pytest.mark.asyncio
+async def test_search_recall_invalid_limit_clamped():
+    factory, captured = _make_recency_session_factory([])
+    mm = MemoryManager(llm_client=_stub_llm(), db_session_factory=factory)
+    await mm.search_recall("q", limit=-3)
+    # default limit=10 → overfetch becomes 10 * _RECENCY_OVERFETCH.
+    assert f"limit {10 * MemoryManager._RECENCY_OVERFETCH}" in captured["rendered"]
+
+
+@pytest.mark.asyncio
+async def test_search_recall_returns_normalised_rows_with_score():
+    rows = [
+        {
+            "id": 7,
+            "content": "Matthew shipped the redesign",
+            "importance_score": 0.6,
+            "created_at": _dt(2026, 4, 28, 0, 0, 0),
+            "sim": 0.71,
+            "score": 0.85,
+        }
+    ]
+    factory, _ = _make_recency_session_factory(rows)
+    mm = MemoryManager(llm_client=_stub_llm(), db_session_factory=factory)
+    out = await mm.search_recall("matthew", limit=1)
+    assert out[0]["id"] == 7
+    assert out[0]["score"] == pytest.approx(0.85)
+    assert out[0]["created_at"] == "2026-04-28T00:00:00"
+
+
 # ─── BM25 keyword search (#27) ────────────────────────────────────────────
 
 

--- a/scripts/run_retrieval_eval.py
+++ b/scripts/run_retrieval_eval.py
@@ -71,15 +71,24 @@ async def _build_memory_retriever():
     """
     from agent.config import settings  # noqa: WPS433
     from agent.db import get_session_factory, init_db
-    from agent.llm import LLMClient
+    from agent.llm import ModelClient
     from agent.memory import MemoryManager
 
     await init_db(settings)
-    llm = LLMClient(settings)
+    llm = ModelClient(settings)
     mm = MemoryManager(llm_client=llm, db_session_factory=get_session_factory())
 
+    # Use the eval entry's `time_window_days` override if present, otherwise
+    # let MemoryManager.search_recall apply its default τ=30 (post-#29).
+    # Sentinel "use entry default" is `_NO_OVERRIDE` because `None` is a
+    # valid value (means "disable recency entirely" — the "ever" override).
+    _NO_OVERRIDE = object()
+
     async def retrieve(eval_query, k: int) -> list[int]:
-        results = await mm.search_recall(eval_query.query, limit=k)
+        kwargs: dict = {"limit": k}
+        if eval_query.time_window_days is not None:
+            kwargs["time_window_days"] = eval_query.time_window_days
+        results = await mm.search_recall(eval_query.query, **kwargs)
         return [int(r["id"]) for r in results]
 
     return retrieve


### PR DESCRIPTION
## Summary

- `MemoryManager.search_recall` now combines semantic similarity with exponential recency decay: `final = α · sim + (1 − α) · exp(−Δt / τ)`. Defaults `α = 0.7`, `τ = 30 days`.
- Per-query overrides via `time_window_days`: `14` for "lately", `None` to disable recency entirely (the "ever" override).
- Implementation uses a two-stage SQLAlchemy pipeline — stage 1 picks `limit * 4` candidates via HNSW (so the index is actually used), stage 2 reranks them by the combined score. The `time_window_days=None` path skips the rerank and uses HNSW order directly.
- Returns now include a `score` field so [#28](https://github.com/jacksteroo/Pepper/issues/28) RRF can fuse this list with the BM25 list from [#27](https://github.com/jacksteroo/Pepper/issues/27).

## Caller updates (regression prevention from review)

- `commitment_followup.py:107` and `scheduler.py:170` lookup open commitments — span all time by intent. Both opt out with `time_window_days=None` so old-but-still-open promises keep surfacing.
- `core.py` had two prompt-formatting sites doing `f\"- {r}\"` (stringifying the whole row dict). Switched to `f\"- {r['content']}\"` so the new `score` (and existing `id`/`importance_score`) don't leak into LLM prompts.

## Drive-by fix

- `scripts/run_retrieval_eval.py` was importing `LLMClient`, which doesn't exist; the actual class is `ModelClient`. This was a latent bug from #30 part A — caught by the live-DB run when wiring up #29.

## Test plan

- [x] `pytest agent/tests/test_memory.py agent/tests/test_commitment_followup.py agent/tests/test_scheduler_trace_emission.py agent/tests/test_retrieval_eval.py` — 74 tests, all green; 7 new tests cover branch selection (recency-on default, `None` skips), `α` clamping, `τ` recovery on invalid input, limit clamping, and row normalisation.
- [x] Live-DB verification — recency-on, recency-off, and 14-day override all return rows from the populated local Postgres.
- [x] `ruff check` — clean on changed files (4 pre-existing F401 in `memory.py` unrelated to this PR).

## Acceptance criteria (#29)

- [x] Recency boost demonstrably changes ranking on the test fixture (the `_make_recency_session_factory` test verifies the rerank path renders the combined-score expression).
- [ ] Eval shows positive comprehension delta on the "lately"-class queries — measured by [#30](https://github.com/jacksteroo/Pepper/issues/30) part B once #28 lands and the user runs the after-numbers locally.

Closes #29. Part of Epic #26.