### PR TITLE
agents: scaffold agents/ + isolation lint (#38)

### DIFF
--- a/agent/tests/test_agents_isolation.py
+++ b/agent/tests/test_agents_isolation.py
@@ -1,0 +1,461 @@
+"""Lint enforcement for the `agents/` boundary (ADR-0004 + ADR-0006).
+
+Four rules, all enforced by static AST analysis (no module execution):
+
+1. No `agents/<X>/` module imports from `agents/<Y>/` for any other
+   archetype Y. (`_shared` is the documented exception — see rule 3.)
+2. No module under `agents/` imports from `subsystems/` or from
+   `agent.core` (or its submodules).
+3. Every file under `agents/_shared/` has a module-level docstring.
+4. `agents/_shared/` does not contain module-level mutable state —
+   no top-level `name = {}`, `name: T = []`, etc., for mutable
+   container types or unguarded `global` writes.
+
+Each rule has a positive case (the real `agents/` tree passes) and a
+negative fixture-based case (a deliberately-violating tree under a
+tmp dir is detected).
+"""
+from __future__ import annotations
+
+import ast
+import textwrap
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+AGENTS_DIR = REPO_ROOT / "agents"
+
+
+# ── Static-analysis helpers ──────────────────────────────────────────────────
+
+
+def _display_path(p: Path) -> str:
+    """Render a path relative to the repo root when possible, else absolute."""
+    try:
+        return str(p.relative_to(REPO_ROOT))
+    except ValueError:
+        return str(p)
+
+
+def _iter_python_files(root: Path) -> list[Path]:
+    if not root.exists():
+        return []
+    return sorted(p for p in root.rglob("*.py") if p.is_file())
+
+
+def _module_path_for(path: Path, agents_root: Path) -> str:
+    """`agents_root/reflector/main.py` → `agents.reflector.main`."""
+    rel = path.relative_to(agents_root.parent).with_suffix("")
+    return ".".join(rel.parts)
+
+
+def _imports_from(tree: ast.AST) -> list[str]:
+    """Collect every fully-qualified import target as dotted names.
+
+    For `from X import a, b`, we emit both `X` AND `X.a` / `X.b`. The
+    second form catches the `from agents import monitor` shape, where
+    the imported symbol IS the archetype module — emitting only `X`
+    would silently miss it.
+    """
+    out: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                out.append(alias.name)
+        elif isinstance(node, ast.ImportFrom):
+            mod = node.module or ""
+            prefix = "." * node.level
+            base = f"{prefix}{mod}"
+            out.append(base)
+            for alias in node.names:
+                if alias.name == "*":
+                    continue
+                if base and not base.endswith("."):
+                    out.append(f"{base}.{alias.name}")
+                else:
+                    out.append(f"{base}{alias.name}")
+    # Escape hatches: `importlib.import_module("agents.monitor")` and
+    # `__import__("subsystems.calendar")` are also imports for the
+    # purpose of the boundary. AST-detect their string-literal first
+    # argument and add it to the import set.
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call):
+            target = _dynamic_import_target(node)
+            if target is not None:
+                out.append(target)
+    return out
+
+
+def _dynamic_import_target(call: ast.Call) -> str | None:
+    """Return the string-literal target of a dynamic-import call, or None.
+
+    Recognises:
+      - `importlib.import_module("X")`
+      - `import_module("X")`        (when imported as bare name)
+      - `__import__("X")`
+    """
+    func = call.func
+    name: str | None = None
+    if isinstance(func, ast.Attribute) and func.attr == "import_module":
+        name = "import_module"
+    elif isinstance(func, ast.Name) and func.id in {"import_module", "__import__"}:
+        name = func.id
+    if name is None:
+        return None
+    if not call.args:
+        return None
+    first = call.args[0]
+    if isinstance(first, ast.Constant) and isinstance(first.value, str):
+        return first.value
+    return None
+
+
+def _archetype_of(module_path: str, agents_root: Path) -> str | None:
+    """Return the archetype name for a module under `agents/`, or None.
+
+    `agents.reflector.main` → "reflector"
+    `agents._shared.logging` → "_shared"
+    `agents.runner` → None (top-level runner, not part of any archetype)
+    `agents` → None
+    `agent.tests.foo` → None (not under agents/)
+    """
+    parts = module_path.split(".")
+    if not parts or parts[0] != "agents":
+        return None
+    if len(parts) < 2:
+        return None
+    return parts[1]
+
+
+def _resolve_relative(importer_module: str, raw_target: str) -> str:
+    """Resolve a possibly-relative import target into an absolute one."""
+    if not raw_target.startswith("."):
+        return raw_target
+    level = 0
+    while level < len(raw_target) and raw_target[level] == ".":
+        level += 1
+    tail = raw_target[level:]
+    parts = importer_module.split(".")
+    base = parts[: max(0, len(parts) - level)]
+    return ".".join([*base, tail] if tail else base)
+
+
+# ── Rule 1 + 2: import boundaries ────────────────────────────────────────────
+
+
+def _scan_imports(agents_root: Path) -> list[tuple[Path, str, str]]:
+    """Yield (file, importer_module, resolved_target) for every import
+    statement in every .py file under `agents_root`.
+    """
+    findings: list[tuple[Path, str, str]] = []
+    for py in _iter_python_files(agents_root):
+        tree = ast.parse(py.read_text(encoding="utf-8"), filename=str(py))
+        importer = _module_path_for(py, agents_root)
+        for raw in _imports_from(tree):
+            resolved = _resolve_relative(importer, raw)
+            findings.append((py, importer, resolved))
+    return findings
+
+
+def _violations_cross_archetype(
+    findings: list[tuple[Path, str, str]], agents_root: Path
+) -> list[str]:
+    bad: list[str] = []
+    for py, importer, target in findings:
+        if not target.startswith("agents."):
+            continue
+        importer_arch = _archetype_of(importer, agents_root)
+        target_arch = _archetype_of(target, agents_root)
+        if importer_arch is None or target_arch is None:
+            continue
+        if importer_arch == target_arch:
+            continue
+        # `_shared` is the only carve-out (ADR-0004 §"_shared/ discipline").
+        if target_arch == "_shared":
+            continue
+        bad.append(f"{_display_path(py)}: {importer} imports {target}")
+    return bad
+
+
+def _violations_into_orchestrator_or_subsystems(
+    findings: list[tuple[Path, str, str]],
+) -> list[str]:
+    bad: list[str] = []
+    for py, importer, target in findings:
+        if target == "agent.core" or target.startswith("agent.core."):
+            bad.append(f"{_display_path(py)}: {importer} imports {target}")
+        elif target == "subsystems" or target.startswith("subsystems."):
+            bad.append(f"{_display_path(py)}: {importer} imports {target}")
+    return bad
+
+
+# ── Rule 3 + 4: `_shared/` discipline ─────────────────────────────────────────
+
+
+def _missing_docstring_files(shared_root: Path) -> list[str]:
+    bad: list[str] = []
+    for py in _iter_python_files(shared_root):
+        # __init__.py with body counts; bare empty __init__.py would also
+        # be a violation under this rule because it carves out a shared
+        # surface without explaining why.
+        tree = ast.parse(py.read_text(encoding="utf-8"), filename=str(py))
+        if ast.get_docstring(tree) is None:
+            bad.append(_display_path(py))
+    return bad
+
+
+_MUTABLE_CONTAINER_NAMES = {"dict", "list", "set"}
+
+
+def _is_mutable_value(node: ast.AST) -> bool:
+    """Heuristic: detect the common module-level state shapes."""
+    # Literals that hold mutable state.
+    if isinstance(node, (ast.Dict, ast.List, ast.Set)):
+        return True
+    # `dict()`, `list()`, `set()`, `defaultdict(...)`, etc.
+    if isinstance(node, ast.Call):
+        func = node.func
+        if isinstance(func, ast.Name) and func.id in _MUTABLE_CONTAINER_NAMES:
+            return True
+        if isinstance(func, ast.Name) and func.id in {"defaultdict", "OrderedDict", "Counter"}:
+            return True
+        if isinstance(func, ast.Attribute) and func.attr in {
+            "defaultdict",
+            "OrderedDict",
+            "Counter",
+        }:
+            return True
+    return False
+
+
+_DOCSTRING_BODY_NODES = (ast.Expr,)  # the docstring itself
+
+
+def _module_level_state_violations(shared_root: Path) -> list[str]:
+    bad: list[str] = []
+    for py in _iter_python_files(shared_root):
+        tree = ast.parse(py.read_text(encoding="utf-8"), filename=str(py))
+        for node in tree.body:
+            # `name = {...}` / `name = []` / `name = dict()` etc.
+            if isinstance(node, ast.Assign):
+                for tgt in node.targets:
+                    if isinstance(tgt, ast.Name) and _is_mutable_value(node.value):
+                        bad.append(
+                            f"{_display_path(py)}:{node.lineno}: "
+                            f"module-level mutable assignment to {tgt.id!r}"
+                        )
+            # `name: dict = {}`
+            elif isinstance(node, ast.AnnAssign):
+                if (
+                    node.value is not None
+                    and isinstance(node.target, ast.Name)
+                    and _is_mutable_value(node.value)
+                ):
+                    bad.append(
+                        f"{_display_path(py)}:{node.lineno}: "
+                        f"module-level mutable annotated assignment to {node.target.id!r}"
+                    )
+            # `global X` at module level is malformed Python; skip.
+    return bad
+
+
+# ── Real-tree tests ──────────────────────────────────────────────────────────
+
+
+@pytest.mark.skipif(not AGENTS_DIR.exists(), reason="agents/ tree not present")
+class TestRealAgentsTree:
+    def test_no_cross_archetype_imports(self) -> None:
+        findings = _scan_imports(AGENTS_DIR)
+        bad = _violations_cross_archetype(findings, AGENTS_DIR)
+        assert bad == [], "cross-archetype imports detected:\n" + "\n".join(bad)
+
+    def test_no_imports_into_orchestrator_or_subsystems(self) -> None:
+        findings = _scan_imports(AGENTS_DIR)
+        bad = _violations_into_orchestrator_or_subsystems(findings)
+        assert bad == [], (
+            "agents/ modules importing agent.core or subsystems/:\n" + "\n".join(bad)
+        )
+
+    def test_shared_files_have_module_docstring(self) -> None:
+        bad = _missing_docstring_files(AGENTS_DIR / "_shared")
+        assert bad == [], "agents/_shared/ files missing module docstring:\n" + "\n".join(bad)
+
+    def test_shared_has_no_module_level_mutable_state(self) -> None:
+        bad = _module_level_state_violations(AGENTS_DIR / "_shared")
+        assert bad == [], "agents/_shared/ module-level state:\n" + "\n".join(bad)
+
+
+# ── Fixture tests: deliberate violations are caught ──────────────────────────
+
+
+def _write(tree_root: Path, rel: str, content: str) -> Path:
+    p = tree_root / rel
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(textwrap.dedent(content).lstrip("\n"), encoding="utf-8")
+    return p
+
+
+class TestFixtureViolationsAreCaught:
+    """Each fixture builds a minimal `agents/` tree under a tmp dir and
+    asserts the relevant rule fires. This guards against future
+    refactors that silently weaken a rule (the real-tree tests would
+    keep passing if the rule were inverted)."""
+
+    def test_cross_archetype_import_is_flagged(self, tmp_path: Path) -> None:
+        agents = tmp_path / "agents"
+        _write(agents, "__init__.py", '"""docs"""\n')
+        _write(agents, "reflector/__init__.py", '"""docs"""\n')
+        _write(
+            agents,
+            "reflector/main.py",
+            '"""reflector main"""\nfrom agents.monitor import helper  # noqa\n',
+        )
+        _write(agents, "monitor/__init__.py", '"""docs"""\n')
+        _write(agents, "monitor/helper.py", '"""monitor helper"""\n')
+
+        findings = _scan_imports(agents)
+        bad = _violations_cross_archetype(findings, agents)
+        assert any("reflector/main.py" in b and "agents.monitor" in b for b in bad), bad
+
+    def test_shared_imports_from_archetype_are_allowed(self, tmp_path: Path) -> None:
+        agents = tmp_path / "agents"
+        _write(agents, "__init__.py", '"""docs"""\n')
+        _write(agents, "_shared/__init__.py", '"""shared"""\n')
+        _write(agents, "_shared/logging.py", '"""shared logging"""\n')
+        _write(agents, "reflector/__init__.py", '"""docs"""\n')
+        _write(
+            agents,
+            "reflector/main.py",
+            '"""reflector main"""\nfrom agents._shared import logging  # noqa\n',
+        )
+
+        findings = _scan_imports(agents)
+        bad = _violations_cross_archetype(findings, agents)
+        assert bad == []
+
+    def test_import_into_subsystems_is_flagged(self, tmp_path: Path) -> None:
+        agents = tmp_path / "agents"
+        _write(agents, "__init__.py", '"""docs"""\n')
+        _write(agents, "reflector/__init__.py", '"""docs"""\n')
+        _write(
+            agents,
+            "reflector/main.py",
+            '"""reflector main"""\nfrom subsystems.calendar import x  # noqa\n',
+        )
+
+        findings = _scan_imports(agents)
+        bad = _violations_into_orchestrator_or_subsystems(findings)
+        assert any("subsystems.calendar" in b for b in bad), bad
+
+    def test_import_into_agent_core_is_flagged(self, tmp_path: Path) -> None:
+        agents = tmp_path / "agents"
+        _write(agents, "__init__.py", '"""docs"""\n')
+        _write(agents, "reflector/__init__.py", '"""docs"""\n')
+        _write(
+            agents,
+            "reflector/main.py",
+            '"""reflector main"""\nfrom agent.core import orchestrator  # noqa\n',
+        )
+
+        findings = _scan_imports(agents)
+        bad = _violations_into_orchestrator_or_subsystems(findings)
+        assert any("agent.core" in b for b in bad), bad
+
+    def test_missing_docstring_in_shared_is_flagged(self, tmp_path: Path) -> None:
+        shared = tmp_path / "agents" / "_shared"
+        # Deliberately no docstring.
+        _write(shared, "no_doc.py", "VALUE = 1\n")
+        bad = _missing_docstring_files(shared)
+        assert any(b.endswith("no_doc.py") for b in bad), bad
+
+    def test_module_level_dict_in_shared_is_flagged(self, tmp_path: Path) -> None:
+        shared = tmp_path / "agents" / "_shared"
+        _write(
+            shared,
+            "stateful.py",
+            '"""shared utility"""\n_cache: dict = {}\n',
+        )
+        bad = _module_level_state_violations(shared)
+        assert bad, bad
+
+    def test_module_level_list_in_shared_is_flagged(self, tmp_path: Path) -> None:
+        shared = tmp_path / "agents" / "_shared"
+        _write(
+            shared,
+            "stateful.py",
+            '"""shared utility"""\nbuffer = []\n',
+        )
+        bad = _module_level_state_violations(shared)
+        assert bad, bad
+
+    def test_from_agents_import_archetype_is_flagged(self, tmp_path: Path) -> None:
+        # `from agents import monitor` — the imported symbol IS the
+        # archetype module, easily missed if only `node.module` is read.
+        agents = tmp_path / "agents"
+        _write(agents, "__init__.py", '"""docs"""\n')
+        _write(agents, "reflector/__init__.py", '"""docs"""\n')
+        _write(
+            agents,
+            "reflector/main.py",
+            '"""reflector main"""\nfrom agents import monitor  # noqa\n',
+        )
+        _write(agents, "monitor/__init__.py", '"""docs"""\n')
+
+        findings = _scan_imports(agents)
+        bad = _violations_cross_archetype(findings, agents)
+        assert any("agents.monitor" in b for b in bad), bad
+
+    def test_importlib_escape_hatch_into_subsystems_is_flagged(
+        self, tmp_path: Path
+    ) -> None:
+        agents = tmp_path / "agents"
+        _write(agents, "__init__.py", '"""docs"""\n')
+        _write(agents, "reflector/__init__.py", '"""docs"""\n')
+        _write(
+            agents,
+            "reflector/main.py",
+            textwrap.dedent(
+                '''
+                """reflector main"""
+                import importlib
+                m = importlib.import_module("subsystems.calendar")
+                '''
+            ),
+        )
+
+        findings = _scan_imports(agents)
+        bad = _violations_into_orchestrator_or_subsystems(findings)
+        assert any("subsystems.calendar" in b for b in bad), bad
+
+    def test_dunder_import_escape_hatch_into_agent_core_is_flagged(
+        self, tmp_path: Path
+    ) -> None:
+        agents = tmp_path / "agents"
+        _write(agents, "__init__.py", '"""docs"""\n')
+        _write(agents, "reflector/__init__.py", '"""docs"""\n')
+        _write(
+            agents,
+            "reflector/main.py",
+            textwrap.dedent(
+                '''
+                """reflector main"""
+                m = __import__("agent.core")
+                '''
+            ),
+        )
+
+        findings = _scan_imports(agents)
+        bad = _violations_into_orchestrator_or_subsystems(findings)
+        assert any("agent.core" in b for b in bad), bad
+
+    def test_module_level_constants_in_shared_are_allowed(self, tmp_path: Path) -> None:
+        shared = tmp_path / "agents" / "_shared"
+        _write(
+            shared,
+            "constants.py",
+            '"""shared constants"""\nDEFAULT = "x"\nPORT: int = 5432\n',
+        )
+        bad = _module_level_state_violations(shared)
+        assert bad == []

--- a/agents/README.md
+++ b/agents/README.md
@@ -1,0 +1,101 @@
+# `agents/` — Cognitive specialists
+
+This directory is the home for Pepper's cognitive archetypes:
+long-running, specialised AI processes that consume traces and produce
+reflections, compressions, summaries, or research outputs.
+
+It is parallel to — and intentionally distinct from:
+
+- **`agent/`** (singular) — the orchestrator and its supporting code.
+- **`subsystems/`** — capability boundaries (Calendar, Communications,
+  Knowledge, Health, Finance, eventually People).
+
+## Why a separate directory
+
+ADR-0004 introduces this directory to keep cognitive specialisation
+from collapsing into either the orchestrator (`agent/`) or capability
+boundaries (`subsystems/`). The OJ-calibration thread documents why a
+single-orchestrator pattern fails once reflection, monitoring, and
+salience scoring need different cadences and prompt windows.
+
+ADR-0006 ratifies the operating shape: each archetype runs as its own
+OS process, triggered from APScheduler in core via a thin Postgres
+`LISTEN/NOTIFY` shim. Crash isolation, memory independence, and per-
+archetype observability fall out of that decision.
+
+## Isolation rule
+
+Every module under `agents/` follows four rules. `_shared/` exists as
+the only narrow exception (see below).
+
+1. **No cross-imports between archetypes.** `agents/reflector/` cannot
+   import from `agents/monitor/`. Archetypes communicate via the trace
+   store and persisted artefacts (reflections, summaries), not via
+   shared code.
+2. **No imports from `agent/core.py` or any `subsystems/`.** The
+   orchestrator is downstream of cognitive agents; agents must never
+   reach back into it. Subsystem capabilities are reached via tool
+   calls / MCP, not via direct Python imports.
+3. **`agents/_shared/` is allowed for utilities only.** Logging setup,
+   config loading, db connection management, pure helpers. Never
+   state. See `_shared/__init__.py` for the safeguards.
+4. **Each archetype is independently replaceable.** Swapping the
+   reflector for a different implementation must not require touching
+   any other archetype.
+
+These rules are enforced by `agent/tests/test_agents_isolation.py`.
+That test fails CI on any violation, including:
+
+- An archetype importing from a sibling archetype.
+- An archetype importing from `agent/core` or `subsystems/`.
+- A new file under `_shared/` without a module-level docstring.
+- A module-level mutable assignment under `_shared/` (the state
+  smell — `_cache: dict = {}`, `state = {}`, etc.).
+
+## `agents/_shared/` carve-out
+
+`_shared/` is a narrow exception. It carries three layered safeguards
+(per ADR-0004 §"`agents/_shared/` discipline"):
+
+1. **Mandatory docstring rationale.** Every file under `_shared/`
+   must carry a top-of-file docstring naming the utility and
+   explaining why it is shared rather than living inside one agent.
+   The lint test fails CI without it.
+2. **PR-review checklist item.** Every PR that adds or modifies a
+   file under `_shared/` answers the question:
+   *"Does this `_shared/` addition store state, or does it just
+   provide utilities?"* If the answer is "stores state," the change
+   is rejected and the state is moved to its own subsystem.
+3. **Quarterly audit.** Once per quarter, `_shared/` is reviewed and
+   anything that has drifted toward coupling is split out as a
+   subsystem with its own MCP contract.
+
+If `_shared/` ever drifts into holding state, the escalation path is
+to **split it out as a subsystem** — not to relax these rules.
+
+## Running an archetype
+
+Archetypes are launched through the generic runner entrypoint:
+
+```bash
+python -m agents.runner --archetype reflector
+```
+
+In production, each archetype runs as its own `docker-compose`
+service (see the `agents/` block in `docker-compose.yml`). The runner
+configures shared logging via `agents/_shared/logging.py`, installs
+SIGTERM/SIGINT handlers, and dispatches to `agents/<name>/main.py:run(
+config)`.
+
+The substrate phase ships one archetype: `agents-reflector` (issue
+#39). `agents-monitor` and `agents-researcher` are reserved names —
+the runner will accept `--archetype monitor`/`--archetype researcher`
+once their implementations land, and emits a clear "not yet
+implemented" error in the meantime.
+
+## See also
+
+- ADR-0004 — directory rule and isolation.
+- ADR-0006 — separate process per archetype.
+- `agent/tests/test_agents_isolation.py` — the lint check.
+- `agents/_shared/__init__.py` — `_shared/` discipline rules.

--- a/agents/__init__.py
+++ b/agents/__init__.py
@@ -1,0 +1,24 @@
+"""Cognitive specialists.
+
+`agents/` (plural) is the home for long-running cognitive processes —
+reflectors, monitors, researchers — that consume traces and produce
+reflections, compressions, summaries, or research outputs.
+
+Distinct from `agent/` (singular, the orchestrator) and from
+`subsystems/` (capability boundaries). Each module here runs as its own
+OS process per ADR-0006; isolation rule per ADR-0004:
+
+1. No cross-imports between agent modules. `agents/reflector/` cannot
+   import from `agents/monitor/` or any other archetype.
+2. No imports from `agent/core.py` or any `subsystems/`. Capabilities
+   are reached the same way the orchestrator reaches them — via tool
+   calls / MCP, not direct Python imports.
+3. Imports from `agents/_shared/` are allowed for utilities only —
+   never for state. See `agents/_shared/__init__.py` for safeguards.
+4. Each archetype is independently replaceable.
+
+These rules are enforced by `agent/tests/test_agents_isolation.py`.
+
+See `agents/README.md` for the longer rationale and ADR-0004/0006 for
+the source-of-truth decisions.
+"""

--- a/agents/_shared/__init__.py
+++ b/agents/_shared/__init__.py
@@ -1,0 +1,26 @@
+"""Utilities shared across cognitive archetypes.
+
+This carve-out is an intentional, narrow exception to the rule that
+agents under `agents/` do not import from each other (ADR-0004 §
+"Isolation rule"). It exists so each archetype does not have to redo
+logging setup, config loading, and Postgres connection plumbing inside
+its own module.
+
+Three discipline rules apply, enforced by
+`agent/tests/test_agents_isolation.py`:
+
+1. **Utilities only.** Modules here MUST be pure helpers — logging
+   setup, env loading, connection factories, formatting. No state.
+2. **Mandatory module docstring.** Every file added under
+   `agents/_shared/` must carry a top-of-file docstring naming the
+   utility and explaining why it is shared rather than living inside a
+   single agent.
+3. **No module-level mutable state.** No `_cache: dict = {}`, no
+   singletons, no shared session objects at module scope. Anything
+   that holds state must move out of `_shared/` into its own
+   subsystem with its own MCP contract.
+
+If `_shared/` ever drifts into holding state across agents, the
+escalation path is to split that state out as a subsystem — not to
+relax these rules. See ADR-0004 §"`agents/_shared/` discipline".
+"""

--- a/agents/_shared/config.py
+++ b/agents/_shared/config.py
@@ -1,0 +1,63 @@
+"""Env-loading helpers for agent processes.
+
+Lives in `_shared/` because every archetype reads the same `.env` file
+that Pepper Core reads — duplicating the loading logic per archetype
+would let configuration drift between processes (different default
+log level, different Postgres URL, different timezone). The helper
+returns plain values; nothing is cached at module scope.
+
+The Pepper-Core `Settings` object in `agent/config.py` is the
+authoritative shape for the full env. Agents typically only need a
+narrow slice (Postgres URL, log level, archetype name) and read it
+through these helpers rather than importing the full `Settings`
+object — that import would pull in orchestrator-only dependencies
+and weaken the archetype's standalone-ness.
+"""
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+DEFAULT_POSTGRES_URL = "postgresql+asyncpg://pepper:pepper@localhost:5432/pepper"
+DEFAULT_LOG_LEVEL = "INFO"
+
+
+@dataclass(frozen=True)
+class AgentRuntimeConfig:
+    """Narrow slice of env every agent process needs.
+
+    Frozen so a long-running process cannot silently mutate its own
+    config mid-flight. Construct once at startup; pass to the
+    archetype's `run()` entrypoint.
+
+    `notify_channel` names the Postgres `LISTEN/NOTIFY` channel the
+    archetype subscribes to (per ADR-0006). Defaults to
+    `f"{archetype}_trigger"`. Note that LISTEN/NOTIFY requires a
+    libpq-style connection (psycopg) and does not interoperate with
+    the `+asyncpg` driver SQLAlchemy URL — the archetype is
+    responsible for opening that connection separately if it wants to
+    LISTEN; `postgres_url` is the SQLAlchemy URL for everything else.
+    """
+
+    archetype: str
+    postgres_url: str
+    log_level: str
+    notify_channel: str
+
+
+def load_runtime_config(archetype: str) -> AgentRuntimeConfig:
+    """Read environment into a runtime config bundle.
+
+    Reads from `os.environ`; any `.env` loading must happen before this
+    is called (the runner relies on the shell / docker-compose
+    `env_file:` directive to populate the environment).
+    """
+    return AgentRuntimeConfig(
+        archetype=archetype,
+        postgres_url=os.environ.get("POSTGRES_URL", DEFAULT_POSTGRES_URL),
+        log_level=os.environ.get("LOG_LEVEL", DEFAULT_LOG_LEVEL),
+        notify_channel=os.environ.get(
+            f"PEPPER_AGENT_{archetype.upper()}_NOTIFY_CHANNEL",
+            f"{archetype}_trigger",
+        ),
+    )

--- a/agents/_shared/db.py
+++ b/agents/_shared/db.py
@@ -1,0 +1,52 @@
+"""Postgres connection factory for agent processes.
+
+Lives in `_shared/` because every archetype talks to the same Postgres
+instance Pepper Core uses (the trace store + per-archetype output
+tables) and re-implementing the engine/session boilerplate inside each
+archetype would risk subtle divergence (different pool sizes,
+different `pool_pre_ping`, different encoding). The factory returns
+fresh engine/session objects on each call; nothing is held at module
+scope.
+
+Note: this module deliberately does NOT import `agent.db` so the
+`agents/` boundary remains clean (per ADR-0004 §"Isolation rule").
+The shape is mirrored by hand and any divergence from `agent/db.py`
+is a review concern.
+"""
+from __future__ import annotations
+
+from sqlalchemy.ext.asyncio import (
+    AsyncEngine,
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
+
+
+def make_engine(postgres_url: str) -> AsyncEngine:
+    """Create a fresh async engine for an archetype process.
+
+    `pool_pre_ping=True` matches `agent.db.init_db` — it's what guards
+    against stale connections after Postgres restarts. `echo=False`
+    keeps SQL out of agent logs by default; per-archetype debugging
+    can wrap individual sessions if needed.
+    """
+    return create_async_engine(
+        postgres_url,
+        echo=False,
+        pool_pre_ping=True,
+    )
+
+
+def make_session_factory(engine: AsyncEngine) -> async_sessionmaker[AsyncSession]:
+    """Create an async session factory bound to `engine`.
+
+    `expire_on_commit=False` matches `agent.db.init_db` — it lets the
+    caller keep using attribute access on ORM rows after commit, which
+    is the common shape for read-mostly archetype loops.
+    """
+    return async_sessionmaker(
+        engine,
+        expire_on_commit=False,
+        class_=AsyncSession,
+    )

--- a/agents/_shared/logging.py
+++ b/agents/_shared/logging.py
@@ -1,0 +1,72 @@
+"""Structlog setup for agent processes.
+
+Mirrors the configuration in `agent/start.py` so every archetype gets
+the same console renderer, ISO timestamps, and stdlib-bridge as Pepper
+Core. Lives in `_shared/` because every archetype needs identical
+logging — divergence between archetypes would make cross-process
+debugging painful — and because the configuration is pure (no state
+held at module scope).
+
+Callers: `agents/runner.py` invokes `configure_logging(...)` once at
+startup; archetype `main.py` modules then `structlog.get_logger(...)`
+as usual.
+"""
+from __future__ import annotations
+
+import logging
+import sys
+
+import structlog
+
+DEFAULT_LOG_LEVEL = "INFO"
+
+_NOISY_THIRD_PARTY = (
+    "httpcore",
+    "httpx",
+    "asyncio",
+    "apscheduler",
+    "tzlocal",
+    "sqlalchemy.engine",
+)
+
+
+def configure_logging(level: str = DEFAULT_LOG_LEVEL, *, archetype: str | None = None) -> None:
+    """Configure structlog + stdlib root logger for an agent process.
+
+    Idempotent: callers may invoke it more than once (tests do).
+    `archetype`, when provided, is bound as a default field on every
+    log line so multi-archetype log aggregation can filter by source.
+    """
+    log_level = getattr(logging, level.upper(), logging.INFO)
+
+    shared_processors: list = [
+        structlog.processors.TimeStamper(fmt="iso"),
+        structlog.stdlib.add_log_level,
+    ]
+
+    renderer = structlog.dev.ConsoleRenderer(
+        exception_formatter=structlog.dev.plain_traceback,
+    )
+
+    structlog.configure(
+        wrapper_class=structlog.make_filtering_bound_logger(log_level),
+        processors=shared_processors + [renderer],
+    )
+
+    if archetype is not None:
+        structlog.contextvars.clear_contextvars()
+        structlog.contextvars.bind_contextvars(archetype=archetype)
+
+    handler = logging.StreamHandler(sys.stdout)
+    handler.setFormatter(
+        structlog.stdlib.ProcessorFormatter(
+            processors=shared_processors + [renderer],
+        )
+    )
+    root = logging.getLogger()
+    root.handlers.clear()
+    root.addHandler(handler)
+    root.setLevel(log_level)
+
+    for noisy in _NOISY_THIRD_PARTY:
+        logging.getLogger(noisy).setLevel(logging.WARNING)

--- a/agents/runner.py
+++ b/agents/runner.py
@@ -1,0 +1,157 @@
+"""Generic entrypoint for agent processes.
+
+Per ADR-0006, each cognitive archetype runs as its own OS process. This
+module is the single CLI entrypoint every process boots from:
+
+    python -m agents.runner --archetype reflector
+
+It loads the named archetype from `agents/<name>/main.py`, configures
+shared logging, installs SIGTERM/SIGINT handlers for graceful
+shutdown, and then awaits the archetype's `run(config)` coroutine.
+
+The archetype implementations are imported lazily — referencing an
+archetype that does not yet exist (e.g. `monitor` in the substrate
+phase) returns a clear "not yet implemented" error rather than an
+ImportError stack.
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import importlib
+import signal
+import sys
+from typing import Awaitable, Callable, Protocol
+
+import structlog
+
+from agents._shared.config import AgentRuntimeConfig, load_runtime_config
+from agents._shared.logging import configure_logging
+
+logger = structlog.get_logger(__name__)
+
+# Archetypes whose main.py is allowed to be discovered. Per ADR-0006:
+#   - reflector lands in #39
+#   - monitor + researcher are listed but not yet implemented
+# Adding a new archetype means adding the directory `agents/<name>/`
+# with a `main.py:run(config)` async entrypoint AND adding the name
+# here. The allow-list is the operational analogue of ADR-0004's
+# enumeration of inhabitants.
+_KNOWN_ARCHETYPES: tuple[str, ...] = ("reflector", "monitor", "researcher")
+
+
+class _AgentMain(Protocol):
+    """Shape every archetype's `main.py` must conform to."""
+
+    async def run(self, config: AgentRuntimeConfig) -> None: ...
+
+
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        prog="agents.runner",
+        description="Run a Pepper cognitive archetype as a long-lived process.",
+    )
+    parser.add_argument(
+        "--archetype",
+        required=True,
+        choices=_KNOWN_ARCHETYPES,
+        help="Which archetype to run. Must match a directory under agents/.",
+    )
+    return parser.parse_args(argv)
+
+
+def _load_archetype_run(name: str) -> Callable[[AgentRuntimeConfig], Awaitable[None]]:
+    """Import `agents.<name>.main:run` and return the coroutine fn.
+
+    Raises `RuntimeError` with a clear message ONLY when the archetype
+    module itself is missing. If the archetype module exists but a
+    transitive import fails (a real bug in the archetype), the
+    `ModuleNotFoundError` is re-raised unchanged so the dev-loop sees
+    the real cause instead of a misleading "not implemented".
+    """
+    module_name = f"agents.{name}.main"
+    try:
+        module = importlib.import_module(module_name)
+    except ModuleNotFoundError as exc:
+        # Only treat as "not implemented" when it's THIS module that's
+        # missing (or its parent package). A transitive failure inside
+        # the archetype keeps `exc.name` pointing at the true missing
+        # dep — let it propagate so the operator sees the real error.
+        missing = getattr(exc, "name", None)
+        owns_failure = missing in {module_name, f"agents.{name}"}
+        if owns_failure:
+            raise RuntimeError(
+                f"archetype {name!r} is not yet implemented "
+                f"(expected module {module_name}; ADR-0006)"
+            ) from exc
+        raise
+
+    run = getattr(module, "run", None)
+    if not callable(run):
+        raise RuntimeError(
+            f"archetype {name!r} module {module_name} does not expose run(config)"
+        )
+    return run  # type: ignore[return-value]
+
+
+def _install_signal_handlers(stop: asyncio.Event) -> None:
+    loop = asyncio.get_running_loop()
+    for sig in (signal.SIGTERM, signal.SIGINT):
+        try:
+            loop.add_signal_handler(sig, stop.set)
+        except NotImplementedError:
+            # Windows / some CI environments — fall back to default.
+            signal.signal(sig, lambda *_: stop.set())
+
+
+async def _run(name: str) -> int:
+    config = load_runtime_config(archetype=name)
+    configure_logging(level=config.log_level, archetype=name)
+
+    logger.info("agent_starting", archetype=name)
+
+    stop = asyncio.Event()
+    _install_signal_handlers(stop)
+
+    try:
+        run_fn = _load_archetype_run(name)
+    except RuntimeError as exc:
+        logger.error("agent_not_implemented", archetype=name, reason=str(exc))
+        return 2
+
+    archetype_task = asyncio.create_task(run_fn(config), name=f"agent-{name}")
+    stop_task = asyncio.create_task(stop.wait(), name="signal-stop")
+
+    done, pending = await asyncio.wait(
+        {archetype_task, stop_task},
+        return_when=asyncio.FIRST_COMPLETED,
+    )
+
+    if stop_task in done and not archetype_task.done():
+        logger.info("agent_shutdown_signal", archetype=name)
+        archetype_task.cancel()
+        try:
+            await archetype_task
+        except asyncio.CancelledError:
+            pass
+
+    for t in pending:
+        t.cancel()
+
+    if archetype_task.done() and not archetype_task.cancelled():
+        exc = archetype_task.exception()
+        if exc is not None:
+            logger.error("agent_crashed", archetype=name, error=str(exc))
+            raise exc
+
+    logger.info("agent_stopped", archetype=name)
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(sys.argv[1:] if argv is None else argv)
+    return asyncio.run(_run(args.archetype))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -119,6 +119,44 @@ services:
     depends_on:
       - pepper
 
+  # ---------------------------------------------------------------------------
+  # Cognitive archetypes (ADR-0004 + ADR-0006). Each archetype runs as its
+  # own service, launched via `python -m agents.runner --archetype <name>`.
+  # The first inhabitant — `agents-reflector` — is added in #39 by
+  # uncommenting the block below and replacing `<archetype>`. Subsequent
+  # archetypes (`monitor`, `researcher`) follow the same shape.
+  #
+  # Skeleton kept here so the diff in #39 is `-#` not "invent the service".
+  # ---------------------------------------------------------------------------
+  # agents-<archetype>:
+  #   build: .
+  #   image: pepper:latest
+  #   container_name: pepper-agents-<archetype>
+  #   restart: unless-stopped
+  #   command: ["python", "-m", "agents.runner", "--archetype", "<archetype>"]
+  #   # NOTE for #39: do NOT inherit Pepper Core's full `.env` here. An
+  #   # archetype only needs POSTGRES_URL + its own archetype-specific
+  #   # vars; pulling the whole env unnecessarily widens blast radius
+  #   # (Google OAuth tokens, WhatsApp bridge token, API keys). When the
+  #   # archetype role split lands (per ADR-0005 §"Postgres roles &
+  #   # grants"), point POSTGRES_URL at the per-archetype role
+  #   # (`pepper_traces_reader` for read-only archetypes) rather than
+  #   # the superuser-equivalent `pepper:pepper`.
+  #   environment:
+  #     POSTGRES_URL: postgresql+asyncpg://pepper:pepper@postgres:5432/pepper
+  #     PYTHONPATH: /app
+  #   volumes:
+  #     # Source mounts are :ro — agents write only to Postgres, never to
+  #     # their own source tree. The shared `agent.traces.*` reader is the
+  #     # documented surface; everything else is forbidden by the lint at
+  #     # `agent/tests/test_agents_isolation.py`.
+  #     - ./agents:/app/agents:ro
+  #     - ./agent:/app/agent:ro
+  #     - ./logs:/app/logs
+  #   depends_on:
+  #     postgres:
+  #       condition: service_healthy
+
   # cloudflared:
   #   image: cloudflare/cloudflared:latest
   #   container_name: pepper-tunnel

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dev = [
 
 [tool.setuptools.packages.find]
 where = ["."]
-include = ["agent*", "subsystems*"]
+include = ["agent*", "agents*", "subsystems*"]
 
 [tool.ruff]
 line-length = 100


### PR DESCRIPTION
## Summary

- Implements ADR-0004's directory rule and ADR-0006's process model: a new `agents/` package with `_shared/` utilities, a generic `--archetype <name>` runner entrypoint, and a 15-test isolation lint that fails CI on any of the four rules from the issue spec.
- First inhabitant (`agents-reflector`) lands in #39 by uncommenting the `docker-compose.yml` skeleton.

## What's in here

- `agents/__init__.py`, `agents/README.md` — boundary docs.
- `agents/_shared/{__init__,logging,config,db}.py` — utilities only, mandatory docstrings, no module-level state. `AgentRuntimeConfig` carries the `LISTEN/NOTIFY` channel name for #39.
- `agents/runner.py` — argparse-gated `--archetype` dispatch, graceful shutdown via SIGTERM/SIGINT, and a `ModuleNotFoundError.name` check so a transitive import bug in `#39` doesn't get mis-reported as "not implemented."
- `agent/tests/test_agents_isolation.py` — 15 tests covering all 4 lint rules with positive + negative fixtures, including:
  - cross-archetype imports (incl. the easy-to-miss `from agents import monitor` shape),
  - imports into `agent.core` / `subsystems/`,
  - `_shared/` missing module docstring,
  - `_shared/` module-level mutable state,
  - escape-hatch detection for `importlib.import_module(...)` and `__import__(...)` string-literal calls.
- `docker-compose.yml` — commented `agents-<archetype>` skeleton with operator notes for #39 (narrow env scope; use `pepper_traces_reader` role for read-only archetypes).
- `pyproject.toml` — `agents*` added to setuptools package discovery.

## Acceptance criteria from #38

- [x] `agents/`, `agents/_shared/`, and `agents/runner.py` exist and import without errors.
- [x] All 4 lint rules tested and passing.
- [x] PR review checklist item documented (Q7 safeguard #2): see `agents/_shared/__init__.py` and `agents/README.md` § "`agents/_shared/` carve-out".
- [ ] Calendar reminder (Q7 safeguard #3): quarterly audit of `agents/_shared/` — left for the operator to schedule once this PR merges.

## Notes for #39

- Use `pepper_traces_reader` role (ADR-0005) when wiring the reflector's `POSTGRES_URL`, not the superuser-equivalent `pepper:pepper`.
- Do not inherit Pepper Core's full `.env`; the reflector only needs `POSTGRES_URL` + its own archetype-specific knobs.
- LISTEN/NOTIFY needs a libpq-style connection (psycopg) — the `+asyncpg` SQLAlchemy URL won't work for the trigger channel. The reflector opens that connection separately.

## Test plan

- [x] `pytest agent/tests/test_agents_isolation.py` — 15 passed.
- [x] `ruff check agents/ agent/tests/test_agents_isolation.py` — clean.
- [x] `python -m agents.runner --archetype reflector` exits 2 with a clear "not yet implemented (expected module agents.reflector.main; ADR-0006)" log line.
- [x] `python -c "from agents import runner"` imports cleanly.

Closes #38.