### PR TITLE
eval_results: flip baseline.json to committable (#30 closeout)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,6 @@ backups/router/*.sql
 # the user's actual memory). The committed `.example.jsonl` is the template;
 # the populated `retrieval_eval_set.jsonl` stays local.
 agent/tests/retrieval_eval_set.jsonl
-# Local-only baseline JSON; aggregate markdown reports may be committed
-# (they don't contain queries).
-eval_results/baseline.json
+# `eval_results/baseline.json` is committable — it holds aggregate metrics
+# only (Recall@K, MRR, per-category averages) which are non-personal by
+# construction. Committing it lets `--mode gate` be checkable from the repo.


### PR DESCRIPTION
## Summary

Closes Epic 02 (#26) on the repo side. Final tweak: \`eval_results/baseline.json\` is now committable.

The aggregate metrics it holds — \`total_queries\`, \`recall_at_k\`, \`mrr\`, per-category averages — are non-personal by construction over a 30+ query set. Committing the JSON makes \`scripts/run_retrieval_eval.py --mode gate\` checkable from the repo.

The real eval set (\`agent/tests/retrieval_eval_set.jsonl\`) remains gitignored — it's RAW_PERSONAL.

## Epic 02 status

| Sub-issue | PR | Landed |
|---|---|---|
| #30 (part A) eval scaffolding | #93 | ✓ |
| #27 BM25 | #94 | ✓ |
| #29 recency tilt | #95 | ✓ |
| #28 RRF combiner | #96 | ✓ |
| #30 (part B) gate-doc + closeout | this PR | — |

## What's left for the user

The empirical ≥10pp Recall@5 gate runs locally against the live memory DB:

\`\`\`bash
cp agent/tests/retrieval_eval_set.example.jsonl agent/tests/retrieval_eval_set.jsonl
\$EDITOR agent/tests/retrieval_eval_set.jsonl  # ≥30 entries, 5 categories

.venv/bin/python scripts/run_retrieval_eval.py --mode baseline
.venv/bin/python scripts/run_retrieval_eval.py --mode gate --retriever-mode hybrid
\`\`\`

CI regression coverage is already in place via \`agent/tests/test_retrieval_eval.py\` (synthetic fixture corpus + \`compare_to_baseline\` round-trip tests).

## Test plan

- [x] No code changed; only \`.gitignore\` flipped.
- [x] Existing 82 tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)