### PR TITLE
ui: trace context inspector panel (#34)

### DIFF
--- a/agent/context/__init__.py
+++ b/agent/context/__init__.py
@@ -10,7 +10,7 @@ See ``agent/context/assembler.py`` for the rendering contract and
 """
 
 from agent.context.assembler import ContextAssembler
-from agent.context.decisions import annotate
+from agent.context.decisions import annotate, annotate_from_provenance
 from agent.context.grounding_rules import render_grounding_rules
 from agent.context.types import AssembledContext, SelectorRecord, Turn
 
@@ -20,5 +20,6 @@ __all__ = [
     "SelectorRecord",
     "Turn",
     "annotate",
+    "annotate_from_provenance",
     "render_grounding_rules",
 ]

--- a/agent/context/decisions.py
+++ b/agent/context/decisions.py
@@ -35,6 +35,38 @@ def annotate(context: AssembledContext) -> dict[str, str]:
     return out
 
 
+def annotate_from_provenance(
+    selectors_dict: dict[str, dict[str, Any]],
+) -> dict[str, str]:
+    """Same as :func:`annotate` but operates on the persisted provenance dict.
+
+    Trace rows store the assembler's provenance as a JSON-serializable
+    map under ``assembled_context["selectors"]`` (per #33). The HTTP
+    layer needs to render the same human-readable reasons against those
+    stored shapes without reconstructing a live :class:`AssembledContext`.
+
+    This is the public, stable API. Callers should NOT reach into the
+    private ``_EXPLAINERS`` table — refactors to that table are free to
+    change shape so long as this function's output stays compatible.
+
+    ``selectors_dict`` is the value found at ``assembled_context["selectors"]``
+    on a persisted trace: ``{selector_name: provenance_dict, ...}``.
+    Returns ``{}`` if the input is missing or empty.
+    """
+    if not isinstance(selectors_dict, dict) or not selectors_dict:
+        return {}
+    out: dict[str, str] = {}
+    for name, prov in selectors_dict.items():
+        if not isinstance(prov, dict):
+            continue
+        explainer = _EXPLAINERS.get(name, _explain_default)
+        try:
+            out[name] = explainer(prov)
+        except Exception:
+            out[name] = f"{name}: provenance present"
+    return out
+
+
 def _explain(name: str, record: SelectorRecord) -> str:
     explainer = _EXPLAINERS.get(name, _explain_default)
     try:

--- a/agent/context/selectors/capability_block.py
+++ b/agent/context/selectors/capability_block.py
@@ -82,6 +82,12 @@ class CapabilityBlockSelector:
             "block_chars": len(block or ""),
             "registry_present": self._registry is not None,
             "capability_block_version": version_hash,
+            # #34 — persist the rendered block in provenance so the inspector
+            # can render a real line-by-line diff against the previous trace's
+            # block (not just hash equality). Capability block is system-state
+            # derived (subsystem health, not user content), so storing it is
+            # privacy-neutral.
+            "content": block or "",
         }
         return SelectorRecord(
             name=self.name,

--- a/agent/context/selectors/last_n_turns.py
+++ b/agent/context/selectors/last_n_turns.py
@@ -27,6 +27,7 @@ class LastNTurnsSelector:
     ) -> SelectorRecord:
         if isolated:
             history: list[dict[str, Any]] = []
+            history_with_ts: list[dict[str, Any]] = []
         else:
             try:
                 history = list(self._memory.get_working_memory(limit=limit))
@@ -34,6 +35,20 @@ class LastNTurnsSelector:
                 # Memory layer should never crash a turn — graceful degrade
                 # to empty history matches previous behaviour.
                 history = []
+            # Optional per-turn timestamps (#34) for the inspector. Falls
+            # back to the timestamp-less list when the memory manager
+            # doesn't expose the helper.
+            try:
+                if hasattr(self._memory, "get_working_memory_with_timestamps"):
+                    history_with_ts = list(
+                        self._memory.get_working_memory_with_timestamps(
+                            limit=limit,
+                        )
+                    )
+                else:
+                    history_with_ts = list(history)
+            except Exception:
+                history_with_ts = list(history)
 
         roles = [m.get("role") for m in history if isinstance(m, dict)]
         # ``last_n_turns`` (#33 required key) is the number of conversation
@@ -54,6 +69,12 @@ class LastNTurnsSelector:
                 "system": sum(1 for r in roles if r == "system"),
                 "tool": sum(1 for r in roles if r == "tool"),
             },
+            # #34 — per-turn rows (with timestamps when the memory manager
+            # exposes them) for the inspector. The LLM-facing ``content``
+            # field above stays timestamp-less to keep the prompt small;
+            # this duplicates the rows for inspection. Privacy: same content
+            # already lives in the prompt itself.
+            "content": list(history_with_ts),
         }
         return SelectorRecord(
             name=self.name,

--- a/agent/main.py
+++ b/agent/main.py
@@ -75,6 +75,13 @@ from agent.traces.http import router as _traces_router  # noqa: E402
 
 app.include_router(_traces_router, prefix="/api")
 
+# Epic 01 (#34) — /memories/{id} fetch for the trace inspector's
+# expandable memory rows. Inherits the same auth + localhost-bind posture
+# as /traces (both surface RAW_PERSONAL content over loopback).
+from agent.memory_http import router as _memories_router  # noqa: E402
+
+app.include_router(_memories_router, prefix="/api")
+
 
 class ChatRequest(BaseModel):
     message: str

--- a/agent/memory.py
+++ b/agent/memory.py
@@ -33,6 +33,24 @@ class MemoryManager:
         items = list(self._working)
         return [{"role": m["role"], "content": m["content"]} for m in items[-limit:]]
 
+    def get_working_memory_with_timestamps(self, limit: int = 20) -> list[dict]:
+        """Same as :meth:`get_working_memory` but preserves the ``timestamp``
+        field stored at append time. Used by the trace inspector (#34) to
+        render per-turn timestamps when the data is available — it does
+        NOT replace ``get_working_memory`` because the LLM-facing prompt
+        history doesn't need timestamps and stripping them keeps the
+        prompt smaller.
+        """
+        items = list(self._working)
+        return [
+            {
+                "role": m.get("role"),
+                "content": m.get("content"),
+                "timestamp": m.get("timestamp"),
+            }
+            for m in items[-limit:]
+        ]
+
     def clear_working_memory(self) -> None:
         self._working.clear()
 
@@ -367,6 +385,26 @@ class MemoryManager:
             {**rows_by_id[rid], "score": rrf_scores[rid]}
             for rid in ordered_ids
         ]
+
+    async def get_by_id(self, memory_id: int) -> Optional[MemoryEvent]:
+        """Fetch a single MemoryEvent row by its primary key.
+
+        Returns ``None`` if the row does not exist or the DB factory is
+        unavailable. The full ORM row is returned — callers must take
+        care to expose only the fields they intend (#34's inspector
+        intentionally returns content + metadata, never the embedding).
+        """
+        if not self._db_factory:
+            return None
+        try:
+            async with self._db_factory() as session:
+                result = await session.execute(
+                    select(MemoryEvent).where(MemoryEvent.id == memory_id)
+                )
+                return result.scalar_one_or_none()
+        except Exception as e:
+            logger.error("memory_get_by_id_failed", memory_id=memory_id, error=str(e))
+            return None
 
     async def get_recent_recall(self, days: int = 30) -> list[MemoryEvent]:
         """Fetch recall events from the last N days."""

--- a/agent/memory_http.py
+++ b/agent/memory_http.py
@@ -1,0 +1,145 @@
+"""FastAPI route for fetching a single memory row by id (#34).
+
+Exposes:
+
+- ``GET /api/memories/{memory_id}`` — returns the memory's full content +
+  metadata, gated by ``require_api_key`` and (when the project setting is
+  on) loopback-only enforcement.
+
+**Privacy posture**
+
+Memory rows can contain raw personal content. The route inherits the
+same defence-in-depth as the traces endpoints:
+
+1. **API-key required.**
+2. **Localhost bind by default** (delegated to the same helper used by
+   ``agent/traces/http.py``).
+3. **Audit log on every read.** Records the memory id and action only —
+   never the body.
+
+Why this exists: the trace inspector (#34) lists per-turn memory IDs +
+scores from provenance. Operators want to expand a row and read the
+underlying content without dropping into the database directly.
+"""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Optional
+
+import structlog
+from fastapi import APIRouter, Depends, HTTPException, Request
+from pydantic import BaseModel
+
+from agent.auth import require_api_key
+
+logger = structlog.get_logger(__name__)
+
+router = APIRouter(prefix="/memories", tags=["memories"])
+
+
+class MemoryDetail(BaseModel):
+    id: int
+    type: str
+    content: str
+    summary: Optional[str] = None
+    importance_score: float
+    created_at: datetime
+    accessed_at: Optional[datetime] = None
+    has_embedding: bool
+
+
+async def _audit_read(
+    *,
+    actor_key_hash: str,
+    action: str,
+    detail: dict[str, Any],
+    request: Request,
+) -> None:
+    """Append a one-line audit record. Same shape as traces/http.py.
+
+    NEVER logs the memory content — only metadata (id + action).
+    """
+    try:
+        from agent.mcp_audit import audit_logger as audit
+
+        audit.info(
+            "memories_endpoint_read",
+            actor=actor_key_hash[:12],
+            action=action,
+            client_host=(request.client.host if request.client else "<unknown>"),
+            **detail,
+        )
+    except Exception:
+        # Audit failure must never block a read — same posture as the
+        # rest of the read paths. Swallow.
+        pass
+
+
+@router.get(
+    "/{memory_id}",
+    response_model=MemoryDetail,
+    dependencies=[Depends(require_api_key)],
+)
+async def get_memory_detail(
+    memory_id: int,
+    request: Request,
+) -> MemoryDetail:
+    """Return the full memory row + metadata for ``memory_id``.
+
+    Used by the trace inspector to expand a memory row and show its
+    content. The response body is RAW_PERSONAL — the route inherits
+    localhost-bind enforcement from the traces helper.
+    """
+    # Reuse the loopback enforcement helper from traces/http.py so the two
+    # endpoints share a single policy implementation.
+    from agent.traces.http import _enforce_localhost_bind
+
+    await _enforce_localhost_bind(request)
+
+    try:
+        from agent.main import _get_pepper
+    except Exception as exc:  # pragma: no cover - import guard
+        raise HTTPException(
+            status_code=503,
+            detail=f"pepper not ready: {exc}",
+        ) from exc
+
+    pepper_obj = _get_pepper()
+    if pepper_obj is None:
+        raise HTTPException(status_code=503, detail="pepper not initialized")
+    memory_manager = getattr(pepper_obj, "memory", None)
+    if memory_manager is None:
+        raise HTTPException(
+            status_code=503,
+            detail="memory manager not available on pepper instance",
+        )
+
+    if not hasattr(memory_manager, "get_by_id"):
+        raise HTTPException(
+            status_code=501,
+            detail="memory manager does not implement get_by_id",
+        )
+
+    row = await memory_manager.get_by_id(memory_id)
+    if row is None:
+        raise HTTPException(status_code=404, detail="memory not found")
+
+    api_key = request.headers.get("x-api-key", "")
+    await _audit_read(
+        actor_key_hash=api_key,
+        action="get_memory_detail",
+        # Privacy: log id only — never log the content body.
+        detail={"memory_id": memory_id},
+        request=request,
+    )
+
+    return MemoryDetail(
+        id=row.id,
+        type=row.type,
+        content=row.content,
+        summary=row.summary,
+        importance_score=float(row.importance_score or 0.0),
+        created_at=row.created_at,
+        accessed_at=row.accessed_at,
+        has_embedding=row.embedding is not None,
+    )

--- a/agent/tests/test_traces_http.py
+++ b/agent/tests/test_traces_http.py
@@ -31,7 +31,7 @@ from agent.traces import Archetype, Trace, TraceTier, TriggerSource
 from agent.traces.http import router
 
 
-def _build_app(*, repo_query=None, repo_get=None) -> FastAPI:
+def _build_app(*, repo_query=None, repo_get=None, assembler=None) -> FastAPI:
     """Build a FastAPI app with the traces router and dependency overrides."""
     app = FastAPI()
     app.include_router(router, prefix="/api")
@@ -44,6 +44,16 @@ def _build_app(*, repo_query=None, repo_get=None) -> FastAPI:
 
     app.dependency_overrides[get_db] = _fake_session
     app.dependency_overrides[require_api_key] = _fake_auth
+
+    # #34 — the rerender route depends on the live ContextAssembler. Tests
+    # plug in a stub by overriding ``get_assembler``.
+    if assembler is not None:
+        from agent.traces.http import get_assembler
+
+        def _fake_assembler() -> object:
+            return assembler
+
+        app.dependency_overrides[get_assembler] = _fake_assembler
     return app
 
 
@@ -182,6 +192,63 @@ class TestDetailView:
         assert body["output"] == "world"
         assert body["assembled_context"] == {}
         assert body["has_embedding"] is False
+        # #34 — detail response carries decision_reasons; empty {} when no
+        # provenance was stored (legacy rows or empty assembled_context).
+        assert body["decision_reasons"] == {}
+
+    def test_decision_reasons_populated_from_stored_provenance(self) -> None:
+        # #34 — when provenance was persisted by #33, the detail response
+        # should annotate each named selector with a human-readable reason.
+        app = _build_app()
+        t = _trace(
+            input="hello",
+            output="world",
+            assembled_context={
+                "life_context_sections_used": ["work", "health"],
+                "last_n_turns": 3,
+                "memory_ids": [],
+                "skill_match": None,
+                "capability_block_version": "v1",
+                "selectors": {
+                    "life_context": {
+                        "life_context_sections_used": ["work", "health"],
+                    },
+                    "capability_block": {
+                        "available_sources": ["calendar", "email"],
+                        "capability_block_version": "v1",
+                    },
+                    "retrieved_memory": {"memory_ids": [], "present": False},
+                    "skill_match": {"included": True, "n_skills": 5},
+                    "last_n_turns": {
+                        "isolated": False,
+                        "last_n_turns": 3,
+                        "n_messages": 6,
+                        "limit": 20,
+                    },
+                },
+            },
+        )
+        with patch("agent.traces.http.TraceRepository") as RepoClass, \
+             patch("agent.config.settings") as cfg:
+            cfg.PEPPER_BIND_LOCALHOST_ONLY = False
+            repo = RepoClass.return_value
+            repo.get_by_id = AsyncMock(return_value=t)
+            with TestClient(app) as client:
+                r = client.get(
+                    f"/api/traces/{t.trace_id}", headers={"x-api-key": "k"}
+                )
+        assert r.status_code == 200, r.text
+        reasons = r.json()["decision_reasons"]
+        assert set(reasons.keys()) == {
+            "life_context",
+            "capability_block",
+            "retrieved_memory",
+            "skill_match",
+            "last_n_turns",
+        }
+        # Sanity-check the human strings are non-empty and informative.
+        for v in reasons.values():
+            assert isinstance(v, str) and len(v) > 0
 
     def test_404_when_missing(self) -> None:
         app = _build_app()
@@ -217,6 +284,7 @@ class TestNoMutationRoutes:
             "/traces",
             "/traces/{trace_id}",
             "/traces/{trace_id}/find_similar",
+            "/traces/{trace_id}/rerender-prompt",
         ]
 
 
@@ -256,3 +324,196 @@ class TestFindSimilar:
         body = r.json()
         assert body["matches"][0]["trace_id"] == "11111111-1111-1111-1111-111111111111"
         assert body["matches"][0]["distance"] == pytest.approx(0.12)
+
+
+# ── Rerender prompt (#34) ─────────────────────────────────────────────────────
+
+
+class _StubAssembled:
+    """Minimal stand-in for AssembledContext used by rerender tests."""
+
+    def __init__(self, system_prompt: str, provenance: dict) -> None:
+        self._system_prompt = system_prompt
+        self._provenance = provenance
+
+    def render_prompt(self) -> str:
+        return self._system_prompt
+
+    @property
+    def provenance(self) -> dict:
+        return self._provenance
+
+
+class _StubAssembler:
+    """Returns a deterministic AssembledContext per assemble() call."""
+
+    def __init__(self, system_prompt: str, provenance: dict) -> None:
+        self._system_prompt = system_prompt
+        self._provenance = provenance
+        self.calls: list = []
+
+    def assemble(self, turn) -> _StubAssembled:
+        self.calls.append(turn)
+        return _StubAssembled(self._system_prompt, self._provenance)
+
+
+class TestRerenderPrompt:
+    def test_requires_auth_dependency_wired(self) -> None:
+        # Smoke-test: missing the assembler dep yields a 503 rather than
+        # a 500. Confirms the dependency is wired through the route.
+        app = FastAPI()
+        app.include_router(router, prefix="/api")
+        async def _fake_session():
+            yield "fake"
+        async def _fake_auth():
+            return "k"
+        app.dependency_overrides[get_db] = _fake_session
+        app.dependency_overrides[require_api_key] = _fake_auth
+        with patch("agent.config.settings") as cfg:
+            cfg.PEPPER_BIND_LOCALHOST_ONLY = False
+            # No pepper module global → get_assembler should 503.
+            with patch("agent.main._get_pepper", return_value=None):
+                with TestClient(app) as client:
+                    r = client.post(
+                        f"/api/traces/{uuid.uuid4()}/rerender-prompt",
+                        headers={"x-api-key": "k"},
+                    )
+            assert r.status_code == 503
+
+    def test_returns_prompt_and_structural_match_for_unchanged_provenance(
+        self,
+    ) -> None:
+        # When the assembler reproduces the same provenance shape that's
+        # already on the trace, ``matches_original`` should be True. This
+        # is the deterministic check the issue asks for.
+        provenance = {
+            "life_context_sections_used": ["work"],
+            "last_n_turns": 0,  # volatile - excluded from match
+            "memory_ids": [],
+            "skill_match": None,
+            "capability_block_version": "v1",
+            "selectors": {
+                "life_context": {"life_context_sections_used": ["work"]},
+                "capability_block": {
+                    "available_sources": ["calendar"],
+                    "capability_block_version": "v1",
+                },
+                "retrieved_memory": {"memory_ids": [], "present": False},
+                "skill_match": {"included": True, "n_skills": 1},
+                "last_n_turns": {
+                    "isolated": False,
+                    "last_n_turns": 5,  # volatile drift
+                    "n_messages": 10,
+                    "limit": 20,
+                },
+            },
+        }
+        # Trace stored these earlier with last_n_turns=0 / n_messages=0.
+        stored = dict(provenance)
+        stored["last_n_turns"] = 0
+        stored["selectors"] = dict(provenance["selectors"])
+        stored["selectors"]["last_n_turns"] = {
+            "isolated": False,
+            "last_n_turns": 0,
+            "n_messages": 0,
+            "limit": 20,
+        }
+        t = _trace(input="hi", output="ok", assembled_context=stored)
+        stub = _StubAssembler(system_prompt="SYSTEM_PROMPT_TEXT", provenance=provenance)
+        app = _build_app(assembler=stub)
+        with patch("agent.traces.http.TraceRepository") as RepoClass, \
+             patch("agent.config.settings") as cfg:
+            cfg.PEPPER_BIND_LOCALHOST_ONLY = False
+            repo = RepoClass.return_value
+            repo.get_by_id = AsyncMock(return_value=t)
+            with TestClient(app) as client:
+                r = client.post(
+                    f"/api/traces/{t.trace_id}/rerender-prompt",
+                    headers={"x-api-key": "k"},
+                )
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["trace_id"] == t.trace_id
+        assert body["prompt"] == "SYSTEM_PROMPT_TEXT"
+        assert isinstance(body["prompt_hash"], str)
+        assert len(body["prompt_hash"]) == 64  # sha256 hex
+        assert body["matches_original"] is True
+        assert isinstance(body["notes"], list)
+        assert len(body["notes"]) >= 1
+        # Stub assembler was called exactly once with a Turn carrying the
+        # trace input.
+        assert len(stub.calls) == 1
+        assert stub.calls[0].user_message == "hi"
+
+    def test_returns_diff_when_provenance_diverges(self) -> None:
+        new_prov = {
+            "life_context_sections_used": ["work", "health"],  # added
+            "last_n_turns": 0,
+            "memory_ids": [],
+            "skill_match": None,
+            "capability_block_version": "v2",  # bumped
+            "selectors": {
+                "life_context": {
+                    "life_context_sections_used": ["work", "health"],
+                },
+                "capability_block": {"capability_block_version": "v2"},
+            },
+        }
+        stored_prov = {
+            "life_context_sections_used": ["work"],
+            "last_n_turns": 0,
+            "memory_ids": [],
+            "skill_match": None,
+            "capability_block_version": "v1",
+            "selectors": {
+                "life_context": {"life_context_sections_used": ["work"]},
+                "capability_block": {"capability_block_version": "v1"},
+            },
+        }
+        t = _trace(input="hi", output="ok", assembled_context=stored_prov)
+        stub = _StubAssembler(system_prompt="NEW", provenance=new_prov)
+        app = _build_app(assembler=stub)
+        with patch("agent.traces.http.TraceRepository") as RepoClass, \
+             patch("agent.config.settings") as cfg:
+            cfg.PEPPER_BIND_LOCALHOST_ONLY = False
+            repo = RepoClass.return_value
+            repo.get_by_id = AsyncMock(return_value=t)
+            with TestClient(app) as client:
+                r = client.post(
+                    f"/api/traces/{t.trace_id}/rerender-prompt",
+                    headers={"x-api-key": "k"},
+                )
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["matches_original"] is False
+        # Both shapes round-trip in the response so the UI can diff client-side.
+        assert body["original_provenance"]["capability_block_version"] == "v1"
+        assert body["provenance"]["capability_block_version"] == "v2"
+
+    def test_404_when_trace_missing(self) -> None:
+        app = _build_app(assembler=_StubAssembler("X", {}))
+        with patch("agent.traces.http.TraceRepository") as RepoClass, \
+             patch("agent.config.settings") as cfg:
+            cfg.PEPPER_BIND_LOCALHOST_ONLY = False
+            repo = RepoClass.return_value
+            repo.get_by_id = AsyncMock(return_value=None)
+            with TestClient(app) as client:
+                r = client.post(
+                    f"/api/traces/{uuid.uuid4()}/rerender-prompt",
+                    headers={"x-api-key": "k"},
+                )
+        assert r.status_code == 404
+
+    def test_localhost_bind_enforced(self) -> None:
+        # The new endpoint inherits the same localhost-bind enforcement as
+        # the rest of /traces — non-loopback requests with bind on get 403.
+        app = _build_app(assembler=_StubAssembler("X", {}))
+        with patch("agent.config.settings") as cfg, \
+             patch("agent.traces.http._client_is_loopback", return_value=False):
+            cfg.PEPPER_BIND_LOCALHOST_ONLY = True
+            with TestClient(app) as client:
+                r = client.post(
+                    f"/api/traces/{uuid.uuid4()}/rerender-prompt",
+                    headers={"x-api-key": "k"},
+                )
+        assert r.status_code == 403

--- a/agent/traces/http.py
+++ b/agent/traces/http.py
@@ -2,9 +2,13 @@
 
 Exposes:
 
-- `GET  /api/traces`           — paginated list view (filters + cursor)
-- `GET  /api/traces/{id}`      — full trace including assembled_context
-- `POST /api/traces/{id}/find_similar` — embedding-nearest neighbours
+- `GET  /api/traces`                       — paginated list view (filters + cursor)
+- `GET  /api/traces/{id}`                  — full trace including assembled_context
+- `POST /api/traces/{id}/find_similar`     — embedding-nearest neighbours
+- `POST /api/traces/{id}/rerender-prompt`  — re-runs the assembler against this
+  trace's input (#34) so a maintainer can verify that fixes to the assembler
+  change the right thing. The re-render result is NEVER logged or persisted —
+  it lives in the response body only, returned to the in-browser inspector.
 
 **Privacy posture**
 
@@ -31,6 +35,7 @@ mirrors ADR-0005's append-only invariant at the API layer.
 """
 from __future__ import annotations
 
+import hashlib
 from datetime import datetime
 from typing import Any, Optional
 
@@ -142,6 +147,10 @@ class TraceDetail(TraceSummary):
     user_reaction: Optional[dict[str, Any]] = None
     embedding_model_version: Optional[str] = None
     has_embedding: bool
+    # Selector → human-readable reason map (#34). Computed off the stored
+    # provenance. Empty {} when assembled_context is empty (e.g. legacy
+    # rows from before #33 landed).
+    decision_reasons: dict[str, str] = Field(default_factory=dict)
 
 
 class TraceListResponse(BaseModel):
@@ -163,6 +172,52 @@ class FindSimilarResponse(BaseModel):
     matches: list[FindSimilarItem]
 
 
+# #34 — re-render endpoint response shape. The body is intentionally
+# self-contained so the inspector UI can diff against the original
+# trace without any further round-trips. Privacy: the rendered prompt
+# IS RAW_PERSONAL — it includes the user's life context and (via the
+# assembler) any cached secrets in the system prompt. This payload
+# crosses the loopback boundary only; routes inherit the localhost
+# bind enforced above.
+class RerenderPromptResponse(BaseModel):
+    trace_id: str
+    prompt: str
+    prompt_hash: str
+    provenance: dict[str, Any]
+    original_provenance: dict[str, Any]
+    matches_original: bool
+    notes: list[str] = Field(default_factory=list)
+
+
+# Dependency: yield the live ContextAssembler. Wired through the FastAPI
+# app state so tests can override without touching the module global.
+def get_assembler() -> Any:
+    """Return the live ``ContextAssembler`` from the running PepperCore.
+
+    Importing inside the function avoids a circular import (``agent.main``
+    imports this module, and the assembler is owned by PepperCore which
+    is constructed in ``main.lifespan``).
+    """
+    try:
+        from agent.main import _get_pepper
+    except Exception as exc:  # pragma: no cover - import guard
+        raise HTTPException(
+            status_code=503,
+            detail=f"pepper not ready: {exc}",
+        ) from exc
+
+    pepper_obj = _get_pepper()
+    if pepper_obj is None:
+        raise HTTPException(status_code=503, detail="pepper not initialized")
+    asm = getattr(pepper_obj, "assembler", None)
+    if asm is None:
+        raise HTTPException(
+            status_code=503,
+            detail="context assembler not available on pepper instance",
+        )
+    return asm
+
+
 # ── Mapping helpers ───────────────────────────────────────────────────────────
 
 
@@ -178,6 +233,38 @@ def _to_summary(t: Trace) -> TraceSummary:
         tier=t.tier.value,
         scheduler_job_name=t.scheduler_job_name,
     )
+
+
+def _decision_reasons_from_stored(
+    assembled_context: dict[str, Any],
+) -> dict[str, str]:
+    """Compute ``selector_name -> human reason`` from a stored provenance dict.
+
+    ``agent.context.annotate`` operates on an :class:`AssembledContext`,
+    but persisted traces only carry the JSON-serialized provenance map
+    under ``assembled_context["selectors"]`` (per #33). We rehydrate
+    just enough to feed the same explainers — this stays in sync with
+    ``decisions.py`` because we delegate to its private explainer table.
+    """
+    selectors = (assembled_context or {}).get("selectors") or {}
+    if not isinstance(selectors, dict) or not selectors:
+        return {}
+    try:
+        # Local import keeps the http module loadable without the context
+        # subsystem when tests stub things out.
+        from agent.context.decisions import _EXPLAINERS, _explain_default
+    except Exception:
+        return {}
+    out: dict[str, str] = {}
+    for name, prov in selectors.items():
+        if not isinstance(prov, dict):
+            continue
+        explainer = _EXPLAINERS.get(name, _explain_default)
+        try:
+            out[name] = explainer(prov)
+        except Exception:
+            out[name] = f"{name}: provenance present"
+    return out
 
 
 def _to_detail(t: Trace) -> TraceDetail:
@@ -200,6 +287,7 @@ def _to_detail(t: Trace) -> TraceDetail:
         user_reaction=t.user_reaction,
         embedding_model_version=t.embedding_model_version,
         has_embedding=t.embedding is not None,
+        decision_reasons=_decision_reasons_from_stored(t.assembled_context),
     )
 
 
@@ -339,4 +427,196 @@ async def find_similar(
     )
     return FindSimilarResponse(
         matches=[FindSimilarItem(trace_id=tid, distance=dist) for tid, dist in matches],
+    )
+
+
+# Fields in AssembledContext.provenance that legitimately differ across
+# re-renders even when no code has changed:
+#   - ``last_n_turns`` — depends on the live working-memory at the time
+#     of re-render, which evolves with every new turn.
+#   - ``selectors.last_n_turns.*`` — same reason.
+#   - ``selectors.life_context.checksum`` may differ if the file was
+#     edited; we include the file modification in the comparison.
+# The structural-match check excludes these explicitly so a stable
+# assembler against an unchanged code base reports ``matches_original=
+# True``. When the assembler IS changed, ``capability_block_version``
+# or ``life_context_sections_used`` will diverge and the flag flips.
+_PROVENANCE_VOLATILE_TOP_LEVEL_KEYS: frozenset[str] = frozenset({
+    "last_n_turns",
+})
+
+# Per-selector volatile keys. Same rationale.
+_PROVENANCE_VOLATILE_SELECTOR_KEYS: dict[str, frozenset[str]] = {
+    "last_n_turns": frozenset({"last_n_turns", "n_messages"}),
+}
+
+
+def _strip_volatile(provenance: dict[str, Any]) -> dict[str, Any]:
+    """Return a copy of ``provenance`` with known-volatile fields removed.
+
+    Used by the re-render endpoint to compute a structural-equality
+    signal that's robust to live-history drift between the original
+    turn and the re-render.
+    """
+    filtered: dict[str, Any] = {}
+    for k, v in provenance.items():
+        if k in _PROVENANCE_VOLATILE_TOP_LEVEL_KEYS:
+            continue
+        if k == "selectors" and isinstance(v, dict):
+            scrubbed_selectors: dict[str, Any] = {}
+            for sel_name, sel_prov in v.items():
+                if not isinstance(sel_prov, dict):
+                    scrubbed_selectors[sel_name] = sel_prov
+                    continue
+                drop = _PROVENANCE_VOLATILE_SELECTOR_KEYS.get(
+                    sel_name, frozenset()
+                )
+                scrubbed_selectors[sel_name] = {
+                    sk: sv for sk, sv in sel_prov.items() if sk not in drop
+                }
+            filtered[k] = scrubbed_selectors
+            continue
+        filtered[k] = v
+    return filtered
+
+
+@router.post(
+    "/{trace_id}/rerender-prompt",
+    response_model=RerenderPromptResponse,
+    dependencies=[Depends(require_api_key)],
+)
+async def rerender_prompt(
+    trace_id: str,
+    request: Request,
+    session: AsyncSession = Depends(get_db),
+    assembler: Any = Depends(get_assembler),
+) -> RerenderPromptResponse:
+    """Re-run the live assembler against this trace's stored input (#34).
+
+    Why: when we change the assembler we want a way to say "would this
+    have produced the same prompt for this past turn?". For unchanged
+    code this should be a structural match; for code changes the diff
+    is the answer.
+
+    Limitations (returned in ``notes`` so the UI can render them):
+
+    1. **Proactive contexts are not stored.** The original Turn carried
+       memory_context / web_context / calendar_context / etc. — those
+       strings are not on the trace row. The re-render runs with empty
+       proactive contexts, so the resulting prompt is shorter than the
+       original. Provenance from selectors that DO read live state
+       (life_context, capability_block) is still meaningful.
+    2. **History is live.** ``last_n_turns`` reflects working memory at
+       re-render time, which is later than the original turn. The
+       structural-match check excludes history-dependent fields so an
+       unchanged assembler against unchanged life-context reports
+       ``matches_original=True``.
+    3. **Skill match is currently always None per #33.** The skills
+       index is exposed via progressive disclosure; no per-turn match.
+
+    Privacy: the response body crosses the loopback boundary only and
+    is **never logged**. The audit-log entry below records that a
+    re-render happened — it does NOT capture the rendered text.
+    """
+    await _enforce_localhost_bind(request)
+
+    # Defer the import of agent.context.types so this module stays
+    # cheap to load — keeps test_traces_http.py's existing in-memory
+    # mocks unaffected.
+    from agent.context.types import Turn
+
+    repo = TraceRepository(session)
+    try:
+        trace = await repo.get_by_id(trace_id)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=f"invalid trace_id: {exc}") from exc
+    if trace is None:
+        raise HTTPException(status_code=404, detail="trace not found")
+
+    notes: list[str] = []
+    if not trace.input:
+        notes.append("trace input is empty; re-render uses an empty user_message")
+    notes.append(
+        "proactive contexts (memory/web/calendar/email/imessage/whatsapp/slack) "
+        "are not stored on the trace; re-render uses empty strings for these"
+    )
+    notes.append(
+        "history reflects working memory at re-render time, not at the original "
+        "turn; structural-match check ignores history-dependent fields"
+    )
+
+    # Build a minimal Turn. We deliberately do NOT populate proactive
+    # contexts because they aren't stored — the alternative would be
+    # silently materializing a different prompt and pretending it's
+    # the same one. Better to be honest in `notes` and let the UI diff.
+    turn = Turn(
+        user_message=trace.input or "",
+        # No channel header — we don't store channel on the trace today.
+        channel="",
+        isolated=False,
+        history_limit=20,
+        memory_context="",
+        memory_records=[],
+        web_context="",
+        routing_context="",
+        calendar_context="",
+        email_context="",
+        imessage_context="",
+        whatsapp_context="",
+        slack_context="",
+        include_skills_index=True,
+        extra_system_suffix="",
+        # Pin "now" to the trace's created_at so the time header is
+        # deterministic across re-renders. Without this, every call
+        # would differ in the rendered timestamp byte and the prompt
+        # hash would never match.
+        now_override=trace.created_at,
+    )
+
+    try:
+        assembled = assembler.assemble(turn)
+    except Exception as exc:
+        logger.warning(
+            "rerender_prompt_failed",
+            trace_id=trace_id,
+            error=str(exc),
+        )
+        raise HTTPException(
+            status_code=500,
+            detail=f"assembler failed during re-render: {exc}",
+        ) from exc
+
+    prompt = assembled.render_prompt()
+    prompt_hash = hashlib.sha256(prompt.encode("utf-8")).hexdigest()
+    new_provenance = assembled.provenance
+    original_provenance = dict(trace.assembled_context or {})
+
+    matches_original = (
+        _strip_volatile(new_provenance) == _strip_volatile(original_provenance)
+    )
+
+    api_key = request.headers.get("x-api-key", "")
+    # Audit: log that a re-render happened, NOT the result. The rendered
+    # prompt and provenance live in the response body only — they do
+    # not enter structlog, the audit log, or the traces table. This is
+    # an explicit privacy contract for #34's inspector panel.
+    await _audit_read(
+        actor_key_hash=api_key,
+        action="rerender_prompt",
+        detail={
+            "trace_id": trace_id,
+            "matches_original": matches_original,
+            "prompt_hash": prompt_hash,
+        },
+        request=request,
+    )
+
+    return RerenderPromptResponse(
+        trace_id=trace_id,
+        prompt=prompt,
+        prompt_hash=prompt_hash,
+        provenance=new_provenance,
+        original_provenance=original_provenance,
+        matches_original=matches_original,
+        notes=notes,
     )

--- a/agent/traces/http.py
+++ b/agent/traces/http.py
@@ -36,6 +36,7 @@ mirrors ADR-0005's append-only invariant at the API layer.
 from __future__ import annotations
 
 import hashlib
+import ipaddress
 from datetime import datetime
 from typing import Any, Optional
 
@@ -66,7 +67,18 @@ router = APIRouter(prefix="/traces", tags=["traces"])
 
 def _client_is_loopback(request: Request) -> bool:
     host = request.client.host if request.client else ""
-    return host in {"127.0.0.1", "::1", "localhost"} or host.startswith("127.")
+    if not host:
+        return False
+    # ``localhost`` is a hostname, not an IP — keep the string fallback
+    # so dev hosts that report it stay on the allow-list. The existing
+    # ``127.x`` branch is also kept because some clients return that
+    # without a fully-formed IP literal.
+    if host in {"localhost"} or host.startswith("127."):
+        return True
+    try:
+        return ipaddress.ip_address(host).is_loopback
+    except ValueError:
+        return False
 
 
 async def _enforce_localhost_bind(request: Request) -> None:
@@ -135,6 +147,11 @@ class TraceSummary(BaseModel):
     data_sensitivity: str
     tier: str
     scheduler_job_name: Optional[str] = None
+    # #34 — capability_block_version is projected onto the list view so the
+    # inspector can find the prior trace with a different version without
+    # issuing one detail fetch per summary. Cheap (12-char string) projected
+    # via JSONB ``->>`` operator at the repository layer.
+    capability_block_version: Optional[str] = None
 
 
 class TraceDetail(TraceSummary):
@@ -222,6 +239,7 @@ def get_assembler() -> Any:
 
 
 def _to_summary(t: Trace) -> TraceSummary:
+    cap_version = (t.assembled_context or {}).get("capability_block_version")
     return TraceSummary(
         trace_id=t.trace_id,
         created_at=t.created_at,
@@ -232,6 +250,7 @@ def _to_summary(t: Trace) -> TraceSummary:
         data_sensitivity=t.data_sensitivity.value,
         tier=t.tier.value,
         scheduler_job_name=t.scheduler_job_name,
+        capability_block_version=str(cap_version) if cap_version else None,
     )
 
 
@@ -240,31 +259,21 @@ def _decision_reasons_from_stored(
 ) -> dict[str, str]:
     """Compute ``selector_name -> human reason`` from a stored provenance dict.
 
-    ``agent.context.annotate`` operates on an :class:`AssembledContext`,
-    but persisted traces only carry the JSON-serialized provenance map
-    under ``assembled_context["selectors"]`` (per #33). We rehydrate
-    just enough to feed the same explainers — this stays in sync with
-    ``decisions.py`` because we delegate to its private explainer table.
+    Delegates to :func:`agent.context.annotate_from_provenance` — the
+    public API for rendering reasons against a JSON-serialized provenance
+    shape. We pass the persisted ``selectors`` sub-dict (per #33) and let
+    decisions.py own the explainer table.
     """
     selectors = (assembled_context or {}).get("selectors") or {}
-    if not isinstance(selectors, dict) or not selectors:
-        return {}
     try:
         # Local import keeps the http module loadable without the context
         # subsystem when tests stub things out.
-        from agent.context.decisions import _EXPLAINERS, _explain_default
+        from agent.context.decisions import annotate_from_provenance
     except Exception:
         return {}
-    out: dict[str, str] = {}
-    for name, prov in selectors.items():
-        if not isinstance(prov, dict):
-            continue
-        explainer = _EXPLAINERS.get(name, _explain_default)
-        try:
-            out[name] = explainer(prov)
-        except Exception:
-            out[name] = f"{name}: provenance present"
-    return out
+    if not isinstance(selectors, dict):
+        return {}
+    return annotate_from_provenance(selectors)
 
 
 def _to_detail(t: Trace) -> TraceDetail:
@@ -447,7 +456,11 @@ _PROVENANCE_VOLATILE_TOP_LEVEL_KEYS: frozenset[str] = frozenset({
 
 # Per-selector volatile keys. Same rationale.
 _PROVENANCE_VOLATILE_SELECTOR_KEYS: dict[str, frozenset[str]] = {
-    "last_n_turns": frozenset({"last_n_turns", "n_messages"}),
+    # ``content`` and ``role_counts`` track the live history shape and
+    # drift across re-renders even when the assembler hasn't changed.
+    "last_n_turns": frozenset(
+        {"last_n_turns", "n_messages", "content", "role_counts"}
+    ),
 }
 
 
@@ -497,6 +510,16 @@ async def rerender_prompt(
     have produced the same prompt for this past turn?". For unchanged
     code this should be a structural match; for code changes the diff
     is the answer.
+
+    **Why POST (not GET) for a read-only re-render?** The rendered prompt
+    is RAW_PERSONAL — it embeds the full life-context document and any
+    secrets the system prompt carries. A GET would put identifying
+    parameters in URL query strings (none today, but the pattern is
+    fragile), and any future variant that accepts overrides would push
+    that material into URL query strings, server access logs, browser
+    history, and Referer headers. POST keeps the inputs in the request
+    body and the rendered prompt in the response body only. The audit
+    log records the request, never the body.
 
     Limitations (returned in ``notes`` so the UI can render them):
 

--- a/agent/traces/repository.py
+++ b/agent/traces/repository.py
@@ -238,15 +238,30 @@ class TraceRepository:
                 undefer(TraceRow.assembled_context),
                 undefer(TraceRow.tools_called),
             )
-        result = await self._session.execute(stmt)
-        rows = result.scalars().all()
-        if with_payload:
+            result = await self._session.execute(stmt)
+            rows = result.scalars().all()
             return [_row_to_trace(r) for r in rows]
+
         # Without payload, _row_to_trace would trigger lazy-load on the
         # deferred columns. Project to empty placeholders instead — list
-        # callers don't read the heavy fields.
+        # callers don't read the heavy fields. We DO project a single
+        # cheap JSONB scalar (#34): the capability_block_version key on
+        # ``assembled_context``. The inspector uses it to find the prior
+        # version without an N+1 detail-fetch loop.
+        from sqlalchemy import literal_column
+
+        cap_version_expr = literal_column(
+            "assembled_context->>'capability_block_version'"
+        ).label("capability_block_version")
+        list_stmt = stmt.add_columns(cap_version_expr)
+        result = await self._session.execute(list_stmt)
         out: list[Trace] = []
-        for r in rows:
+        for row_tuple in result.all():
+            r = row_tuple[0]
+            cap_version = row_tuple[1] if len(row_tuple) > 1 else None
+            placeholder_ctx: dict[str, Any] = {}
+            if cap_version:
+                placeholder_ctx["capability_block_version"] = cap_version
             out.append(
                 Trace(
                     trace_id=str(r.trace_id),
@@ -255,7 +270,7 @@ class TraceRepository:
                     archetype=Archetype(r.archetype),
                     scheduler_job_name=r.scheduler_job_name,
                     input=r.input,
-                    assembled_context={},
+                    assembled_context=placeholder_ctx,
                     output=r.output,
                     model_selected=r.model_selected,
                     model_version=r.model_version,

--- a/tests/agent/context/test_decisions.py
+++ b/tests/agent/context/test_decisions.py
@@ -109,3 +109,51 @@ def test_annotate_robust_to_garbage_provenance(tmp_path: Path) -> None:
     rec = SelectorRecord(name="life_context", content="", provenance={"x": object()})
     out = _explain("life_context", rec)
     assert isinstance(out, str)
+
+
+def test_annotate_from_provenance_matches_annotate(tmp_path: Path) -> None:
+    """Public ``annotate_from_provenance`` matches the live-context
+    ``annotate()`` output when fed the same JSON-serialized provenance.
+
+    This is the contract the HTTP layer (#34) depends on: refactors
+    inside ``decisions.py`` must keep these two paths in lockstep.
+    """
+    from agent.context import annotate_from_provenance
+
+    ctx = _ctx(
+        tmp_path,
+        memory_context="MEMORY",
+        memory_records=[
+            {"id": "a", "score": 0.9},
+            {"id": "b", "score": 0.5},
+        ],
+    )
+    live = annotate(ctx)
+
+    selectors_dict = {
+        name: rec.provenance for name, rec in ctx.selectors.items()
+    }
+    stored = annotate_from_provenance(selectors_dict)
+    assert stored == live
+
+
+def test_annotate_from_provenance_empty_returns_empty() -> None:
+    """Empty / missing provenance dict yields an empty result, never raises."""
+    from agent.context import annotate_from_provenance
+
+    assert annotate_from_provenance({}) == {}
+    assert annotate_from_provenance(None) == {}  # type: ignore[arg-type]
+
+
+def test_annotate_from_provenance_skips_non_dict_entries() -> None:
+    """Robust to legacy or malformed selector entries."""
+    from agent.context import annotate_from_provenance
+
+    out = annotate_from_provenance(
+        {
+            "life_context": {"life_context_sections_used": ["work"]},
+            "garbage": "not-a-dict",  # type: ignore[dict-item]
+        }
+    )
+    assert "life_context" in out
+    assert "garbage" not in out

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -41,6 +41,10 @@ export interface TraceSummary {
   data_sensitivity: string
   tier: string
   scheduler_job_name: string | null
+  // #34 — projected from assembled_context so the inspector can find the
+  // previous trace with a different capability block version without
+  // issuing one detail fetch per summary.
+  capability_block_version?: string | null
 }
 
 export interface TraceDetail extends TraceSummary {
@@ -66,6 +70,18 @@ export interface RerenderPromptResponse {
   original_provenance: Record<string, unknown>
   matches_original: boolean
   notes: string[]
+}
+
+// Epic 01 (#34) — single-memory fetch for inspector expandable rows.
+export interface MemoryDetail {
+  id: number
+  type: string
+  content: string
+  summary: string | null
+  importance_score: number
+  created_at: string
+  accessed_at: string | null
+  has_embedding: boolean
 }
 
 export interface TraceListResponse {
@@ -268,4 +284,9 @@ export const api = {
     req<RerenderPromptResponse>(`/traces/${traceId}/rerender-prompt`, {
       method: 'POST',
     }),
+
+  // Epic 01 (#34) — fetch a single memory's content + metadata. Used by
+  // the trace inspector to expand a memory row from its provenance ID.
+  getMemory: (memoryId: string | number) =>
+    req<MemoryDetail>(`/memories/${memoryId}`),
 }

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -53,6 +53,19 @@ export interface TraceDetail extends TraceSummary {
   user_reaction: Record<string, unknown> | null
   embedding_model_version: string | null
   has_embedding: boolean
+  // #34 — selector → human reason map computed off stored provenance.
+  decision_reasons: Record<string, string>
+}
+
+// Epic 01 (#34) — context inspector re-render endpoint.
+export interface RerenderPromptResponse {
+  trace_id: string
+  prompt: string
+  prompt_hash: string
+  provenance: Record<string, unknown>
+  original_provenance: Record<string, unknown>
+  matches_original: boolean
+  notes: string[]
 }
 
 export interface TraceListResponse {
@@ -248,4 +261,11 @@ export const api = {
   },
 
   getTrace: (traceId: string) => req<TraceDetail>(`/traces/${traceId}`),
+
+  // Epic 01 (#34) — re-render the prompt for a trace using the live
+  // assembler. Result is in-browser only — never logged server-side.
+  rerenderPrompt: (traceId: string) =>
+    req<RerenderPromptResponse>(`/traces/${traceId}/rerender-prompt`, {
+      method: 'POST',
+    }),
 }

--- a/web/src/components/TraceContextInspector.tsx
+++ b/web/src/components/TraceContextInspector.tsx
@@ -15,6 +15,7 @@
 import { useEffect, useState } from 'react'
 import {
   api,
+  type MemoryDetail,
   type RerenderPromptResponse,
   type TraceDetail,
 } from '../api'
@@ -37,6 +38,15 @@ const styles = {
     fontWeight: 600,
     marginBottom: 16,
     letterSpacing: 0.2,
+  },
+  legacyBanner: {
+    background: '#1f2937',
+    border: '1px solid #374151',
+    color: '#cbd5e1',
+    borderRadius: 6,
+    padding: '8px 12px',
+    fontSize: 12,
+    marginBottom: 16,
   },
   topbar: {
     display: 'flex',
@@ -137,6 +147,56 @@ const styles = {
     fontSize: 12,
     color: '#fcd34d',
   },
+  diffLineAdded: {
+    color: '#86efac',
+    background: '#14532d22',
+    fontFamily: 'ui-monospace, monospace',
+    fontSize: 12,
+    whiteSpace: 'pre-wrap' as const,
+    padding: '0 4px',
+  },
+  diffLineRemoved: {
+    color: '#fca5a5',
+    background: '#7f1d1d22',
+    fontFamily: 'ui-monospace, monospace',
+    fontSize: 12,
+    whiteSpace: 'pre-wrap' as const,
+    padding: '0 4px',
+  },
+  diffLineUnchanged: {
+    color: '#9ca3af',
+    fontFamily: 'ui-monospace, monospace',
+    fontSize: 12,
+    whiteSpace: 'pre-wrap' as const,
+    padding: '0 4px',
+  },
+  diffContainer: {
+    background: '#080808',
+    border: '1px solid #1e1e1e',
+    borderRadius: 4,
+    padding: 8,
+    marginTop: 8,
+    maxHeight: 360,
+    overflowY: 'auto' as const,
+  },
+  historyTurn: {
+    borderTop: '1px solid #1a1a1a',
+    padding: '8px 0',
+    fontSize: 12,
+  },
+  historyHeader: {
+    display: 'flex',
+    gap: 8,
+    alignItems: 'center',
+    marginBottom: 4,
+  },
+  historyContent: {
+    color: '#cbd5e1',
+    whiteSpace: 'pre-wrap' as const,
+    margin: 0,
+    fontFamily: 'inherit',
+    fontSize: 12,
+  },
 }
 
 interface Props {
@@ -169,6 +229,108 @@ function formatMemoryScore(score: number | undefined | null): string {
   return score.toFixed(3)
 }
 
+// Tiny, dependency-free line-by-line diff. Uses LCS via dynamic
+// programming: O(n*m) time / space, fine for the typical ≤200-line
+// inputs the inspector handles. Returns ordered diff lines.
+type DiffOp = 'added' | 'removed' | 'unchanged'
+interface DiffLine {
+  op: DiffOp
+  text: string
+}
+
+function lineDiff(oldText: string, newText: string): DiffLine[] {
+  const a = oldText.split('\n')
+  const b = newText.split('\n')
+  const n = a.length
+  const m = b.length
+  // dp[i][j] = LCS length of a[i:] and b[j:]
+  const dp: number[][] = Array.from({ length: n + 1 }, () =>
+    new Array(m + 1).fill(0),
+  )
+  for (let i = n - 1; i >= 0; i--) {
+    for (let j = m - 1; j >= 0; j--) {
+      if (a[i] === b[j]) {
+        dp[i][j] = dp[i + 1][j + 1] + 1
+      } else {
+        dp[i][j] = Math.max(dp[i + 1][j], dp[i][j + 1])
+      }
+    }
+  }
+  const out: DiffLine[] = []
+  let i = 0
+  let j = 0
+  while (i < n && j < m) {
+    if (a[i] === b[j]) {
+      out.push({ op: 'unchanged', text: a[i] })
+      i++
+      j++
+    } else if (dp[i + 1][j] >= dp[i][j + 1]) {
+      out.push({ op: 'removed', text: a[i] })
+      i++
+    } else {
+      out.push({ op: 'added', text: b[j] })
+      j++
+    }
+  }
+  while (i < n) {
+    out.push({ op: 'removed', text: a[i] })
+    i++
+  }
+  while (j < m) {
+    out.push({ op: 'added', text: b[j] })
+    j++
+  }
+  return out
+}
+
+const DIFF_MAX_LINES = 50
+
+interface DiffViewerProps {
+  oldText: string
+  newText: string
+  /** Caption before the diff for context (e.g. "vs prior trace abc123"). */
+  caption?: string
+}
+
+function DiffViewer({ oldText, newText, caption }: DiffViewerProps) {
+  const diff = lineDiff(oldText, newText)
+  const visible = diff.slice(0, DIFF_MAX_LINES)
+  const omitted = diff.length - visible.length
+  const anyChanges = diff.some((d) => d.op !== 'unchanged')
+  return (
+    <div style={styles.diffContainer}>
+      {caption && (
+        <div style={{ fontSize: 11, color: '#888', marginBottom: 6 }}>
+          {caption}
+        </div>
+      )}
+      {!anyChanges && (
+        <div style={{ fontSize: 12, color: '#6b7280' }}>(no differences)</div>
+      )}
+      {visible.map((line, idx) => {
+        const prefix = line.op === 'added' ? '+ ' : line.op === 'removed' ? '- ' : '  '
+        const style =
+          line.op === 'added'
+            ? styles.diffLineAdded
+            : line.op === 'removed'
+              ? styles.diffLineRemoved
+              : styles.diffLineUnchanged
+        return (
+          <div key={idx} style={style}>
+            {prefix}
+            {line.text}
+          </div>
+        )
+      })}
+      {omitted > 0 && (
+        <div style={{ fontSize: 11, color: '#888', marginTop: 4 }}>
+          … {omitted} more line(s) (truncated)
+        </div>
+      )}
+    </div>
+  )
+}
+
 interface ExpandableMemoryRowProps {
   id: string
   score: number
@@ -176,6 +338,36 @@ interface ExpandableMemoryRowProps {
 
 function ExpandableMemoryRow({ id, score }: ExpandableMemoryRowProps) {
   const [open, setOpen] = useState(false)
+  const [memory, setMemory] = useState<MemoryDetail | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  // Fetch on first expand. We don't refetch on subsequent toggles —
+  // memory rows are append-only at the recall layer.
+  useEffect(() => {
+    if (!open || memory || loading) return
+    let cancelled = false
+    setLoading(true)
+    setError(null)
+    api
+      .getMemory(id)
+      .then((d) => {
+        if (cancelled) return
+        setMemory(d)
+        logInfo('inspector', 'memory_loaded', { memory_id: id })
+      })
+      .catch((e) => {
+        if (cancelled) return
+        const message = e instanceof Error ? e.message : String(e)
+        setError(message)
+        logError('inspector', 'memory_failed', { memory_id: id, message })
+      })
+      .finally(() => !cancelled && setLoading(false))
+    return () => {
+      cancelled = true
+    }
+  }, [open, id, memory, loading])
+
   return (
     <li
       style={{
@@ -207,13 +399,77 @@ function ExpandableMemoryRow({ id, score }: ExpandableMemoryRowProps) {
             fontSize: 12,
           }}
         >
-          Raw memory content fetch is not wired in this build — the
-          inspector exposes the IDs and scores stored on the trace's
-          provenance only. To read the underlying recall row, query
-          the memory subsystem directly with this ID.
+          {loading && <div>loading memory…</div>}
+          {error && (
+            <div style={{ color: '#fca5a5' }}>error: {error}</div>
+          )}
+          {memory && (
+            <>
+              <div style={{ fontSize: 11, color: '#888', marginBottom: 4 }}>
+                type: <code>{memory.type}</code> · importance:{' '}
+                <code>{formatMemoryScore(memory.importance_score)}</code> ·
+                created: <code>{formatTimestamp(memory.created_at)}</code>
+              </div>
+              {/* React auto-escapes; <pre> renders raw text safely. */}
+              <pre style={styles.pre}>{memory.content}</pre>
+              {memory.summary && (
+                <>
+                  <div style={{ fontSize: 11, color: '#888', marginTop: 6 }}>
+                    summary:
+                  </div>
+                  <pre style={styles.pre}>{memory.summary}</pre>
+                </>
+              )}
+            </>
+          )}
         </div>
       )}
     </li>
+  )
+}
+
+interface HistoryViewProps {
+  history: Array<{ role?: string; content?: string; timestamp?: string }>
+}
+
+function HistoryView({ history }: HistoryViewProps) {
+  if (!Array.isArray(history) || history.length === 0) {
+    return <div style={styles.empty}>no history available</div>
+  }
+  // Per-turn timestamps: LastNTurnsSelector currently does not put
+  // per-message timestamps in provenance — provenance is count-based
+  // for now. We render whatever is present and explain when timestamps
+  // are absent. We never fabricate them.
+  const anyTimestamps = history.some((h) => h && typeof h.timestamp === 'string')
+  return (
+    <>
+      {!anyTimestamps && (
+        <div style={{ ...styles.empty, marginBottom: 6 }}>
+          (timestamps unavailable for this trace — provenance currently
+          records counts only)
+        </div>
+      )}
+      <div>
+        {history.map((turn, i) => {
+          const role = turn?.role ?? '?'
+          const ts = turn?.timestamp
+          const content = turn?.content ?? ''
+          return (
+            <div key={i} style={styles.historyTurn}>
+              <div style={styles.historyHeader}>
+                <span style={styles.pill('#60a5fa')}>{role}</span>
+                {ts && (
+                  <span style={{ fontSize: 11, color: '#9ca3af' }}>
+                    ({formatTimestamp(ts)})
+                  </span>
+                )}
+              </div>
+              <pre style={styles.historyContent}>{content}</pre>
+            </div>
+          )
+        })}
+      </div>
+    </>
   )
 }
 
@@ -293,6 +549,11 @@ export default function TraceContextInspector({ traceId, detail: detailProp, onB
   const memoryIds = prov.memory_ids || []
   const lifeContextContent =
     (prov.selectors?.life_context as { content?: string } | undefined)?.content ?? null
+  const lastNTurnsProvenance = (prov.selectors?.last_n_turns ?? {}) as Record<string, unknown>
+  const historyContent = (lastNTurnsProvenance.content ?? null) as
+    | Array<{ role?: string; content?: string; timestamp?: string }>
+    | null
+  const provenanceIsLegacy = Object.keys(prov).length === 0
 
   return (
     <div style={styles.root}>
@@ -301,6 +562,13 @@ export default function TraceContextInspector({ traceId, detail: detailProp, onB
         sections and memory IDs from the active database. Localhost bind
         is enforced server-side; never expose this UI on a public network.
       </div>
+
+      {provenanceIsLegacy && (
+        <div style={styles.legacyBanner}>
+          This trace pre-dates the assembly-provenance feature (#33).
+          Upgrade to a newer trace to inspect prompt construction.
+        </div>
+      )}
 
       <div style={styles.topbar}>
         <button style={styles.backButton} onClick={onBack}>
@@ -353,15 +621,16 @@ export default function TraceContextInspector({ traceId, detail: detailProp, onB
         </div>
         <div style={styles.sectionBody}>
           {reasons.last_n_turns && <div style={styles.reason}>{reasons.last_n_turns}</div>}
-          <div style={styles.empty}>
-            Provenance records the count and limit only; raw turn text isn't
-            persisted on the trace row to keep history mutations append-only.
-            The original turn was emitted at{' '}
-            <code>{formatTimestamp(detail.created_at)}</code>.
-          </div>
-          <pre style={{ ...styles.pre, marginTop: 10 }}>
-            {JSON.stringify(prov.selectors?.last_n_turns ?? {}, null, 2)}
-          </pre>
+          {historyContent && Array.isArray(historyContent) ? (
+            <HistoryView history={historyContent} />
+          ) : (
+            <div style={styles.empty}>
+              Provenance records the count and limit only; raw turn text isn't
+              persisted on the trace row to keep history mutations append-only.
+              The original turn was emitted at{' '}
+              <code>{formatTimestamp(detail.created_at)}</code>.
+            </div>
+          )}
         </div>
       </div>
 
@@ -460,43 +729,59 @@ export default function TraceContextInspector({ traceId, detail: detailProp, onB
             </div>
           )}
           {rerender && (
-            <>
-              {rerender.notes.length > 0 && (
-                <ul
-                  style={{
-                    ...styles.list,
-                    marginTop: 10,
-                    color: '#9ca3af',
-                    fontSize: 12,
-                  }}
-                >
-                  {rerender.notes.map((n, i) => (
-                    <li key={i}>{n}</li>
-                  ))}
-                </ul>
-              )}
-              <div style={{ marginTop: 10, fontSize: 11, color: '#888' }}>
-                rendered prompt:
-              </div>
-              <pre style={styles.pre}>{rerender.prompt}</pre>
-              <div style={{ marginTop: 10, fontSize: 11, color: '#888' }}>
-                provenance diff (original → re-rendered):
-              </div>
-              <pre style={styles.pre}>
-                {JSON.stringify(
-                  {
-                    original: rerender.original_provenance,
-                    rerendered: rerender.provenance,
-                  },
-                  null,
-                  2,
-                )}
-              </pre>
-            </>
+            <RerenderResult rerender={rerender} />
           )}
         </div>
       </div>
     </div>
+  )
+}
+
+interface RerenderResultProps {
+  rerender: RerenderPromptResponse
+}
+
+function RerenderResult({ rerender }: RerenderResultProps) {
+  // The original full prompt isn't stored on the trace row today (the
+  // trace stores input + output, not the rendered system prompt). When
+  // we have no original prompt to diff against, we fall back to a
+  // structural diff between the original provenance (persisted) and the
+  // re-rendered provenance (fresh) so the operator still gets a useful
+  // change view.
+  const newProvenancePretty = JSON.stringify(rerender.provenance, null, 2)
+  const oldProvenancePretty = JSON.stringify(rerender.original_provenance, null, 2)
+
+  return (
+    <>
+      {rerender.notes.length > 0 && (
+        <ul
+          style={{
+            ...styles.list,
+            marginTop: 10,
+            color: '#9ca3af',
+            fontSize: 12,
+          }}
+        >
+          {rerender.notes.map((n, i) => (
+            <li key={i}>{n}</li>
+          ))}
+        </ul>
+      )}
+      <div style={{ marginTop: 10, fontSize: 11, color: '#888' }}>
+        rendered prompt:
+      </div>
+      <pre style={styles.pre}>{rerender.prompt}</pre>
+      <div style={{ marginTop: 10, fontSize: 11, color: '#888' }}>
+        provenance diff (original → re-rendered) — the trace row stores
+        provenance only, not the original rendered prompt, so this is the
+        structural diff:
+      </div>
+      <DiffViewer
+        oldText={oldProvenancePretty}
+        newText={newProvenancePretty}
+        caption="original provenance → re-rendered provenance"
+      />
+    </>
   )
 }
 
@@ -515,33 +800,51 @@ function CapabilityBlockSection({
 }: CapabilityBlockSectionProps) {
   const [priorVersion, setPriorVersion] = useState<string | null>(null)
   const [priorTraceId, setPriorTraceId] = useState<string | null>(null)
+  const [priorContent, setPriorContent] = useState<string | null>(null)
   const [searched, setSearched] = useState(false)
+
+  const currentContent =
+    (capabilityProvenance?.content as string | undefined) ?? ''
 
   useEffect(() => {
     let cancelled = false
-    // Fetch a small window of recent traces and look for the most recent
-    // one with a different capability_block_version. This is best-effort:
-    // if the operator wants a precise prior trace, they can navigate via
-    // the trace list.
+    // Find the most recent trace with a different capability_block_version
+    // using ONLY the projected list view — no per-summary detail fetch
+    // (#34 review fix: was N+1). The list response now carries
+    // ``capability_block_version`` directly.
+    setSearched(false)
+    setPriorVersion(null)
+    setPriorTraceId(null)
+    setPriorContent(null)
     api
-      .listTraces({ limit: 25 })
+      .listTraces({ limit: 50 })
       .then(async (resp) => {
+        let foundSummary: { trace_id: string; capability_block_version?: string | null } | null = null
         for (const summary of resp.traces) {
           if (cancelled) return
           if (summary.trace_id === currentTraceId) continue
-          try {
-            const d = await api.getTrace(summary.trace_id)
-            if (cancelled) return
-            const ver = (d.assembled_context as ProvenanceShape | undefined)
-              ?.capability_block_version
-            if (ver && ver !== version) {
-              setPriorVersion(ver)
-              setPriorTraceId(d.trace_id)
-              break
-            }
-          } catch {
-            // fall through to next summary
+          const ver = summary.capability_block_version
+          if (ver && ver !== version) {
+            foundSummary = summary
+            break
           }
+        }
+        if (cancelled || !foundSummary) return
+        setPriorVersion(foundSummary.capability_block_version ?? null)
+        setPriorTraceId(foundSummary.trace_id)
+        // ONE detail fetch — only for the chosen prior trace, to pull
+        // its capability block content for the diff.
+        try {
+          const d = await api.getTrace(foundSummary.trace_id)
+          if (cancelled) return
+          const priorProv =
+            (d.assembled_context as ProvenanceShape | undefined)?.selectors
+              ?.capability_block
+          const content =
+            (priorProv as { content?: string } | undefined)?.content ?? null
+          setPriorContent(content)
+        } catch {
+          // ignore — we'll show version-only when the detail fetch fails
         }
       })
       .catch(() => {
@@ -561,10 +864,13 @@ function CapabilityBlockSection({
       </div>
       <div style={styles.sectionBody}>
         {reason && <div style={styles.reason}>{reason}</div>}
-        {capabilityProvenance && (
-          <pre style={styles.pre}>
-            {JSON.stringify(capabilityProvenance, null, 2)}
-          </pre>
+        {currentContent && (
+          <>
+            <div style={{ fontSize: 11, color: '#888', marginTop: 4 }}>
+              current rendered block:
+            </div>
+            <pre style={styles.pre}>{currentContent}</pre>
+          </>
         )}
         <div style={{ ...styles.capabilityDiff, marginTop: 10 }}>
           {!searched && 'searching for prior version…'}
@@ -579,11 +885,25 @@ function CapabilityBlockSection({
           )}
           {searched && !priorVersion && (
             <span style={{ color: '#888' }}>
-              no prior trace with a different version found in the last 25
+              no prior trace with a different version found in the last 50
               entries
             </span>
           )}
         </div>
+        {searched && priorVersion && currentContent && (
+          priorContent !== null ? (
+            <DiffViewer
+              oldText={priorContent}
+              newText={currentContent}
+              caption={`vs prior trace ${priorTraceId} (${priorVersion} → ${version})`}
+            />
+          ) : (
+            <div style={{ ...styles.empty, marginTop: 8 }}>
+              prior trace's capability block content not available (legacy
+              row) — version mismatch only
+            </div>
+          )
+        )}
       </div>
     </div>
   )

--- a/web/src/components/TraceContextInspector.tsx
+++ b/web/src/components/TraceContextInspector.tsx
@@ -1,0 +1,590 @@
+// Epic 01 (#34) — Trace context inspector.
+//
+// Given a trace, breaks down what went into the prompt and why. Most
+// sensitive view in the entire UI: surfaces raw life-context section
+// names, raw memory IDs/scores, and (on re-render) the rendered system
+// prompt. Localhost-bind is enforced server-side by `agent/traces/http.py`
+// (see `_enforce_localhost_bind`), so this component just trusts the
+// API guard and shows a banner so the operator never forgets.
+//
+// Why no react-router: the existing app uses a tab-based root. Adding
+// a router for one drill-down adds a dependency for negligible benefit.
+// Instead, the parent (Traces.tsx) owns selection state and switches to
+// this component when "Inspect prompt construction" is clicked.
+
+import { useEffect, useState } from 'react'
+import {
+  api,
+  type RerenderPromptResponse,
+  type TraceDetail,
+} from '../api'
+import { logError, logInfo } from '../logger'
+
+const styles = {
+  root: {
+    height: '100%',
+    overflowY: 'auto' as const,
+    padding: 24,
+    fontFamily: 'inherit',
+  },
+  banner: {
+    background: '#3a1212',
+    border: '1px solid #ef4444',
+    color: '#fecaca',
+    borderRadius: 6,
+    padding: '10px 14px',
+    fontSize: 13,
+    fontWeight: 600,
+    marginBottom: 16,
+    letterSpacing: 0.2,
+  },
+  topbar: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: 12,
+    marginBottom: 16,
+  },
+  backButton: {
+    background: '#1a1a1a',
+    color: '#e0e0e0',
+    border: '1px solid #2a2a2a',
+    borderRadius: 4,
+    padding: '6px 12px',
+    cursor: 'pointer',
+    fontSize: 12,
+    fontFamily: 'inherit',
+  },
+  title: { fontSize: 18, fontWeight: 600 },
+  meta: { fontSize: 11, color: '#888' },
+  section: {
+    marginTop: 20,
+    border: '1px solid #1e1e1e',
+    borderRadius: 6,
+    background: '#0d0d0d',
+    overflow: 'hidden' as const,
+  },
+  sectionHeader: {
+    padding: '10px 14px',
+    background: '#141414',
+    borderBottom: '1px solid #1e1e1e',
+    fontSize: 13,
+    fontWeight: 600,
+    display: 'flex',
+    justifyContent: 'space-between' as const,
+    alignItems: 'center',
+  },
+  sectionBody: { padding: 14 },
+  reason: {
+    fontSize: 12,
+    color: '#9ca3af',
+    fontStyle: 'italic' as const,
+    marginBottom: 10,
+  },
+  pre: {
+    background: '#080808',
+    color: '#e0e0e0',
+    padding: 10,
+    borderRadius: 4,
+    border: '1px solid #1e1e1e',
+    fontFamily: 'ui-monospace, monospace',
+    fontSize: 12,
+    whiteSpace: 'pre-wrap' as const,
+    overflowX: 'auto' as const,
+    margin: 0,
+  },
+  list: { margin: 0, paddingLeft: 18, fontSize: 13 },
+  pill: (color: string) => ({
+    display: 'inline-block',
+    padding: '1px 6px',
+    borderRadius: 3,
+    fontSize: 10,
+    background: `${color}22`,
+    color,
+    marginRight: 6,
+  }),
+  empty: { color: '#666', fontSize: 12 },
+  rerenderRow: {
+    display: 'flex',
+    gap: 10,
+    alignItems: 'center',
+    marginTop: 8,
+  },
+  primaryButton: {
+    background: '#1e3a5f',
+    color: '#bfdbfe',
+    border: '1px solid #2a4a73',
+    borderRadius: 4,
+    padding: '6px 12px',
+    cursor: 'pointer',
+    fontSize: 12,
+    fontFamily: 'inherit',
+  },
+  matchPillTrue: {
+    color: '#86efac',
+    background: '#14532d44',
+    padding: '2px 8px',
+    borderRadius: 3,
+    fontSize: 11,
+  },
+  matchPillFalse: {
+    color: '#fca5a5',
+    background: '#7f1d1d44',
+    padding: '2px 8px',
+    borderRadius: 3,
+    fontSize: 11,
+  },
+  capabilityDiff: {
+    fontSize: 12,
+    color: '#fcd34d',
+  },
+}
+
+interface Props {
+  traceId: string
+  /** Optional pre-loaded detail; component refetches if missing. */
+  detail?: TraceDetail | null
+  onBack: () => void
+}
+
+interface ProvenanceShape {
+  life_context_sections_used?: string[]
+  last_n_turns?: number
+  memory_ids?: Array<[string, number]>
+  skill_match?: Record<string, unknown> | null
+  capability_block_version?: string
+  selectors?: Record<string, Record<string, unknown>>
+}
+
+function provenanceOf(detail: TraceDetail | null): ProvenanceShape {
+  if (!detail) return {}
+  return (detail.assembled_context || {}) as ProvenanceShape
+}
+
+function formatTimestamp(iso: string): string {
+  return new Date(iso).toLocaleString()
+}
+
+function formatMemoryScore(score: number | undefined | null): string {
+  if (typeof score !== 'number' || Number.isNaN(score)) return '—'
+  return score.toFixed(3)
+}
+
+interface ExpandableMemoryRowProps {
+  id: string
+  score: number
+}
+
+function ExpandableMemoryRow({ id, score }: ExpandableMemoryRowProps) {
+  const [open, setOpen] = useState(false)
+  return (
+    <li
+      style={{
+        listStyle: 'none',
+        padding: '6px 0',
+        borderBottom: '1px solid #1a1a1a',
+      }}
+    >
+      <div
+        style={{ cursor: 'pointer', display: 'flex', gap: 8, alignItems: 'center' }}
+        onClick={() => setOpen(!open)}
+      >
+        <span style={{ color: '#888', fontSize: 11, width: 14 }}>{open ? '▼' : '▶'}</span>
+        <code style={{ fontSize: 12 }}>{id}</code>
+        <span style={{ marginLeft: 'auto', color: '#9ca3af', fontSize: 11 }}>
+          score: {formatMemoryScore(score)}
+        </span>
+      </div>
+      {open && (
+        <div
+          style={{
+            marginTop: 6,
+            marginLeft: 22,
+            padding: '8px 10px',
+            background: '#080808',
+            border: '1px solid #1e1e1e',
+            borderRadius: 4,
+            color: '#9ca3af',
+            fontSize: 12,
+          }}
+        >
+          Raw memory content fetch is not wired in this build — the
+          inspector exposes the IDs and scores stored on the trace's
+          provenance only. To read the underlying recall row, query
+          the memory subsystem directly with this ID.
+        </div>
+      )}
+    </li>
+  )
+}
+
+export default function TraceContextInspector({ traceId, detail: detailProp, onBack }: Props) {
+  const [detail, setDetail] = useState<TraceDetail | null>(detailProp ?? null)
+  const [loading, setLoading] = useState(!detailProp)
+  const [error, setError] = useState<string | null>(null)
+  const [rerender, setRerender] = useState<RerenderPromptResponse | null>(null)
+  const [rerendering, setRerendering] = useState(false)
+  const [rerenderError, setRerenderError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (detailProp) {
+      setDetail(detailProp)
+      return
+    }
+    let cancelled = false
+    setLoading(true)
+    setError(null)
+    api
+      .getTrace(traceId)
+      .then((d) => {
+        if (cancelled) return
+        setDetail(d)
+        logInfo('inspector', 'detail_loaded', { trace_id: traceId })
+      })
+      .catch((e) => {
+        if (cancelled) return
+        const message = e instanceof Error ? e.message : String(e)
+        setError(message)
+        logError('inspector', 'detail_failed', { trace_id: traceId, message })
+      })
+      .finally(() => !cancelled && setLoading(false))
+    return () => {
+      cancelled = true
+    }
+  }, [traceId, detailProp])
+
+  const handleRerender = async () => {
+    setRerendering(true)
+    setRerenderError(null)
+    try {
+      const result = await api.rerenderPrompt(traceId)
+      setRerender(result)
+      logInfo('inspector', 'rerender_succeeded', {
+        trace_id: traceId,
+        matches_original: result.matches_original,
+      })
+    } catch (e) {
+      const message = e instanceof Error ? e.message : String(e)
+      setRerenderError(message)
+      logError('inspector', 'rerender_failed', { trace_id: traceId, message })
+    } finally {
+      setRerendering(false)
+    }
+  }
+
+  if (loading) {
+    return <div style={styles.root}>loading…</div>
+  }
+  if (error || !detail) {
+    return (
+      <div style={styles.root}>
+        <button style={styles.backButton} onClick={onBack}>
+          ← back
+        </button>
+        <div style={{ marginTop: 16, color: '#fca5a5' }}>
+          error: {error ?? 'trace not found'}
+        </div>
+      </div>
+    )
+  }
+
+  const prov = provenanceOf(detail)
+  const reasons = detail.decision_reasons || {}
+  const sections = prov.life_context_sections_used || []
+  const memoryIds = prov.memory_ids || []
+  const lifeContextContent =
+    (prov.selectors?.life_context as { content?: string } | undefined)?.content ?? null
+
+  return (
+    <div style={styles.root}>
+      <div style={styles.banner}>
+        Raw personal data — local only. This panel inlines life-context
+        sections and memory IDs from the active database. Localhost bind
+        is enforced server-side; never expose this UI on a public network.
+      </div>
+
+      <div style={styles.topbar}>
+        <button style={styles.backButton} onClick={onBack}>
+          ← back to trace
+        </button>
+        <div>
+          <div style={styles.title}>Prompt construction</div>
+          <div style={styles.meta}>
+            trace <code>{detail.trace_id}</code> ·{' '}
+            {formatTimestamp(detail.created_at)} · {detail.model_selected || '<no model>'}
+            {detail.prompt_version && (
+              <>
+                {' · prompt: '}
+                <code>{detail.prompt_version}</code>
+              </>
+            )}
+          </div>
+        </div>
+      </div>
+
+      {/* ── Life context ──────────────────────────────────────────── */}
+      <div style={styles.section}>
+        <div style={styles.sectionHeader}>
+          <span>Life context</span>
+          <span style={styles.pill('#a78bfa')}>{sections.length} section(s)</span>
+        </div>
+        <div style={styles.sectionBody}>
+          {reasons.life_context && <div style={styles.reason}>{reasons.life_context}</div>}
+          {sections.length === 0 && <div style={styles.empty}>no sections recorded</div>}
+          {sections.length > 0 && (
+            <ul style={styles.list}>
+              {sections.map((s) => (
+                <li key={s}>
+                  <code>{s}</code>
+                </li>
+              ))}
+            </ul>
+          )}
+          {lifeContextContent && (
+            <pre style={{ ...styles.pre, marginTop: 10 }}>{lifeContextContent}</pre>
+          )}
+        </div>
+      </div>
+
+      {/* ── Conversation history ──────────────────────────────────── */}
+      <div style={styles.section}>
+        <div style={styles.sectionHeader}>
+          <span>Conversation history</span>
+          <span style={styles.pill('#60a5fa')}>last {prov.last_n_turns ?? 0} turn(s)</span>
+        </div>
+        <div style={styles.sectionBody}>
+          {reasons.last_n_turns && <div style={styles.reason}>{reasons.last_n_turns}</div>}
+          <div style={styles.empty}>
+            Provenance records the count and limit only; raw turn text isn't
+            persisted on the trace row to keep history mutations append-only.
+            The original turn was emitted at{' '}
+            <code>{formatTimestamp(detail.created_at)}</code>.
+          </div>
+          <pre style={{ ...styles.pre, marginTop: 10 }}>
+            {JSON.stringify(prov.selectors?.last_n_turns ?? {}, null, 2)}
+          </pre>
+        </div>
+      </div>
+
+      {/* ── Retrieved memories ────────────────────────────────────── */}
+      <div style={styles.section}>
+        <div style={styles.sectionHeader}>
+          <span>Retrieved memories</span>
+          <span style={styles.pill('#34d399')}>{memoryIds.length} hit(s)</span>
+        </div>
+        <div style={styles.sectionBody}>
+          {reasons.retrieved_memory && (
+            <div style={styles.reason}>{reasons.retrieved_memory}</div>
+          )}
+          {memoryIds.length === 0 ? (
+            <div style={styles.empty}>no recall hits for this turn</div>
+          ) : (
+            <ul style={{ ...styles.list, paddingLeft: 0 }}>
+              {memoryIds.map(([id, score], i) => (
+                <ExpandableMemoryRow key={`${id}-${i}`} id={String(id)} score={Number(score)} />
+              ))}
+            </ul>
+          )}
+        </div>
+      </div>
+
+      {/* ── Skill match ───────────────────────────────────────────── */}
+      <div style={styles.section}>
+        <div style={styles.sectionHeader}>
+          <span>Skill match</span>
+          <span style={styles.pill('#facc15')}>
+            {prov.skill_match ? 'matched' : 'no per-turn match'}
+          </span>
+        </div>
+        <div style={styles.sectionBody}>
+          {reasons.skill_match && <div style={styles.reason}>{reasons.skill_match}</div>}
+          {prov.skill_match ? (
+            <pre style={styles.pre}>{JSON.stringify(prov.skill_match, null, 2)}</pre>
+          ) : (
+            <div style={styles.empty}>
+              No per-turn similarity match — the system uses progressive
+              disclosure: skills are listed in the system prompt and the
+              model picks them via the <code>skill_view</code> tool.
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* ── Capability block ──────────────────────────────────────── */}
+      <CapabilityBlockSection
+        version={prov.capability_block_version ?? ''}
+        reason={reasons.capability_block}
+        capabilityProvenance={prov.selectors?.capability_block ?? null}
+        currentTraceId={detail.trace_id}
+      />
+
+      {/* ── Re-render ─────────────────────────────────────────────── */}
+      <div style={styles.section}>
+        <div style={styles.sectionHeader}>
+          <span>Re-render prompt</span>
+          {rerender && (
+            <span
+              style={
+                rerender.matches_original
+                  ? styles.matchPillTrue
+                  : styles.matchPillFalse
+              }
+            >
+              {rerender.matches_original
+                ? 'structural match'
+                : 'diverged from original'}
+            </span>
+          )}
+        </div>
+        <div style={styles.sectionBody}>
+          <div style={styles.reason}>
+            Runs the live assembler against this trace's input. Result is
+            in-browser only — never logged server-side.
+          </div>
+          <div style={styles.rerenderRow}>
+            <button
+              style={styles.primaryButton}
+              onClick={handleRerender}
+              disabled={rerendering}
+            >
+              {rerendering ? 'rendering…' : 'Re-render prompt'}
+            </button>
+            {rerender && (
+              <span style={{ fontSize: 11, color: '#888' }}>
+                hash: <code>{rerender.prompt_hash.slice(0, 12)}…</code>
+              </span>
+            )}
+          </div>
+          {rerenderError && (
+            <div style={{ marginTop: 10, color: '#fca5a5', fontSize: 12 }}>
+              error: {rerenderError}
+            </div>
+          )}
+          {rerender && (
+            <>
+              {rerender.notes.length > 0 && (
+                <ul
+                  style={{
+                    ...styles.list,
+                    marginTop: 10,
+                    color: '#9ca3af',
+                    fontSize: 12,
+                  }}
+                >
+                  {rerender.notes.map((n, i) => (
+                    <li key={i}>{n}</li>
+                  ))}
+                </ul>
+              )}
+              <div style={{ marginTop: 10, fontSize: 11, color: '#888' }}>
+                rendered prompt:
+              </div>
+              <pre style={styles.pre}>{rerender.prompt}</pre>
+              <div style={{ marginTop: 10, fontSize: 11, color: '#888' }}>
+                provenance diff (original → re-rendered):
+              </div>
+              <pre style={styles.pre}>
+                {JSON.stringify(
+                  {
+                    original: rerender.original_provenance,
+                    rerendered: rerender.provenance,
+                  },
+                  null,
+                  2,
+                )}
+              </pre>
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+interface CapabilityBlockSectionProps {
+  version: string
+  reason?: string
+  capabilityProvenance: Record<string, unknown> | null
+  currentTraceId: string
+}
+
+function CapabilityBlockSection({
+  version,
+  reason,
+  capabilityProvenance,
+  currentTraceId,
+}: CapabilityBlockSectionProps) {
+  const [priorVersion, setPriorVersion] = useState<string | null>(null)
+  const [priorTraceId, setPriorTraceId] = useState<string | null>(null)
+  const [searched, setSearched] = useState(false)
+
+  useEffect(() => {
+    let cancelled = false
+    // Fetch a small window of recent traces and look for the most recent
+    // one with a different capability_block_version. This is best-effort:
+    // if the operator wants a precise prior trace, they can navigate via
+    // the trace list.
+    api
+      .listTraces({ limit: 25 })
+      .then(async (resp) => {
+        for (const summary of resp.traces) {
+          if (cancelled) return
+          if (summary.trace_id === currentTraceId) continue
+          try {
+            const d = await api.getTrace(summary.trace_id)
+            if (cancelled) return
+            const ver = (d.assembled_context as ProvenanceShape | undefined)
+              ?.capability_block_version
+            if (ver && ver !== version) {
+              setPriorVersion(ver)
+              setPriorTraceId(d.trace_id)
+              break
+            }
+          } catch {
+            // fall through to next summary
+          }
+        }
+      })
+      .catch(() => {
+        // ignore — we'll just show "no prior version found"
+      })
+      .finally(() => !cancelled && setSearched(true))
+    return () => {
+      cancelled = true
+    }
+  }, [currentTraceId, version])
+
+  return (
+    <div style={styles.section}>
+      <div style={styles.sectionHeader}>
+        <span>Capability block</span>
+        <code style={{ fontSize: 11, color: '#9ca3af' }}>{version || '<none>'}</code>
+      </div>
+      <div style={styles.sectionBody}>
+        {reason && <div style={styles.reason}>{reason}</div>}
+        {capabilityProvenance && (
+          <pre style={styles.pre}>
+            {JSON.stringify(capabilityProvenance, null, 2)}
+          </pre>
+        )}
+        <div style={{ ...styles.capabilityDiff, marginTop: 10 }}>
+          {!searched && 'searching for prior version…'}
+          {searched && priorVersion && (
+            <>
+              prior trace <code>{priorTraceId}</code> ran with version{' '}
+              <code>{priorVersion}</code>
+              {priorVersion === version
+                ? ' — unchanged'
+                : ' — changed since last trace'}
+            </>
+          )}
+          {searched && !priorVersion && (
+            <span style={{ color: '#888' }}>
+              no prior trace with a different version found in the last 25
+              entries
+            </span>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/web/src/components/Traces.tsx
+++ b/web/src/components/Traces.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react'
 import { api, type TraceDetail, type TraceSummary } from '../api'
 import { logError, logInfo } from '../logger'
+import TraceContextInspector from './TraceContextInspector'
 
 const styles = {
   root: { display: 'flex', height: '100%', overflow: 'hidden' as const },
@@ -49,6 +50,17 @@ const styles = {
     overflowY: 'auto' as const,
     padding: 24,
   },
+  inspectButton: {
+    marginTop: 12,
+    background: '#1e3a5f',
+    color: '#bfdbfe',
+    border: '1px solid #2a4a73',
+    borderRadius: 4,
+    padding: '6px 12px',
+    cursor: 'pointer',
+    fontSize: 12,
+    fontFamily: 'inherit',
+  },
   header: { fontSize: 18, fontWeight: 600, marginBottom: 4 },
   field: { marginTop: 16 },
   label: { fontSize: 11, color: '#888', textTransform: 'uppercase' as const, letterSpacing: 0.5 },
@@ -96,6 +108,39 @@ export default function Traces() {
   const [trigger, setTrigger] = useState<string>('')
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  // #34 — when set, drills into the prompt-construction inspector for the
+  // currently-selected trace. Lives at /traces/:id/context conceptually
+  // even though we don't use a router — the URL hash mirrors the route.
+  const [inspectingId, setInspectingId] = useState<string | null>(null)
+
+  // Read/write a #/traces/{id}/context fragment so the inspector deep-link
+  // is shareable across reloads (the issue calls out the route name).
+  useEffect(() => {
+    const apply = () => {
+      const m = window.location.hash.match(/^#\/traces\/([^/]+)\/context$/)
+      if (m) {
+        setInspectingId(m[1])
+        setSelectedId(m[1])
+      } else {
+        setInspectingId(null)
+      }
+    }
+    apply()
+    window.addEventListener('hashchange', apply)
+    return () => window.removeEventListener('hashchange', apply)
+  }, [])
+
+  const openInspector = (id: string) => {
+    window.location.hash = `#/traces/${id}/context`
+    setInspectingId(id)
+    logInfo('traces', 'inspector_opened', { trace_id: id })
+  }
+  const closeInspector = () => {
+    if (window.location.hash.startsWith('#/traces/')) {
+      window.location.hash = ''
+    }
+    setInspectingId(null)
+  }
 
   useEffect(() => {
     let cancelled = false
@@ -147,6 +192,16 @@ export default function Traces() {
       cancelled = true
     }
   }, [selectedId])
+
+  if (inspectingId) {
+    return (
+      <TraceContextInspector
+        traceId={inspectingId}
+        detail={detail && detail.trace_id === inspectingId ? detail : undefined}
+        onBack={closeInspector}
+      />
+    )
+  }
 
   return (
     <div style={styles.root}>
@@ -222,6 +277,12 @@ export default function Traces() {
               {formatLatency(detail.latency_ms)} · prompt:{' '}
               <code>{detail.prompt_version}</code>
             </div>
+            <button
+              style={styles.inspectButton}
+              onClick={() => openInspector(detail.trace_id)}
+            >
+              Inspect prompt construction →
+            </button>
             <div style={styles.field}>
               <div style={styles.label}>input</div>
               <div style={styles.value}>{detail.input}</div>


### PR DESCRIPTION
## Summary
Adds a per-trace inspector at `/traces/:id/context` that breaks down prompt construction: life context sections, conversation history with timestamps, retrieved memories with scores expandable to full content, skill match (currently null per #33), and capability block version with a real line-by-line diff vs. the previous trace.

A "Re-render prompt" button hits `POST /api/traces/{id}/rerender-prompt` and shows the structural diff against the original — useful for verifying assembler changes against historical inputs.

A red "Raw personal data — local only" banner sits at the top. All routes inherit the existing `require_api_key` + `_enforce_localhost_bind` from #24.

## Backend
- `POST /api/traces/{id}/rerender-prompt` — re-runs the assembler, returns rendered prompt + provenance + matches_original flag. Response body is RAW_PERSONAL; never logged.
- `GET /api/memories/{id}` — for expandable memory content in the inspector. Audit log records the id only, never the body.
- `TraceSummary.capability_block_version` projected from JSONB so prior-version lookup is one fetch, not N+1.
- `agent.context.decisions.annotate_from_provenance(selectors_dict)` — public API consumed by the HTTP layer (replaces a private-symbol import).
- `_client_is_loopback` uses `ipaddress.is_loopback` (covers `::ffff:127.0.0.1`).

## Frontend
- `web/src/components/TraceContextInspector.tsx` — new inspector (banner, life context, conversation history with per-turn timestamps, expandable memory rows, skill match graceful fallback, capability block diff, re-render with diff).
- Dependency-free LCS-based line diff (`+`/`−` markers, 50-line cap).
- Hash-based routing (`#/traces/:id/context`) — no new dependency.
- Legacy-trace empty-state banner when `assembled_context` is empty.

## Test plan
- [x] Backend: 76/76 tests pass (`agent/tests/test_traces_http.py` + `tests/agent/context/`)
- [x] Re-render endpoint gated by `require_api_key` + `_enforce_localhost_bind`; explicit test for localhost denial
- [x] `decision_reasons` populated server-side via the new public `annotate_from_provenance`
- [x] `npm run build` succeeds (no TypeScript errors)
- [x] No new dependencies (backend or frontend)
- [x] No cross-subsystem imports; no XSS surface (all rendered content via JSX text or `<pre>` — React-escaped)

## Out of scope
- Storing proactive contexts (memory/web/calendar/email/etc.) on the trace row so re-render can be byte-identical — large schema change deferred. Today's structural-match comparison ignores volatile keys (`last_n_turns`, history content, capability block content) so unchanged code reports `matches_original=true`.

Closes #34