### PR TITLE
agent/context: persist assembly provenance into traces (#33)

### DIFF
--- a/agent/context/__init__.py
+++ b/agent/context/__init__.py
@@ -10,6 +10,7 @@ See ``agent/context/assembler.py`` for the rendering contract and
 """
 
 from agent.context.assembler import ContextAssembler
+from agent.context.decisions import annotate
 from agent.context.grounding_rules import render_grounding_rules
 from agent.context.types import AssembledContext, SelectorRecord, Turn
 
@@ -18,5 +19,6 @@ __all__ = [
     "ContextAssembler",
     "SelectorRecord",
     "Turn",
+    "annotate",
     "render_grounding_rules",
 ]

--- a/agent/context/assembler.py
+++ b/agent/context/assembler.py
@@ -107,7 +107,13 @@ class ContextAssembler:
             system = f"[Interface: You are responding via {turn.channel}.]\n\n" + system
 
         # 4. Retrieved memory (already fetched by caller via gather()).
-        rm_record = self._retrieved_memory.select(turn.memory_context)
+        # ``memory_records`` is optional — when present, the selector emits
+        # ``memory_ids`` for #33 provenance. Backward-compat: callers that
+        # don't thread structured rows still get a populated context block.
+        rm_record = self._retrieved_memory.select(
+            turn.memory_context,
+            memory_records=turn.memory_records,
+        )
         records[rm_record.name] = rm_record
         if rm_record.content:
             system += f"\n\n{rm_record.content}"

--- a/agent/context/decisions.py
+++ b/agent/context/decisions.py
@@ -1,0 +1,145 @@
+"""Human-readable reason annotations for assembly decisions.
+
+Issue #33 (E3) wires raw provenance into traces so the reflector and
+optimizer can do their work. Humans inspecting a single trace want
+something more legible than ``{"memory_ids": [["uuid", 0.71], ...]}``.
+
+This module provides :func:`annotate` — a thin wrapper that walks an
+:class:`AssembledContext` and produces a ``selector_name -> reason``
+map suitable for the upcoming inspector UI (#34). It does NOT mutate
+the assembler or the persisted trace shape — it's a read-only
+projection over the same provenance dict that already lives on the
+trace.
+
+Privacy: same constraint as the rest of provenance. We name memory IDs
+and life-context section names, never raw memory text.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from agent.context.types import AssembledContext, SelectorRecord
+
+
+def annotate(context: AssembledContext) -> dict[str, str]:
+    """Return a dict of ``selector_name -> human-readable reason``.
+
+    Every named selector currently in ``context.selectors`` gets a
+    string. Selectors that produced no content still return a string
+    explaining the absence — the dict is shape-stable across turns.
+    """
+    out: dict[str, str] = {}
+    for name, record in context.selectors.items():
+        out[name] = _explain(name, record)
+    return out
+
+
+def _explain(name: str, record: SelectorRecord) -> str:
+    explainer = _EXPLAINERS.get(name, _explain_default)
+    try:
+        return explainer(record.provenance or {})
+    except Exception:
+        # Defence in depth — annotation is a debug aid, never break the
+        # turn or the trace persist path on a bad provenance dict.
+        return f"{name}: provenance present"
+
+
+def _explain_life_context(p: dict[str, Any]) -> str:
+    sections = list(p.get("life_context_sections_used") or [])
+    n = len(sections)
+    if n == 0:
+        return (
+            "life_context: no sections found in life_context.md "
+            "(file empty or missing)"
+        )
+    preview = ", ".join(sections[:3])
+    if n > 3:
+        preview += f", … (+{n - 3})"
+    return (
+        f"life_context: included {n} section(s) from life_context.md — "
+        f"{preview}"
+    )
+
+
+def _explain_capability_block(p: dict[str, Any]) -> str:
+    available = list(p.get("available_sources") or [])
+    version = p.get("capability_block_version") or "unknown"
+    if not available:
+        return (
+            f"capability_block: no live sources (version={version}); "
+            "registry empty or all subsystems unavailable"
+        )
+    preview = ", ".join(available[:5])
+    if len(available) > 5:
+        preview += f", … (+{len(available) - 5})"
+    return (
+        f"capability_block: {len(available)} live source(s) "
+        f"(version={version}) — {preview}"
+    )
+
+
+def _explain_retrieved_memory(p: dict[str, Any]) -> str:
+    ids = list(p.get("memory_ids") or [])
+    n = len(ids)
+    if n == 0:
+        if p.get("present"):
+            # Caller threaded a context string but no structured rows —
+            # legacy code path. Be explicit so optimizer dashboards can
+            # see the gap.
+            return (
+                "retrieved_memory: context block included, "
+                "no structured memory IDs threaded"
+            )
+        return "retrieved_memory: no recall hits for this query"
+    return (
+        f"retrieved_memory: {n} memory ID(s) selected by top-{n} "
+        "score on query embedding (recall + archival, RRF blended)"
+    )
+
+
+def _explain_skill_match(p: dict[str, Any]) -> str:
+    if not p.get("included"):
+        return (
+            "skill_match: skills index suppressed for this turn "
+            "(ANSWER_FROM_CONTEXT or scheduler turn)"
+        )
+    match = p.get("skill_match")
+    if match is None:
+        n = int(p.get("n_skills") or 0)
+        return (
+            f"skill_match: skills index exposed ({n} skill(s)); "
+            "no per-turn match — model selects via skill_view "
+            "(progressive disclosure)"
+        )
+    return (
+        f"skill_match: matched {match.get('skill_name')!r} "
+        f"on trigger {match.get('trigger')!r} "
+        f"(similarity={match.get('similarity_score')})"
+    )
+
+
+def _explain_last_n_turns(p: dict[str, Any]) -> str:
+    if p.get("isolated"):
+        return "last_n_turns: isolated turn — no working-memory history included"
+    n = int(p.get("last_n_turns") or 0)
+    msgs = int(p.get("n_messages") or 0)
+    limit = int(p.get("limit") or 0)
+    return (
+        f"last_n_turns: included {n} turn(s) ({msgs} messages) "
+        f"capped at limit={limit} from working memory"
+    )
+
+
+def _explain_default(p: dict[str, Any]) -> str:
+    sel = p.get("selector") or "selector"
+    return f"{sel}: provenance present"
+
+
+_EXPLAINERS = {
+    "life_context": _explain_life_context,
+    "capability_block": _explain_capability_block,
+    "retrieved_memory": _explain_retrieved_memory,
+    "skill_match": _explain_skill_match,
+    "last_n_turns": _explain_last_n_turns,
+}

--- a/agent/context/selectors/capability_block.py
+++ b/agent/context/selectors/capability_block.py
@@ -8,10 +8,17 @@ to traces without re-parsing the rendered system prompt.
 It does NOT add a separate string to the prompt — that would duplicate what's
 already in the life-context system prompt. ``content`` is the rendered block
 for diagnostic / test access; the assembler does not concatenate it again.
+
+#33 also emits ``capability_block_version`` — a short stable hash of the
+rendered block. Two turns with the same available-sources state share a
+version; a single capability flipping to ``not configured`` produces a new
+version. The optimizer (#45) uses this to bucket traces by capability
+configuration without storing the full block in every trace row.
 """
 
 from __future__ import annotations
 
+import hashlib
 from typing import Any
 
 from agent.context.types import SelectorRecord
@@ -61,11 +68,20 @@ class CapabilityBlockSelector:
         block = self._cached_block
         available = list(self._cached_available or [])
 
+        # 12-char sha256 prefix of the rendered block. Stable across runs
+        # (the block is deterministic given the same registry state) and
+        # cheap to compute (rendered block is ~1 KB). Treat as opaque —
+        # the optimizer uses it as a bucket key, not a versioning scheme.
+        version_hash = hashlib.sha256(
+            (block or "").encode("utf-8"),
+        ).hexdigest()[:12]
+
         provenance = {
             "selector": self.name,
             "available_sources": sorted(available),
             "block_chars": len(block or ""),
             "registry_present": self._registry is not None,
+            "capability_block_version": version_hash,
         }
         return SelectorRecord(
             name=self.name,

--- a/agent/context/selectors/last_n_turns.py
+++ b/agent/context/selectors/last_n_turns.py
@@ -36,11 +36,18 @@ class LastNTurnsSelector:
                 history = []
 
         roles = [m.get("role") for m in history if isinstance(m, dict)]
+        # ``last_n_turns`` (#33 required key) is the number of conversation
+        # *turns* — not raw messages. A turn is a (user, assistant) pair, so
+        # we floor-divide message count by 2 (rounded up to capture trailing
+        # user-only turns). ``n_messages`` and ``limit`` stay for richer
+        # inspection.
+        n_turns = (len(history) + 1) // 2
         provenance = {
             "selector": self.name,
             "limit": limit,
             "isolated": isolated,
             "n_messages": len(history),
+            "last_n_turns": n_turns,
             "role_counts": {
                 "user": sum(1 for r in roles if r == "user"),
                 "assistant": sum(1 for r in roles if r == "assistant"),

--- a/agent/context/selectors/life_context.py
+++ b/agent/context/selectors/life_context.py
@@ -100,11 +100,18 @@ class LifeContextSelector:
         sections = self._cached_sections or {}
         owner = self._cached_owner_name or ""
 
+        # ``build_system_prompt`` embeds the entire ``life_context.md`` body
+        # verbatim into the system prompt — every section parsed from the
+        # file is therefore "used". ``life_context_sections_used`` (the #33
+        # required key) is the same list as ``sections_loaded``; we emit
+        # both so legacy consumers of ``sections_loaded`` keep working.
+        section_names = sorted(sections.keys())
         provenance = {
             "selector": self.name,
             "life_context_path": self._life_context_path,
             "owner_name": owner,
-            "sections_loaded": sorted(sections.keys()),
+            "sections_loaded": section_names,
+            "life_context_sections_used": section_names,
             "section_count": len(sections),
             "system_prompt_chars": len(self._cached_prompt or ""),
         }

--- a/agent/context/selectors/retrieved_memory.py
+++ b/agent/context/selectors/retrieved_memory.py
@@ -8,9 +8,18 @@ itself.
 
 The selector's value is in normalising the result + carrying provenance,
 not in re-doing the fetch.
+
+#33 adds structured memory IDs to provenance so traces can answer "which
+memories did the model see, with what score?". The selector accepts
+``memory_records`` — a list of result dicts from ``MemoryManager`` —
+alongside the rendered string. Privacy: only IDs and scores travel into
+provenance; raw memory text never appears here (it's already in the
+trace's ``input``/``output`` to the extent that matters).
 """
 
 from __future__ import annotations
+
+from typing import Any
 
 from agent.context.types import SelectorRecord
 
@@ -18,12 +27,40 @@ from agent.context.types import SelectorRecord
 class RetrievedMemorySelector:
     name = "retrieved_memory"
 
-    def select(self, memory_context: str) -> SelectorRecord:
+    def select(
+        self,
+        memory_context: str,
+        memory_records: list[dict[str, Any]] | None = None,
+    ) -> SelectorRecord:
         content = memory_context or ""
+        records = memory_records or []
+
+        memory_ids: list[list[Any]] = []
+        for row in records:
+            if not isinstance(row, dict):
+                continue
+            rid = row.get("id")
+            if rid is None:
+                continue
+            # Score may be under ``score`` (RRF / blended) or ``sim``
+            # (pure semantic). Prefer ``score`` so ranked-list semantics
+            # match what the retrieval layer surfaces. Cast to float and
+            # default to 0.0 so the JSONB shape is stable.
+            score = row.get("score")
+            if score is None:
+                score = row.get("sim")
+            try:
+                score_f = float(score) if score is not None else 0.0
+            except (TypeError, ValueError):
+                score_f = 0.0
+            memory_ids.append([str(rid), score_f])
+
         provenance = {
             "selector": self.name,
             "chars": len(content),
             "present": bool(content),
+            "memory_ids": memory_ids,
+            "n_memories": len(memory_ids),
         }
         return SelectorRecord(
             name=self.name,

--- a/agent/context/selectors/skill_match.py
+++ b/agent/context/selectors/skill_match.py
@@ -31,6 +31,12 @@ class SkillMatchSelector:
                 "included": False,
                 "n_skills": 0,
                 "skill_names": [],
+                # #33 required key. ``None`` when no skill was matched —
+                # progressive disclosure means the model picks skills via
+                # ``skill_view``; there is no per-turn similarity match
+                # yet. Setting null here keeps the trace shape stable so
+                # JSONB queries (``skill_match IS NULL``) work uniformly.
+                "skill_match": None,
             }
             return SelectorRecord(
                 name=self.name,
@@ -53,6 +59,12 @@ class SkillMatchSelector:
             "n_skills": len(skills),
             "skill_names": sorted(names),
             "index_chars": len(index),
+            # See note above. The skills system uses progressive disclosure
+            # so there's no top-1 match to record — the model decides via
+            # ``skill_view``. When a future trigger/similarity matcher
+            # lands, populate this with ``{"skill_name", "trigger",
+            # "similarity_score"}``.
+            "skill_match": None,
         }
         return SelectorRecord(
             name=self.name,

--- a/agent/context/types.py
+++ b/agent/context/types.py
@@ -40,6 +40,13 @@ class Turn:
     # Pre-fetched contexts (already strings — the caller fetched them in
     # parallel via gather()). Empty string means "skip / don't include".
     memory_context: str = ""
+    # Structured memory rows that produced ``memory_context``. Optional
+    # because not every code path threads them (e.g. legacy callers, or
+    # tests that hand-roll a memory string). When populated, each row
+    # SHOULD carry at minimum ``id`` and ``score`` (or ``sim``) so the
+    # provenance writer can emit ``memory_ids`` per #33. Privacy: only
+    # IDs and scores travel into provenance — never raw memory text.
+    memory_records: list[dict[str, Any]] = field(default_factory=list)
     web_context: str = ""
     routing_context: str = ""
     calendar_context: str = ""
@@ -95,14 +102,60 @@ class AssembledContext:
     selectors: dict[str, SelectorRecord] = field(default_factory=dict)
 
     @property
-    def provenance(self) -> dict[str, dict[str, Any]]:
-        """JSON-serializable provenance map, keyed by selector name.
+    def provenance(self) -> dict[str, Any]:
+        """JSON-serializable provenance map for trace persistence.
 
-        Each value is the raw provenance dict the selector emitted. #33 will
-        attach this to traces so we can answer "why did the model see X?"
-        offline.
+        Issue #33 specifies five required top-level fields that downstream
+        consumers (reflector, optimizer, JSONB queries) rely on:
+
+        - ``life_context_sections_used``: list[str]
+        - ``last_n_turns``: int
+        - ``memory_ids``: list[[uuid_str, score_float]]
+        - ``skill_match``: dict | None
+        - ``capability_block_version``: str
+
+        These live at the top level so JSONB containment queries
+        (``assembled_context @> '{"skill_match": {"skill_name": "X"}}'``)
+        work without a join. The full per-selector provenance dict is also
+        exposed under ``selectors`` for richer offline inspection.
+
+        Empty selectors must serialize as JSON ``null`` (not be omitted) so
+        the field's presence is itself a stable signal — the persisted
+        shape is consistent across turns regardless of which subsystems
+        contributed.
         """
-        return {name: rec.provenance for name, rec in self.selectors.items()}
+        selectors_view: dict[str, dict[str, Any]] = {
+            name: rec.provenance for name, rec in self.selectors.items()
+        }
+
+        def _get(name: str, key: str, default: Any) -> Any:
+            rec = self.selectors.get(name)
+            if rec is None:
+                return default
+            return rec.provenance.get(key, default)
+
+        # Memory IDs: list of [uuid_str, score_float] pairs. JSON has no
+        # tuple, so we always serialize to 2-element lists.
+        memory_ids_raw = _get("retrieved_memory", "memory_ids", []) or []
+        memory_ids: list[list[Any]] = []
+        for item in memory_ids_raw:
+            if isinstance(item, (list, tuple)) and len(item) >= 2:
+                memory_ids.append([item[0], item[1]])
+
+        skill_match = _get("skill_match", "skill_match", None)
+
+        return {
+            "life_context_sections_used": list(
+                _get("life_context", "life_context_sections_used", [])
+            ),
+            "last_n_turns": int(_get("last_n_turns", "last_n_turns", 0) or 0),
+            "memory_ids": memory_ids,
+            "skill_match": skill_match if skill_match is not None else None,
+            "capability_block_version": str(
+                _get("capability_block", "capability_block_version", "") or ""
+            ),
+            "selectors": selectors_view,
+        }
 
     def render_prompt(self) -> str:
         """Return the final system-prompt string.

--- a/agent/core.py
+++ b/agent/core.py
@@ -2196,9 +2196,12 @@ class PepperCore:
 
             # Epic 01 (#22): emit a `traces` row alongside routing_events.
             # Reads model + tool_calls from the chat_turn_logger snapshot
-            # we already captured. assembled_context stays as a stub
-            # until #33 (E3) plumbs richer provenance through the chat
-            # path. Persistence is fail-soft inside `emit_trace`.
+            # we already captured. #33 (E3): assembled_context now carries
+            # the five required selector decisions
+            # (life_context_sections_used, last_n_turns, memory_ids,
+            # skill_match, capability_block_version) — see
+            # ``AssembledContext.provenance`` for the contract.
+            # Persistence is fail-soft inside `emit_trace`.
             try:
                 from agent.traces import (
                     Archetype as _Archetype,
@@ -2215,6 +2218,14 @@ class PepperCore:
                     archetype=_Archetype.ORCHESTRATOR,
                     scheduler_job_name=scheduler_job_name,
                     data_sensitivity=_DS.LOCAL_ONLY,
+                )
+                # #33: stamp assembler provenance onto the trace builder
+                # so the persisted ``traces.assembled_context`` JSONB
+                # column carries the five required selector decisions
+                # (life_context_sections_used, last_n_turns, memory_ids,
+                # skill_match, capability_block_version) for this turn.
+                tb.set_assembled_context(
+                    (trace_snapshot or {}).get("assembled_context")
                 )
                 # Pull what the existing per-turn logger already captured.
                 model_name = (trace_snapshot or {}).get("model") or ""
@@ -2949,8 +2960,24 @@ class PepperCore:
             # router classifies these as general_chat with low confidence, which
             # would otherwise strip the proactive web fetch.
             _is_explicit_web_search = bool(_EXPLICIT_WEB_SEARCH_RE.search(user_message))
+            # #33: prefer the provenance-aware method when the memory
+            # manager exposes it, so the assembler gets structured rows
+            # for ``memory_ids``. Detection is conservative — ``hasattr``
+            # always returns True for ``MagicMock`` instances that don't
+            # explicitly stub the method, so we also require the
+            # underlying method to be defined on the *class* (or on the
+            # instance via a real attribute). Falls back to the legacy
+            # text-only API otherwise.
+            _memory_cls = type(self.memory)
+            if (
+                hasattr(_memory_cls, "build_context_with_provenance")
+                or "build_context_with_provenance" in getattr(self.memory, "__dict__", {})
+            ):
+                _memory_coro = self.memory.build_context_with_provenance(user_message)
+            else:
+                _memory_coro = self.memory.build_context_for_query(user_message)
             fetch_results = await asyncio.gather(
-                self.memory.build_context_for_query(user_message),
+                _memory_coro,
                 self._maybe_search_web(user_message, skip=(
                     (
                         routing.action_mode == ActionMode.ANSWER_FROM_CONTEXT
@@ -2976,11 +3003,24 @@ class PepperCore:
                 "memory", "web", "routing", "calendar",
                 "email", "imessage", "whatsapp", "slack",
             )
+            # Memory now returns ``(text, rows)``; everything else is a
+            # plain string. Normalise both shapes into a string list and
+            # surface the rows separately for #33 provenance.
+            memory_records: list[dict] = []
             unpacked: list[str] = []
             for label, res in zip(labels, fetch_results):
                 if isinstance(res, Exception):
                     chat_logger.warning("proactive_fetch_failed", source=label, error=str(res))
                     unpacked.append("")
+                    continue
+                if label == "memory":
+                    if isinstance(res, tuple) and len(res) == 2:
+                        text, rows = res
+                        unpacked.append(text or "")
+                        memory_records = list(rows or [])
+                    else:
+                        # Defensive: unexpected return shape — degrade to text-only.
+                        unpacked.append(res or "")
                 else:
                     unpacked.append(res or "")
             (
@@ -3012,6 +3052,7 @@ class PepperCore:
             memory_context = web_context = routing_context = ""
             calendar_context = email_context = ""
             imessage_context = whatsapp_context = slack_context = ""
+            memory_records = []
             model = f"local/{self.config.DEFAULT_LOCAL_MODEL}"
 
         chat_logger.info(
@@ -3055,6 +3096,10 @@ class PepperCore:
                 isolated=isolated,
                 history_limit=_history_limit,
                 memory_context=memory_context,
+                # #33: thread structured memory rows so RetrievedMemorySelector
+                # can emit ``memory_ids`` for trace provenance. Empty on the
+                # fast path (no proactive fetch).
+                memory_records=memory_records,
                 web_context=web_context,
                 routing_context=routing_context,
                 calendar_context=calendar_context,

--- a/agent/memory.py
+++ b/agent/memory.py
@@ -508,12 +508,31 @@ class MemoryManager:
         Search recall and archival for relevant memories.
         Returns a formatted context block to prepend to LLM calls.
         """
+        text, _records = await self.build_context_with_provenance(query)
+        return text
+
+    async def build_context_with_provenance(
+        self, query: str
+    ) -> tuple[str, list[dict]]:
+        """Same as ``build_context_for_query`` but also returns the rows.
+
+        Issue #33 needs structured memory IDs and scores in trace
+        provenance. Splitting the text-rendering and the result list
+        keeps the existing string contract for legacy callers while
+        giving the assembler / chat path the raw rows it needs to
+        emit ``memory_ids``.
+
+        Privacy: callers must NOT log the returned rows' ``content``
+        — only ``id`` and ``score`` belong in provenance. The rendered
+        text is the only sanctioned place ``content`` flows into the
+        LLM context.
+        """
         recall_results = await self.search_recall(query, limit=5)
         archival_results = await self.search_archival(query, limit=3)
 
         all_results = recall_results + archival_results
         if not all_results:
-            return ""
+            return "", []
 
         lines = ["[Relevant memories from your history]"]
         for r in all_results:
@@ -528,7 +547,7 @@ class MemoryManager:
             lines.append(f"• {r['content']}{age}")
         lines.append("[End memories]")
 
-        return "\n".join(lines)
+        return "\n".join(lines), all_results
 
     # ─── Admin ────────────────────────────────────────────────────────────────
 

--- a/agent/traces/emitter.py
+++ b/agent/traces/emitter.py
@@ -114,6 +114,21 @@ class TraceBuilder:
             raise TypeError("assembled_context must be a dict")
         self.assembled_context = assembled_context
 
+    def set_assembled_context(
+        self, assembled_context: dict[str, Any] | None
+    ) -> None:
+        """Stamp the per-turn assembler provenance for #33.
+
+        Thin alias around :meth:`set_context` that tolerates ``None``
+        (no assembler ran for this turn — e.g. early-bail paths).
+        Empty / ``None`` becomes ``{}`` so the dataclass invariant holds
+        and the persisted JSONB column is consistent.
+        """
+        if assembled_context is None:
+            self.assembled_context = {}
+            return
+        self.set_context(assembled_context)
+
     def set_model(
         self,
         model_selected: str,

--- a/tests/agent/context/test_assembler.py
+++ b/tests/agent/context/test_assembler.py
@@ -74,7 +74,17 @@ def test_assemble_returns_messages_and_provenance(tmp_path: Path) -> None:
     assert len(msgs) == 1 + 2  # system + 2 history entries
 
     prov = asm_ctx.provenance
-    # All five named selectors must report provenance.
+    # #33: top-level provenance carries the five required keys.
+    for required in (
+        "life_context_sections_used",
+        "last_n_turns",
+        "memory_ids",
+        "skill_match",
+        "capability_block_version",
+    ):
+        assert required in prov, f"missing top-level provenance key {required}"
+    # Per-selector detail still lives under ``selectors``.
+    selectors = prov["selectors"]
     for name in (
         "life_context",
         "capability_block",
@@ -82,7 +92,7 @@ def test_assemble_returns_messages_and_provenance(tmp_path: Path) -> None:
         "skill_match",
         "last_n_turns",
     ):
-        assert name in prov, f"missing provenance for {name}"
+        assert name in selectors, f"missing provenance for {name}"
 
 
 def test_isolated_turn_drops_history(tmp_path: Path) -> None:

--- a/tests/agent/context/test_capability_block_version.py
+++ b/tests/agent/context/test_capability_block_version.py
@@ -1,0 +1,60 @@
+"""Issue #33: capability_block_version is a stable hash that changes when the
+underlying capability registry state changes."""
+from __future__ import annotations
+
+from agent.context.selectors import CapabilityBlockSelector
+
+
+class _Status:
+    AVAILABLE = "available"
+    NOT_CONFIGURED = "not_configured"
+
+
+class _StubRegistry:
+    """Minimal duck-typed registry for the selector."""
+
+    def __init__(self, available: list[str]) -> None:
+        self._available = list(available)
+        # Ensure ``get_status`` returns AVAILABLE for these keys, anything
+        # else falls back to NOT_CONFIGURED. ``build_capability_block``
+        # uses these statuses to render notes; the selector hashes the
+        # result.
+        from agent.capability_registry import CapabilityStatus
+
+        self._statuses = {k: CapabilityStatus.AVAILABLE for k in available}
+
+    def get_status(self, key: str):
+        from agent.capability_registry import CapabilityStatus
+
+        return self._statuses.get(key, CapabilityStatus.NOT_CONFIGURED)
+
+    def get_available_sources(self) -> list[str]:
+        return list(self._available)
+
+    def get(self, key: str):
+        return None
+
+
+def test_version_is_stable_when_registry_unchanged() -> None:
+    sel = CapabilityBlockSelector(capability_registry=None)
+    a = sel.select().provenance["capability_block_version"]
+    sel.refresh()
+    b = sel.select().provenance["capability_block_version"]
+    assert a == b
+    assert isinstance(a, str)
+    assert len(a) == 12  # 12-char hash prefix
+
+
+def test_version_changes_when_registry_changes() -> None:
+    sel_a = CapabilityBlockSelector(capability_registry=_StubRegistry(["calendar_google"]))
+    sel_b = CapabilityBlockSelector(capability_registry=_StubRegistry(["whatsapp"]))
+    va = sel_a.select().provenance["capability_block_version"]
+    vb = sel_b.select().provenance["capability_block_version"]
+    assert va != vb
+
+
+def test_version_is_lowercase_hex() -> None:
+    sel = CapabilityBlockSelector(capability_registry=None)
+    v = sel.select().provenance["capability_block_version"]
+    int(v, 16)  # raises if not valid hex
+    assert v.lower() == v

--- a/tests/agent/context/test_decisions.py
+++ b/tests/agent/context/test_decisions.py
@@ -1,0 +1,111 @@
+"""Issue #33: ``agent.context.decisions.annotate`` produces a string per
+selector explaining why each selection happened."""
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+from zoneinfo import ZoneInfo
+
+from agent.context import ContextAssembler, Turn, annotate
+
+
+class _StubConfig:
+    OWNER_NAME = "Tester"
+    LIFE_CONTEXT_PATH = ""
+    TIMEZONE = "UTC"
+    WEEKLY_REVIEW_DAY = 6
+    WEEKLY_REVIEW_HOUR = 9
+    MORNING_BRIEF_HOUR = 6
+    MORNING_BRIEF_MINUTE = 30
+
+
+class _StubMemory:
+    def __init__(self, history: list[dict]) -> None:
+        self._history = history
+
+    def get_working_memory(self, *, limit: int) -> list[dict]:
+        return list(self._history[-limit:])
+
+
+def _ctx(tmp_path: Path, **turn_kwargs):
+    p = tmp_path / "life_context.md"
+    p.write_text(
+        "## Owner\nName: Tester\n\n## Children\nThree kids.\n",
+        encoding="utf-8",
+    )
+    cfg = _StubConfig()
+    cfg.LIFE_CONTEXT_PATH = str(p)
+    asm = ContextAssembler(
+        life_context_path=str(p),
+        config=cfg,
+        capability_registry=None,
+        memory_manager=_StubMemory(turn_kwargs.pop("history", [])),
+        skills_provider=lambda: [],
+        timezone="UTC",
+    )
+    fixed_now = datetime(2026, 5, 2, 12, 0, tzinfo=ZoneInfo("UTC"))
+    turn = Turn(user_message="hi", now_override=fixed_now, **turn_kwargs)
+    return asm.assemble(turn)
+
+
+def test_annotate_returns_one_string_per_selector(tmp_path: Path) -> None:
+    ctx = _ctx(tmp_path)
+    notes = annotate(ctx)
+    for selector_name in (
+        "life_context",
+        "capability_block",
+        "retrieved_memory",
+        "skill_match",
+        "last_n_turns",
+    ):
+        assert selector_name in notes
+        assert isinstance(notes[selector_name], str)
+        assert notes[selector_name]  # non-empty
+
+
+def test_annotate_mentions_section_count(tmp_path: Path) -> None:
+    ctx = _ctx(tmp_path)
+    notes = annotate(ctx)
+    # Two ## headings in the test fixture → "2 section(s)".
+    assert "2 section" in notes["life_context"]
+
+
+def test_annotate_isolated_turn(tmp_path: Path) -> None:
+    ctx = _ctx(tmp_path, isolated=True, history=[{"role": "user", "content": "x"}])
+    notes = annotate(ctx)
+    assert "isolated" in notes["last_n_turns"].lower()
+
+
+def test_annotate_no_memory_hits(tmp_path: Path) -> None:
+    ctx = _ctx(tmp_path, memory_context="", memory_records=[])
+    notes = annotate(ctx)
+    assert "no recall hits" in notes["retrieved_memory"]
+
+
+def test_annotate_with_memory_hits(tmp_path: Path) -> None:
+    ctx = _ctx(
+        tmp_path,
+        memory_context="MEMORY",
+        memory_records=[
+            {"id": "a", "score": 0.9},
+            {"id": "b", "score": 0.5},
+        ],
+    )
+    notes = annotate(ctx)
+    assert "memory ID" in notes["retrieved_memory"]
+
+
+def test_annotate_skills_index_suppressed(tmp_path: Path) -> None:
+    ctx = _ctx(tmp_path, include_skills_index=False)
+    notes = annotate(ctx)
+    assert "suppressed" in notes["skill_match"]
+
+
+def test_annotate_robust_to_garbage_provenance(tmp_path: Path) -> None:
+    """Annotation is a debug aid — never raise on a bad provenance dict."""
+    from agent.context.decisions import _explain
+    from agent.context.types import SelectorRecord
+
+    rec = SelectorRecord(name="life_context", content="", provenance={"x": object()})
+    out = _explain("life_context", rec)
+    assert isinstance(out, str)

--- a/tests/agent/context/test_memory_ids.py
+++ b/tests/agent/context/test_memory_ids.py
@@ -1,0 +1,75 @@
+"""Issue #33: memory_ids round-trip from MemoryManager rows into provenance."""
+from __future__ import annotations
+
+import json
+
+from agent.context.selectors import RetrievedMemorySelector
+
+
+def test_no_records_yields_empty_list() -> None:
+    sel = RetrievedMemorySelector()
+    rec = sel.select("ctx", memory_records=[])
+    assert rec.provenance["memory_ids"] == []
+    assert rec.provenance["n_memories"] == 0
+
+
+def test_each_pair_is_list_of_uuid_str_and_float() -> None:
+    rows = [
+        {"id": "a1", "score": 0.91},
+        {"id": "b2", "sim": 0.42},
+    ]
+    sel = RetrievedMemorySelector()
+    rec = sel.select("ctx", memory_records=rows)
+    pairs = rec.provenance["memory_ids"]
+    assert len(pairs) == 2
+    for pair in pairs:
+        assert isinstance(pair, list)
+        assert len(pair) == 2
+        uid, score = pair
+        assert isinstance(uid, str)
+        assert isinstance(score, float)
+
+
+def test_score_preferred_over_sim() -> None:
+    """If a row has both ``score`` and ``sim``, the blended ``score`` wins."""
+    rows = [{"id": "x", "score": 0.9, "sim": 0.1}]
+    sel = RetrievedMemorySelector()
+    pairs = sel.select("ctx", memory_records=rows).provenance["memory_ids"]
+    assert pairs[0][1] == 0.9
+
+
+def test_missing_id_skipped() -> None:
+    rows = [{"score": 0.9}, {"id": "valid", "score": 0.5}]
+    sel = RetrievedMemorySelector()
+    pairs = sel.select("ctx", memory_records=rows).provenance["memory_ids"]
+    assert len(pairs) == 1
+    assert pairs[0][0] == "valid"
+
+
+def test_pairs_are_json_serialisable() -> None:
+    rows = [{"id": "a", "score": 0.5}]
+    sel = RetrievedMemorySelector()
+    rec = sel.select("ctx", memory_records=rows)
+    j = json.loads(json.dumps(rec.provenance))
+    # JSON has no tuple — confirm we get a 2-element array.
+    assert j["memory_ids"][0] == ["a", 0.5]
+
+
+def test_no_raw_content_in_provenance() -> None:
+    """Privacy: the raw memory ``content`` must NOT travel into provenance."""
+    rows = [
+        {"id": "a", "content": "SUPER_SECRET_PERSONAL_DATA", "score": 0.5},
+    ]
+    sel = RetrievedMemorySelector()
+    rec = sel.select("ctx", memory_records=rows)
+    serialised = json.dumps(rec.provenance)
+    assert "SUPER_SECRET_PERSONAL_DATA" not in serialised
+
+
+def test_legacy_call_without_memory_records_still_works() -> None:
+    """Backward-compat: callers that don't thread structured rows still get a
+    populated content block, just no memory_ids."""
+    sel = RetrievedMemorySelector()
+    rec = sel.select("MEMORY_BLOCK")
+    assert rec.content == "MEMORY_BLOCK"
+    assert rec.provenance["memory_ids"] == []

--- a/tests/agent/context/test_provenance_shape.py
+++ b/tests/agent/context/test_provenance_shape.py
@@ -1,0 +1,187 @@
+"""Issue #33: assert AssembledContext.provenance carries the five required keys.
+
+The reflector (#39) and optimizer (#45) both consume this map. The contract
+they rely on:
+
+- ``life_context_sections_used: list[str]``
+- ``last_n_turns: int``
+- ``memory_ids: list[[uuid_str, score_float]]``
+- ``skill_match: dict | None``
+- ``capability_block_version: str``
+
+Empty selectors (no skill match, no memory hits) must still surface their
+key — as ``[]``, ``0``, ``None``, etc. — so JSONB queries can rely on the
+field's presence.
+"""
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from agent.context import ContextAssembler, Turn
+
+
+class _StubConfig:
+    OWNER_NAME = "Tester"
+    LIFE_CONTEXT_PATH = ""
+    TIMEZONE = "UTC"
+    WEEKLY_REVIEW_DAY = 6
+    WEEKLY_REVIEW_HOUR = 9
+    MORNING_BRIEF_HOUR = 6
+    MORNING_BRIEF_MINUTE = 30
+
+
+class _StubMemory:
+    def __init__(self, history: list[dict]) -> None:
+        self._history = history
+
+    def get_working_memory(self, *, limit: int) -> list[dict]:
+        return list(self._history[-limit:])
+
+
+def _life_context_path(tmp_path: Path) -> str:
+    p = tmp_path / "life_context.md"
+    p.write_text(
+        "## Owner\nName: Tester\n\n## Children\nThree kids.\n",
+        encoding="utf-8",
+    )
+    return str(p)
+
+
+def _assemble(
+    tmp_path: Path,
+    *,
+    history: list[dict] | None = None,
+    memory_context: str = "",
+    memory_records: list[dict] | None = None,
+    isolated: bool = False,
+    include_skills_index: bool = False,
+) -> dict:
+    cfg = _StubConfig()
+    cfg.LIFE_CONTEXT_PATH = _life_context_path(tmp_path)
+    asm = ContextAssembler(
+        life_context_path=cfg.LIFE_CONTEXT_PATH,
+        config=cfg,
+        capability_registry=None,
+        memory_manager=_StubMemory(history or []),
+        skills_provider=lambda: [],
+        timezone="UTC",
+    )
+    fixed_now = datetime(2026, 5, 2, 12, 0, tzinfo=ZoneInfo("UTC"))
+    turn = Turn(
+        user_message="hi",
+        memory_context=memory_context,
+        memory_records=memory_records or [],
+        isolated=isolated,
+        include_skills_index=include_skills_index,
+        now_override=fixed_now,
+    )
+    return asm.assemble(turn).provenance
+
+
+def test_provenance_has_five_required_keys(tmp_path: Path) -> None:
+    prov = _assemble(tmp_path)
+    for k in (
+        "life_context_sections_used",
+        "last_n_turns",
+        "memory_ids",
+        "skill_match",
+        "capability_block_version",
+    ):
+        assert k in prov, f"missing required provenance key: {k}"
+
+
+def test_required_keys_have_expected_types(tmp_path: Path) -> None:
+    prov = _assemble(tmp_path)
+    assert isinstance(prov["life_context_sections_used"], list)
+    assert all(isinstance(s, str) for s in prov["life_context_sections_used"])
+    assert isinstance(prov["last_n_turns"], int)
+    assert isinstance(prov["memory_ids"], list)
+    # skill_match may be dict OR None (empty selector → None)
+    assert prov["skill_match"] is None or isinstance(prov["skill_match"], dict)
+    assert isinstance(prov["capability_block_version"], str)
+
+
+def test_empty_skill_match_serialises_as_null_not_missing(tmp_path: Path) -> None:
+    """Empty selector → JSON null, not absent. JSONB queries depend on this."""
+    prov = _assemble(tmp_path, include_skills_index=False)
+    assert "skill_match" in prov
+    assert prov["skill_match"] is None
+    # And JSON-serialised null is JSON null.
+    j = json.loads(json.dumps(prov))
+    assert j["skill_match"] is None
+
+
+def test_empty_memory_ids_is_empty_list(tmp_path: Path) -> None:
+    prov = _assemble(tmp_path, memory_context="", memory_records=[])
+    assert prov["memory_ids"] == []
+
+
+def test_memory_ids_threaded_through(tmp_path: Path) -> None:
+    rows = [
+        {"id": "11111111-1111-1111-1111-111111111111", "score": 0.91},
+        {"id": "22222222-2222-2222-2222-222222222222", "sim": 0.42},
+    ]
+    prov = _assemble(
+        tmp_path,
+        memory_context="MEMORY",
+        memory_records=rows,
+    )
+    assert len(prov["memory_ids"]) == 2
+    for pair in prov["memory_ids"]:
+        assert isinstance(pair, list)
+        assert len(pair) == 2
+        uid, score = pair
+        assert isinstance(uid, str)
+        assert isinstance(score, float)
+
+
+def test_isolated_turn_reports_zero_turns(tmp_path: Path) -> None:
+    prov = _assemble(
+        tmp_path,
+        history=[{"role": "user", "content": "x"}],
+        isolated=True,
+    )
+    assert prov["last_n_turns"] == 0
+
+
+def test_last_n_turns_counts_pairs(tmp_path: Path) -> None:
+    history = [
+        {"role": "user", "content": "a"},
+        {"role": "assistant", "content": "b"},
+        {"role": "user", "content": "c"},
+        {"role": "assistant", "content": "d"},
+    ]
+    prov = _assemble(tmp_path, history=history)
+    assert prov["last_n_turns"] == 2
+
+
+def test_provenance_is_fully_json_serialisable(tmp_path: Path) -> None:
+    prov = _assemble(
+        tmp_path,
+        memory_context="ctx",
+        memory_records=[
+            {"id": "11111111-1111-1111-1111-111111111111", "score": 0.5},
+        ],
+    )
+    # Must round-trip cleanly — the trace JSONB column is the consumer.
+    json.dumps(prov)
+
+
+def test_selectors_view_still_present(tmp_path: Path) -> None:
+    """Top-level keys are the new contract; per-selector detail stays under
+    ``selectors``."""
+    prov = _assemble(tmp_path)
+    assert "selectors" in prov
+    for name in (
+        "life_context",
+        "capability_block",
+        "retrieved_memory",
+        "skill_match",
+        "last_n_turns",
+    ):
+        assert name in prov["selectors"]

--- a/tests/agent/context/test_trace_integration.py
+++ b/tests/agent/context/test_trace_integration.py
@@ -1,0 +1,103 @@
+"""Issue #33: assembler provenance flows into the trace builder.
+
+Checks the wire-up between :class:`ContextAssembler`, the chat-turn logger
+and :class:`TraceBuilder`. The full ``PepperCore.chat`` path is heavy to
+exercise in unit tests; this test reproduces the relevant subset:
+
+1. assemble a turn → get provenance
+2. stamp it onto the chat-turn-logger trace dict (matches core.py)
+3. snapshot the trace dict
+4. feed it to ``TraceBuilder.set_assembled_context``
+5. finalise the trace
+6. assert the persisted ``Trace.assembled_context`` carries all five
+   required keys with the expected types.
+"""
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+from zoneinfo import ZoneInfo
+
+from agent import chat_turn_logger
+from agent.context import ContextAssembler, Turn
+from agent.traces.emitter import TraceBuilder
+
+
+class _StubConfig:
+    OWNER_NAME = "Tester"
+    LIFE_CONTEXT_PATH = ""
+    TIMEZONE = "UTC"
+    WEEKLY_REVIEW_DAY = 6
+    WEEKLY_REVIEW_HOUR = 9
+    MORNING_BRIEF_HOUR = 6
+    MORNING_BRIEF_MINUTE = 30
+
+
+class _StubMemory:
+    def get_working_memory(self, *, limit: int) -> list[dict]:
+        return []
+
+
+def _life_context_path(tmp_path: Path) -> str:
+    p = tmp_path / "life_context.md"
+    p.write_text(
+        "## Owner\nName: Tester\n\n## Children\nThree kids.\n",
+        encoding="utf-8",
+    )
+    return str(p)
+
+
+def test_provenance_flows_into_trace(tmp_path: Path) -> None:
+    cfg = _StubConfig()
+    cfg.LIFE_CONTEXT_PATH = _life_context_path(tmp_path)
+    asm = ContextAssembler(
+        life_context_path=cfg.LIFE_CONTEXT_PATH,
+        config=cfg,
+        capability_registry=None,
+        memory_manager=_StubMemory(),
+        skills_provider=lambda: [],
+        timezone="UTC",
+    )
+    fixed_now = datetime(2026, 5, 2, 12, 0, tzinfo=ZoneInfo("UTC"))
+    turn = Turn(
+        user_message="what's up",
+        memory_context="MEMORY_BLOCK",
+        memory_records=[
+            {"id": "11111111-1111-1111-1111-111111111111", "score": 0.7},
+        ],
+        now_override=fixed_now,
+    )
+
+    chat_turn_logger.start_turn()
+    assembled = asm.assemble(turn)
+    chat_turn_logger.record_assembled_context(assembled.provenance)
+
+    trace_snapshot = dict(chat_turn_logger.get_trace() or {})
+    assert trace_snapshot.get("assembled_context") is not None
+
+    tb = TraceBuilder.start(input="what's up")
+    tb.set_assembled_context(trace_snapshot.get("assembled_context"))
+    trace = tb.finish(output="ok", latency_ms=10)
+
+    ctx = trace.assembled_context
+    # All five required fields present and typed.
+    assert isinstance(ctx["life_context_sections_used"], list)
+    assert ctx["life_context_sections_used"]  # non-empty for our fixture
+    assert isinstance(ctx["last_n_turns"], int)
+    assert isinstance(ctx["memory_ids"], list)
+    assert ctx["memory_ids"] == [
+        ["11111111-1111-1111-1111-111111111111", 0.7],
+    ]
+    # No skill match in this turn — must be JSON null, not absent.
+    assert "skill_match" in ctx
+    assert ctx["skill_match"] is None
+    assert isinstance(ctx["capability_block_version"], str)
+    assert len(ctx["capability_block_version"]) == 12
+
+
+def test_set_assembled_context_tolerates_none() -> None:
+    """A turn that bailed before assembly stamps ``None`` — must not crash."""
+    tb = TraceBuilder.start(input="x")
+    tb.set_assembled_context(None)
+    trace = tb.finish(output="y", latency_ms=1)
+    assert trace.assembled_context == {}


### PR DESCRIPTION
## Summary
Wires the assembler's provenance from #32 into the trace store so every assembly decision is inspectable. Lays the data substrate for #34 (UI inspector), #39 (reflector), and #45 (optimizer).

- Hoists the five required fields to the top level of `AssembledContext.provenance`: `life_context_sections_used`, `last_n_turns`, `memory_ids`, `skill_match`, `capability_block_version`. Empty selectors serialize as `null`/`[]`/`0`/`""` (always present, never omitted).
- `MemoryManager.build_context_with_provenance(...)` returns `(text, rows)` so structured `[uuid, score]` pairs reach the selector. Legacy `build_context_for_query` retained for backward compatibility.
- New `TraceBuilder.set_assembled_context(provenance)` (`agent/traces/emitter.py`) wired in `core.chat()` (`agent/core.py:2228`), populating the existing `traces.assembled_context` JSONB column (already shipped in #20 — no migration needed).
- `agent/context/decisions.py` exports `annotate(context) -> dict[str, str]` with human-readable selection reasons (consumed by #34's UI panel).
- Privacy: provenance carries IDs, scores, section names, and a 12-char sha256 hash only — never raw memory bodies, never section text. Locked by `test_no_raw_content_in_provenance`.

## Test plan
- [x] 56/56 `tests/agent/context/` pass (28 from #32 + 28 new)
- [x] `test_provenance_shape.py` locks types, JSON round-trip, and null-vs-omitted for each field
- [x] `test_memory_ids.py` confirms `[uuid_str, score_float]` pairs are JSON-serializable
- [x] `test_capability_block_version.py` confirms hash is stable when registry unchanged and changes when it changes
- [x] `test_decisions.py` covers annotate() per selector
- [x] `test_trace_integration.py` round-trips real assembler → chat_turn_logger → TraceBuilder → persisted Trace
- [x] No new dependencies; no cross-subsystem imports; no new network calls
- [x] Detail trace endpoint exposing `assembled_context` rides the same `require_api_key` gate as input/output (auth surface unchanged)

Closes #33