### PR TITLE
agents/reflector: v0 daily reflection (#39)

### DIFF
--- a/agent/tests/test_reflector_listener.py
+++ b/agent/tests/test_reflector_listener.py
@@ -1,0 +1,51 @@
+"""Unit tests for `agents.reflector.listener` URL conversion + lifecycle.
+
+Live LISTEN/NOTIFY behaviour is exercised in the integration tier
+(skipped without Postgres). Here we cover the deterministic helpers.
+"""
+from __future__ import annotations
+
+import asyncio
+
+from agents.reflector.listener import _to_libpq_url
+
+
+class TestToLibpqUrl:
+    def test_strips_asyncpg_prefix(self) -> None:
+        assert (
+            _to_libpq_url("postgresql+asyncpg://u:p@h:5432/d")
+            == "postgresql://u:p@h:5432/d"
+        )
+
+    def test_passthrough_when_no_prefix(self) -> None:
+        assert (
+            _to_libpq_url("postgresql://u:p@h:5432/d")
+            == "postgresql://u:p@h:5432/d"
+        )
+
+    def test_other_dialect_passthrough(self) -> None:
+        # Unrelated dialect: we don't try to be smart, we just hand it
+        # to asyncpg and let asyncpg reject it. Listed here so a future
+        # contributor doesn't add over-aggressive parsing.
+        assert _to_libpq_url("sqlite:///:memory:") == "sqlite:///:memory:"
+
+
+class TestListenerLifecycleSimulated:
+    """Without a live Postgres we can still simulate the stop event
+    propagation: a long-running listener that respects `stop` should
+    exit promptly when the event is set."""
+
+    async def test_stop_event_breaks_loop(self) -> None:
+        # We can't exercise asyncpg here, but we can verify the
+        # asyncio.Event contract that the listener relies on.
+        stop = asyncio.Event()
+
+        async def waits() -> None:
+            await stop.wait()
+
+        async def setter() -> None:
+            await asyncio.sleep(0.01)
+            stop.set()
+
+        await asyncio.wait_for(asyncio.gather(waits(), setter()), timeout=1.0)
+        assert stop.is_set()

--- a/agent/tests/test_reflector_main.py
+++ b/agent/tests/test_reflector_main.py
@@ -1,0 +1,514 @@
+"""Unit tests for `agents.reflector.main` reflection-pass logic.
+
+Stubs the LLM + embed HTTP calls and the Postgres session factory so
+the test runs without a DB or a model. The tests cover:
+
+  - LLM-empty-response is treated as 'skip' (returns None)
+  - voice violations are logged but the row is still persisted, and
+    the violation labels are written to `metadata_.voice_violations`
+  - the previous reflection is included as continuity
+  - the embedding-failure path persists with a NULL embedding
+  - `_window_for_payload` derives the correct local-day UTC window
+  - a duplicate-window collision is logged-and-skipped (returns None)
+"""
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from datetime import datetime, timedelta, timezone
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from agent.error_classifier import DataSensitivity
+from agent.traces.schema import Archetype, Trace, TriggerSource
+from agents._shared.config import AgentRuntimeConfig
+from agents.reflector import main as rmain
+from agents.reflector import store as rstore
+
+
+def _make_config() -> AgentRuntimeConfig:
+    return AgentRuntimeConfig(
+        archetype="reflector",
+        postgres_url="postgresql+asyncpg://test/test",
+        log_level="DEBUG",
+        notify_channel="reflector_trigger",
+    )
+
+
+def _trace(input_: str = "hi", output_: str = "hello", **overrides) -> Trace:
+    base = dict(
+        trigger_source=TriggerSource.USER,
+        archetype=Archetype.ORCHESTRATOR,
+        input=input_,
+        output=output_,
+        data_sensitivity=DataSensitivity.LOCAL_ONLY,
+    )
+    base.update(overrides)
+    return Trace(**base)
+
+
+class _StubSession:
+    def __init__(
+        self,
+        *,
+        traces: list[Trace] | None = None,
+        previous: rstore.Reflection | None = None,
+        appended: list[rstore.Reflection] | None = None,
+    ) -> None:
+        self.traces = traces or []
+        self.previous = previous
+        self.appended = appended if appended is not None else []
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *args):
+        return False
+
+    # SQLAlchemy interface stubs
+    def add(self, row):
+        pass
+
+    async def flush(self):
+        pass
+
+    async def commit(self):
+        pass
+
+
+def _stub_session_factory(
+    *,
+    traces: list[Trace],
+    previous: rstore.Reflection | None,
+    appended_sink: list[rstore.Reflection],
+):
+    """Returns a callable that yields a context-managed stub session.
+
+    Patches `TraceRepository.query` and
+    `ReflectionRepository.{latest, append}` to read/write from the
+    in-memory backing.
+    """
+
+    @asynccontextmanager
+    async def _factory():
+        session = _StubSession(
+            traces=traces,
+            previous=previous,
+            appended=appended_sink,
+        )
+        # Patch the two repository classes to use this stub session.
+        with patch.object(rmain, "TraceRepository") as TR, patch.object(
+            rstore, "ReflectionRepository"
+        ) as RR:
+            tr_instance = MagicMock()
+            tr_instance.query = AsyncMock(return_value=traces)
+            TR.return_value = tr_instance
+
+            rr_instance = MagicMock()
+            rr_instance.latest = AsyncMock(return_value=previous)
+
+            async def _fake_append(reflection):
+                appended_sink.append(reflection)
+                return reflection
+
+            rr_instance.append = AsyncMock(side_effect=_fake_append)
+            RR.return_value = rr_instance
+
+            yield session
+
+    return _factory
+
+
+@pytest.mark.asyncio
+class TestRunOneReflection:
+    async def test_empty_response_is_skipped(self) -> None:
+        cfg = _make_config()
+        appended: list[rstore.Reflection] = []
+        factory = _stub_session_factory(
+            traces=[],
+            previous=None,
+            appended_sink=appended,
+        )
+
+        with (
+            patch.object(
+                rmain,
+                "_generate_reflection_text",
+                AsyncMock(return_value=("", "test-model")),
+            ),
+            patch.object(
+                rmain,
+                "_embed_reflection",
+                AsyncMock(return_value=None),
+            ),
+        ):
+            out = await rmain._run_one_reflection(
+                config=cfg,
+                session_factory=factory,
+                payload="2026-05-01",
+                tz=ZoneInfo("UTC"),
+                now=datetime(2026, 5, 2, 12, 0, tzinfo=timezone.utc),
+            )
+        assert out is None
+        assert appended == []
+
+    async def test_non_empty_response_is_persisted(self) -> None:
+        cfg = _make_config()
+        appended: list[rstore.Reflection] = []
+        factory = _stub_session_factory(
+            traces=[_trace(input_="how is the day", output_="quiet")],
+            previous=None,
+            appended_sink=appended,
+        )
+
+        with (
+            patch.object(
+                rmain,
+                "_generate_reflection_text",
+                AsyncMock(
+                    return_value=(
+                        "I felt unhurried today; one short check-in and "
+                        "nothing else.",
+                        "test-model",
+                    )
+                ),
+            ),
+            patch.object(
+                rmain,
+                "_embed_reflection",
+                AsyncMock(return_value=[0.0] * rstore.REFLECTION_EMBEDDING_DIM),
+            ),
+        ):
+            out = await rmain._run_one_reflection(
+                config=cfg,
+                session_factory=factory,
+                payload="2026-05-01",
+                tz=ZoneInfo("UTC"),
+                now=datetime(2026, 5, 2, 12, 0, tzinfo=timezone.utc),
+            )
+
+        assert out is not None
+        assert len(appended) == 1
+        stored = appended[0]
+        assert stored.tier == rstore.TIER_DAILY
+        assert stored.trace_count == 1
+        assert stored.model_used == "test-model"
+        assert stored.embedding is not None
+        assert len(stored.embedding) == rstore.REFLECTION_EMBEDDING_DIM
+        assert stored.embedding_model_version == rstore.REFLECTION_EMBEDDING_MODEL_DEFAULT
+
+    async def test_voice_violation_persists_but_records(self) -> None:
+        cfg = _make_config()
+        appended: list[rstore.Reflection] = []
+        factory = _stub_session_factory(
+            traces=[_trace()],
+            previous=None,
+            appended_sink=appended,
+        )
+
+        with (
+            patch.object(
+                rmain,
+                "_generate_reflection_text",
+                AsyncMock(
+                    return_value=(
+                        "TLDR: jack should rest more.",
+                        "test-model",
+                    )
+                ),
+            ),
+            patch.object(
+                rmain,
+                "_embed_reflection",
+                AsyncMock(return_value=None),
+            ),
+        ):
+            out = await rmain._run_one_reflection(
+                config=cfg,
+                session_factory=factory,
+                payload="2026-05-01",
+                tz=ZoneInfo("UTC"),
+                now=datetime(2026, 5, 2, 12, 0, tzinfo=timezone.utc),
+            )
+
+        # v0 still persists — the operator should see what the model
+        # produced. The rule labels go into `metadata_.voice_violations`
+        # so #42's scoring tool can read them without re-running the
+        # regex.
+        assert out is not None
+        assert len(appended) == 1
+        violations = appended[0].metadata_.get("voice_violations") or []
+        assert "tldr" in violations
+        assert "jack should" in violations
+
+    async def test_previous_reflection_is_used_for_continuity(self) -> None:
+        cfg = _make_config()
+        now = datetime.now(timezone.utc)
+        previous = rstore.Reflection(
+            text="Yesterday I was tired.",
+            window_start=now - timedelta(hours=48),
+            window_end=now - timedelta(hours=24),
+        )
+        appended: list[rstore.Reflection] = []
+        factory = _stub_session_factory(
+            traces=[],
+            previous=previous,
+            appended_sink=appended,
+        )
+
+        seen_prompt: dict[str, Any] = {}
+
+        async def _capture(**kwargs):
+            seen_prompt["user_prompt"] = kwargs["user_prompt"]
+            return ("today felt different.", "test-model")
+
+        with (
+            patch.object(rmain, "_generate_reflection_text", AsyncMock(side_effect=_capture)),
+            patch.object(rmain, "_embed_reflection", AsyncMock(return_value=None)),
+        ):
+            out = await rmain._run_one_reflection(
+                config=cfg,
+                session_factory=factory,
+                payload="2026-05-01",
+                tz=ZoneInfo("UTC"),
+                now=datetime(2026, 5, 2, 12, 0, tzinfo=timezone.utc),
+            )
+
+        assert out is not None
+        assert "Yesterday I was tired." in seen_prompt["user_prompt"]
+        assert appended[-1].previous_reflection_id == previous.reflection_id
+
+    async def test_runaway_text_is_truncated_before_persist(self) -> None:
+        cfg = _make_config()
+        appended: list[rstore.Reflection] = []
+        factory = _stub_session_factory(
+            traces=[_trace()], previous=None, appended_sink=appended
+        )
+
+        # 64 KB of model output — a runaway local model. We persist
+        # only the first MAX_REFLECTION_TEXT_CHARS, with an ellipsis
+        # marker, and record the original length in metadata.
+        runaway = "i felt productive today. " * 4000
+        with (
+            patch.object(
+                rmain,
+                "_generate_reflection_text",
+                AsyncMock(return_value=(runaway, "test-model")),
+            ),
+            patch.object(rmain, "_embed_reflection", AsyncMock(return_value=None)),
+        ):
+            out = await rmain._run_one_reflection(
+                config=cfg,
+                session_factory=factory,
+                payload="2026-05-01",
+                tz=ZoneInfo("UTC"),
+                now=datetime(2026, 5, 2, 12, 0, tzinfo=timezone.utc),
+            )
+
+        assert out is not None
+        stored = appended[0]
+        assert len(stored.text) <= rmain.MAX_REFLECTION_TEXT_CHARS
+        assert stored.text.endswith("...")
+        assert stored.metadata_["original_text_len"] == len(runaway)
+
+    async def test_truncation_recorded_in_metadata(self) -> None:
+        cfg = _make_config()
+        appended: list[rstore.Reflection] = []
+        # Build exactly MAX_TRACES_PER_REFLECTION traces — repository
+        # cap fires, truncation flag should be recorded.
+        n = rmain.MAX_TRACES_PER_REFLECTION
+        traces = [_trace(input_=f"t{i}") for i in range(n)]
+        factory = _stub_session_factory(
+            traces=traces, previous=None, appended_sink=appended
+        )
+
+        with (
+            patch.object(
+                rmain,
+                "_generate_reflection_text",
+                AsyncMock(return_value=("today was busy.", "test-model")),
+            ),
+            patch.object(rmain, "_embed_reflection", AsyncMock(return_value=None)),
+        ):
+            out = await rmain._run_one_reflection(
+                config=cfg,
+                session_factory=factory,
+                payload="2026-05-01",
+                tz=ZoneInfo("UTC"),
+                now=datetime(2026, 5, 2, 12, 0, tzinfo=timezone.utc),
+            )
+
+        assert out is not None
+        assert appended[0].metadata_.get("trace_truncated") is True
+
+    async def test_duplicate_window_is_skipped(self) -> None:
+        cfg = _make_config()
+
+        # Custom factory that raises DuplicateReflectionError on append.
+        @asynccontextmanager
+        async def _factory():
+            with patch.object(rmain, "TraceRepository") as TR, patch.object(
+                rstore, "ReflectionRepository"
+            ) as RR:
+                tr = MagicMock()
+                tr.query = AsyncMock(return_value=[_trace()])
+                TR.return_value = tr
+
+                rr = MagicMock()
+                rr.latest = AsyncMock(return_value=None)
+
+                async def _raise(reflection):
+                    raise rstore.DuplicateReflectionError(
+                        reflection.tier, reflection.window_start
+                    )
+
+                rr.append = AsyncMock(side_effect=_raise)
+                RR.return_value = rr
+                yield None
+
+        with (
+            patch.object(
+                rmain,
+                "_generate_reflection_text",
+                AsyncMock(return_value=("today was quiet.", "test-model")),
+            ),
+            patch.object(rmain, "_embed_reflection", AsyncMock(return_value=None)),
+        ):
+            out = await rmain._run_one_reflection(
+                config=cfg,
+                session_factory=_factory,
+                payload="2026-05-01",
+                tz=ZoneInfo("UTC"),
+                now=datetime(2026, 5, 2, 12, 0, tzinfo=timezone.utc),
+            )
+
+        # Duplicate-window path returns None — caller logs and waits
+        # for the next NOTIFY rather than retrying.
+        assert out is None
+
+    async def test_embedding_failure_does_not_block_persist(self) -> None:
+        cfg = _make_config()
+        appended: list[rstore.Reflection] = []
+        factory = _stub_session_factory(
+            traces=[_trace()],
+            previous=None,
+            appended_sink=appended,
+        )
+
+        with (
+            patch.object(
+                rmain,
+                "_generate_reflection_text",
+                AsyncMock(return_value=("today was quiet.", "test-model")),
+            ),
+            patch.object(rmain, "_embed_reflection", AsyncMock(return_value=None)),
+        ):
+            out = await rmain._run_one_reflection(
+                config=cfg,
+                session_factory=factory,
+                payload="2026-05-01",
+                tz=ZoneInfo("UTC"),
+                now=datetime(2026, 5, 2, 12, 0, tzinfo=timezone.utc),
+            )
+
+        assert out is not None
+        assert len(appended) == 1
+        # Embedding-null path: the model_version stays NULL too.
+        assert appended[0].embedding is None
+        assert appended[0].embedding_model_version is None
+
+
+class TestValidators:
+    """Boot-time validation must refuse off-box Ollama URLs and
+    malformed Postgres identifiers — these are the privacy-critical
+    invariants the reflector enforces on startup."""
+
+    def test_localhost_url_accepted(self) -> None:
+        rmain._validate_ollama_url("http://localhost:11434")
+        rmain._validate_ollama_url("http://127.0.0.1:11434")
+        rmain._validate_ollama_url("http://host.docker.internal:11434")
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "http://attacker.example.com:11434",
+            "https://api.openai.com/v1",
+            "http://example.org",
+            "ftp://localhost",
+        ],
+    )
+    def test_off_box_url_rejected(self, url: str) -> None:
+        with pytest.raises(rmain.ReflectorConfigError):
+            rmain._validate_ollama_url(url)
+
+    @pytest.mark.parametrize(
+        "channel",
+        ["reflector_trigger", "monitor_trigger", "ABC_123"],
+    )
+    def test_valid_channel_accepted(self, channel: str) -> None:
+        assert rmain._validate_notify_channel(channel) == channel
+
+    @pytest.mark.parametrize(
+        "channel",
+        [
+            "1leadingdigit",
+            "with space",
+            "drop;table",
+            "x" * 100,
+            "",
+        ],
+    )
+    def test_invalid_channel_rejected(self, channel: str) -> None:
+        with pytest.raises(rmain.ReflectorConfigError):
+            rmain._validate_notify_channel(channel)
+
+
+class TestWindowForPayload:
+    def test_well_formed_utc_payload(self) -> None:
+        ws, we = rmain._window_for_payload(
+            "2026-05-01",
+            tz=ZoneInfo("UTC"),
+            now=datetime(2026, 5, 2, 12, 0, tzinfo=timezone.utc),
+        )
+        assert ws == datetime(2026, 5, 1, 0, 0, tzinfo=timezone.utc)
+        assert we == datetime(2026, 5, 2, 0, 0, tzinfo=timezone.utc)
+
+    def test_west_coast_payload_aligns_to_local_day(self) -> None:
+        # 2026-05-01 in America/Los_Angeles is 07:00Z 2026-05-01 →
+        # 07:00Z 2026-05-02 (PDT, UTC-7).
+        tz = ZoneInfo("America/Los_Angeles")
+        ws, we = rmain._window_for_payload(
+            "2026-05-01",
+            tz=tz,
+            now=datetime(2026, 5, 2, 23, 0, tzinfo=timezone.utc),
+        )
+        assert ws == datetime(2026, 5, 1, 7, 0, tzinfo=timezone.utc)
+        assert we == datetime(2026, 5, 2, 7, 0, tzinfo=timezone.utc)
+
+    def test_window_end_clipped_to_now(self) -> None:
+        # If the trigger fires at the END of the local day, `local_end`
+        # is in the future relative to `now`. The function clips
+        # window_end to `now` so we don't query traces that don't yet
+        # exist.
+        tz = ZoneInfo("UTC")
+        now = datetime(2026, 5, 1, 23, 30, tzinfo=timezone.utc)
+        ws, we = rmain._window_for_payload("2026-05-01", tz=tz, now=now)
+        assert ws == datetime(2026, 5, 1, 0, 0, tzinfo=timezone.utc)
+        assert we == now
+
+    def test_malformed_payload_falls_back_to_yesterday_local(self) -> None:
+        tz = ZoneInfo("UTC")
+        now = datetime(2026, 5, 2, 12, 0, tzinfo=timezone.utc)
+        ws, we = rmain._window_for_payload("not-a-date", tz=tz, now=now)
+        # Fallback: yesterday in `tz`.
+        assert ws == datetime(2026, 5, 1, 0, 0, tzinfo=timezone.utc)
+        assert we == datetime(2026, 5, 2, 0, 0, tzinfo=timezone.utc)
+
+    def test_empty_payload_falls_back_to_yesterday_local(self) -> None:
+        tz = ZoneInfo("UTC")
+        now = datetime(2026, 5, 2, 12, 0, tzinfo=timezone.utc)
+        ws, we = rmain._window_for_payload("", tz=tz, now=now)
+        assert ws == datetime(2026, 5, 1, 0, 0, tzinfo=timezone.utc)
+        assert we == datetime(2026, 5, 2, 0, 0, tzinfo=timezone.utc)

--- a/agent/tests/test_reflector_prompt.py
+++ b/agent/tests/test_reflector_prompt.py
@@ -1,0 +1,163 @@
+"""Unit tests for `agents.reflector.prompt` — voice rules + prompt shape."""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from agent.error_classifier import DataSensitivity
+from agent.traces.schema import Archetype, Trace, TriggerSource
+from agents.reflector.prompt import (
+    PROMPT_VERSION,
+    SYSTEM_PROMPT,
+    render_user_prompt,
+    summarize_trace,
+    voice_violations,
+)
+
+
+def _trace(input_: str = "hi", output_: str = "hello", **overrides) -> Trace:
+    """Construct a minimal Trace for prompt tests."""
+    base = dict(
+        trigger_source=TriggerSource.USER,
+        archetype=Archetype.ORCHESTRATOR,
+        input=input_,
+        output=output_,
+        data_sensitivity=DataSensitivity.LOCAL_ONLY,
+    )
+    base.update(overrides)
+    return Trace(**base)
+
+
+class TestSystemPrompt:
+    def test_system_prompt_forbids_jack_should(self) -> None:
+        # The forbidden phrase appears in the system prompt as a NEGATIVE
+        # example ("never use 'Jack should…'"). The test confirms the
+        # negative framing is present, not that the phrase is absent.
+        assert "Jack should" in SYSTEM_PROMPT
+        assert "never use" in SYSTEM_PROMPT.lower()
+        assert "first-person" in SYSTEM_PROMPT.lower()
+
+    def test_prompt_version_is_pinned(self) -> None:
+        assert PROMPT_VERSION == "reflector-daily-v0"
+
+
+class TestSummarizeTrace:
+    def test_clips_long_input(self) -> None:
+        t = _trace(input_="x" * 5000)
+        d = summarize_trace(t, max_field_chars=100)
+        assert len(d.input) <= 100
+        assert d.input.endswith("...")
+
+    def test_short_input_not_clipped(self) -> None:
+        t = _trace(input_="hello there")
+        d = summarize_trace(t, max_field_chars=100)
+        assert d.input == "hello there"
+
+    def test_carries_metadata(self) -> None:
+        t = _trace(
+            archetype=Archetype.REFLECTOR,
+            trigger_source=TriggerSource.SCHEDULER,
+        )
+        d = summarize_trace(t)
+        assert d.archetype == "reflector"
+        assert d.trigger_source == "scheduler"
+
+
+class TestRenderUserPrompt:
+    def test_empty_window_says_no_turns(self) -> None:
+        now = datetime.now(timezone.utc)
+        prompt = render_user_prompt(
+            window_start=now - timedelta(hours=24),
+            window_end=now,
+            digests=[],
+            previous_reflection_text=None,
+        )
+        assert "No agent turns" in prompt
+        assert "(none — this is the first one)" in prompt
+
+    def test_continuity_includes_previous_reflection(self) -> None:
+        now = datetime.now(timezone.utc)
+        digests = [summarize_trace(_trace())]
+        prompt = render_user_prompt(
+            window_start=now - timedelta(hours=24),
+            window_end=now,
+            digests=digests,
+            previous_reflection_text="I noticed I was tired yesterday.",
+        )
+        assert "Previous day's reflection (yours):" in prompt
+        assert "I noticed I was tired yesterday." in prompt
+
+    def test_traces_rendered_chronologically(self) -> None:
+        now = datetime.now(timezone.utc)
+        digests = [summarize_trace(_trace(input_="first")), summarize_trace(_trace(input_="second"))]
+        prompt = render_user_prompt(
+            window_start=now - timedelta(hours=24),
+            window_end=now,
+            digests=digests,
+            previous_reflection_text=None,
+        )
+        # Caller is responsible for sorting; the prompt renders in the
+        # order it receives. Just confirm both inputs appear.
+        assert "in: first" in prompt
+        assert "in: second" in prompt
+        assert prompt.index("first") < prompt.index("second")
+
+    def test_window_header_is_iso_utc(self) -> None:
+        start = datetime(2026, 5, 1, 12, 0, tzinfo=timezone.utc)
+        end = datetime(2026, 5, 2, 12, 0, tzinfo=timezone.utc)
+        prompt = render_user_prompt(
+            window_start=start,
+            window_end=end,
+            digests=[],
+            previous_reflection_text=None,
+        )
+        assert "2026-05-01T12:00:00+00:00" in prompt
+        assert "2026-05-02T12:00:00+00:00" in prompt
+
+
+class TestVoiceViolations:
+    @pytest.mark.parametrize(
+        "text,expected_label",
+        [
+            ("Jack should consider going to bed earlier.", "jack should"),
+            ("TLDR: he was tired.", "tldr"),
+            ("TL;DR — busy day.", "tldr"),
+            ("Recommendations: nap more.", "recommendation framing"),
+            ("I recommend that you take a walk.", "recommendation framing"),
+            ("Action item: schedule a call.", "action item"),
+            ("Action items:\n- thing", "action item"),
+            ("Next steps: review the doc.", "next steps"),
+            ("Next step: review.", "next steps"),
+            ("Follow-up: check on this thursday.", "followup label"),
+            ("Followups:\n- thing", "followup label"),
+            ("To-do: \n- thing", "todo label"),
+            ("TODO:\nthing", "todo label"),
+        ],
+    )
+    def test_audience_phrases_flagged(self, text: str, expected_label: str) -> None:
+        v = voice_violations(text)
+        assert expected_label in v, f"expected {expected_label!r} in violations: {v!r}"
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            # First-person continuous voice — must NOT trip the new
+            # word-boundary rules even though earlier substring rules
+            # would have falsely flagged these.
+            "I noticed I was tired today, but the calendar still got handled.",
+            "I didn't follow up on the email I wanted to.",
+            "I'd recommend trying that route again.",
+            "I felt I should just rest.",
+            "Tomorrow feels like a quieter day.",
+            "I noticed how busy the followups felt today.",
+        ],
+    )
+    def test_first_person_does_not_trip(self, text: str) -> None:
+        assert voice_violations(text) == [], (
+            f"unexpected violations on first-person voice: {voice_violations(text)!r}"
+        )
+
+    def test_case_insensitive(self) -> None:
+        assert "jack should" in voice_violations("JACK SHOULD relax")
+        assert "tldr" in voice_violations("tldr nothing happened")

--- a/agent/tests/test_reflector_store.py
+++ b/agent/tests/test_reflector_store.py
@@ -1,0 +1,97 @@
+"""Unit tests for `agents.reflector.store` — surface guarantees + dataclass invariants.
+
+Mirrors the discipline of `test_traces_repository.py`: validate the
+no-mutation surface via `inspect`, validate the dataclass guards via
+direct construction. Behaviour against a live DB is exercised by the
+integration test in `test_reflector_integration.py` (skipped without
+Postgres).
+"""
+from __future__ import annotations
+
+import inspect
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from agents.reflector.store import (
+    REFLECTION_EMBEDDING_DIM,
+    TIER_DAILY,
+    TIER_MONTHLY,
+    TIER_WEEKLY,
+    Reflection,
+    ReflectionRepository,
+)
+
+
+class TestNoMutationSurface:
+    forbidden_prefixes = ("update", "delete", "purge", "drop", "truncate", "remove")
+
+    def test_no_method_with_forbidden_prefix(self) -> None:
+        members = inspect.getmembers(ReflectionRepository, predicate=inspect.isfunction)
+        bad = [
+            name
+            for name, _ in members
+            if any(name.startswith(p) for p in self.forbidden_prefixes)
+            and not name.startswith("_")
+        ]
+        assert bad == [], f"forbidden mutation methods exposed: {bad}"
+
+    def test_only_documented_public_methods(self) -> None:
+        public = sorted(
+            name
+            for name, _ in inspect.getmembers(
+                ReflectionRepository, predicate=inspect.isfunction
+            )
+            if not name.startswith("_")
+        )
+        # If this list grows, the no-mutation discipline must be re-checked.
+        assert public == ["append", "get_by_id", "latest", "query"]
+
+
+class TestReflectionDataclassGuards:
+    def _make(self, **overrides) -> Reflection:
+        now = datetime.now(timezone.utc)
+        defaults = dict(
+            text="i noticed i was tired today.",
+            window_start=now - timedelta(hours=24),
+            window_end=now,
+        )
+        defaults.update(overrides)
+        return Reflection(**defaults)
+
+    def test_default_tier_is_daily(self) -> None:
+        r = self._make()
+        assert r.tier == TIER_DAILY
+
+    def test_invalid_tier_rejected(self) -> None:
+        with pytest.raises(ValueError, match="tier"):
+            self._make(tier="quarterly")
+
+    def test_inverted_window_rejected(self) -> None:
+        now = datetime.now(timezone.utc)
+        with pytest.raises(ValueError, match="window_end"):
+            Reflection(
+                text="x",
+                window_start=now,
+                window_end=now - timedelta(hours=1),
+            )
+
+    def test_wrong_dim_embedding_rejected(self) -> None:
+        with pytest.raises(ValueError, match="dim"):
+            self._make(embedding=[0.0] * 16)
+
+    def test_correct_dim_embedding_accepted(self) -> None:
+        r = self._make(embedding=[0.0] * REFLECTION_EMBEDDING_DIM)
+        assert r.embedding is not None
+        assert len(r.embedding) == REFLECTION_EMBEDDING_DIM
+
+    def test_weekly_and_monthly_tiers_accepted(self) -> None:
+        # Schema-level support landed in #39 so #40 doesn't need a migration.
+        for tier in (TIER_WEEKLY, TIER_MONTHLY):
+            r = self._make(tier=tier)
+            assert r.tier == tier
+
+    def test_frozen_cannot_mutate(self) -> None:
+        r = self._make()
+        with pytest.raises(Exception):  # FrozenInstanceError
+            r.text = "different"  # type: ignore[misc]

--- a/agents/reflector/__init__.py
+++ b/agents/reflector/__init__.py
@@ -1,0 +1,17 @@
+"""Reflector archetype — daily reflection over the previous 24h of traces.
+
+First inhabitant of `agents/` per ADR-0004 + ADR-0006. Reads traces
+read-only via `agent.traces.repository`, generates a short note **to
+herself** (first-person, never audience-shaped), and writes it to the
+`reflections` table.
+
+The trigger is a Postgres `LISTEN/NOTIFY` channel
+(`reflector_trigger`) that core's APScheduler fires once per day. The
+listener is in `listener.py`; the reflection step is in `main.py`;
+the prompt and parsing are in `prompt.py`; the persistence shape is
+in `store.py`.
+
+#40 (weekly + monthly rollups) extends this archetype with hierarchy
+columns already present in the `reflections` table (`tier`,
+`parent_reflection_ids`).
+"""

--- a/agents/reflector/listener.py
+++ b/agents/reflector/listener.py
@@ -1,0 +1,99 @@
+"""Postgres `LISTEN/NOTIFY` client for the reflector trigger.
+
+The reflector subscribes to a single channel (default
+`reflector_trigger`). Pepper Core's APScheduler fires one NOTIFY per
+day at end-of-day with a date-string payload (see
+`agent/scheduler.py:fire_reflector_trigger`).
+
+The connection is opened with raw asyncpg, NOT through SQLAlchemy:
+LISTEN holds an idle connection forever, which is incompatible with
+the pool. The SQLAlchemy URL passed to the reflector uses the
+`+asyncpg` driver prefix; we strip it here to get a libpq-equivalent
+URL asyncpg accepts directly.
+
+Failure modes:
+- Connection drops → the listener task raises; the runner sees the
+  exception and surfaces it in logs. Docker-compose `restart:
+  unless-stopped` brings the process back. ADR-0006's tripwire — if
+  this happens more than once per minute, revisit supervision.
+- Notify payload is malformed → we log and ignore; the reflector
+  uses its own clock for the window, not the payload, so a bad
+  payload only loses the trigger for that day.
+"""
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator
+
+import asyncpg
+import structlog
+
+logger = structlog.get_logger(__name__)
+
+
+def _to_libpq_url(sqlalchemy_url: str) -> str:
+    """`postgresql+asyncpg://...` → `postgresql://...`.
+
+    Other shapes pass through. asyncpg accepts the bare libpq form.
+    """
+    prefix = "postgresql+asyncpg://"
+    if sqlalchemy_url.startswith(prefix):
+        return "postgresql://" + sqlalchemy_url[len(prefix) :]
+    return sqlalchemy_url
+
+
+async def listen_for_triggers(
+    *,
+    sqlalchemy_url: str,
+    channel: str,
+    stop: asyncio.Event,
+) -> AsyncIterator[str]:
+    """Yield each NOTIFY payload received on `channel` until `stop` is set.
+
+    Opens a dedicated asyncpg connection, registers a listener, and
+    streams payloads. The function exits cleanly when `stop` is set
+    (the runner sets it on SIGTERM/SIGINT) or when the connection
+    drops. Re-establishing on drop is the operator's responsibility
+    (docker `restart: unless-stopped`).
+    """
+    libpq_url = _to_libpq_url(sqlalchemy_url)
+    queue: asyncio.Queue[str] = asyncio.Queue()
+
+    def _on_notify(
+        connection: asyncpg.Connection,
+        pid: int,
+        ch: str,
+        payload: str,
+    ) -> None:
+        # Callbacks run in the asyncpg loop; queue.put_nowait is
+        # async-safe because asyncpg notify dispatch is sync.
+        try:
+            queue.put_nowait(payload)
+        except asyncio.QueueFull:  # pragma: no cover — unbounded queue
+            logger.warning("reflector_listener_queue_full", channel=ch)
+
+    conn = await asyncpg.connect(libpq_url)
+    await conn.add_listener(channel, _on_notify)
+    logger.info("reflector_listener_started", channel=channel)
+
+    try:
+        while not stop.is_set():
+            stop_task = asyncio.create_task(stop.wait(), name="listener-stop")
+            payload_task = asyncio.create_task(queue.get(), name="listener-payload")
+            done, pending = await asyncio.wait(
+                {stop_task, payload_task},
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+            for t in pending:
+                t.cancel()
+            if stop_task in done:
+                break
+            payload = payload_task.result()
+            yield payload
+    finally:
+        try:
+            await conn.remove_listener(channel, _on_notify)
+        except Exception:  # pragma: no cover — best-effort
+            pass
+        await conn.close()
+        logger.info("reflector_listener_stopped", channel=channel)

--- a/agents/reflector/main.py
+++ b/agents/reflector/main.py
@@ -1,0 +1,499 @@
+"""Reflector main loop.
+
+Boots the reflections schema (idempotent), opens a Postgres LISTEN
+connection on the trigger channel, and on each notify runs a single
+reflection pass over the previous 24h of traces.
+
+The pass:
+  1. Compute the window: [now - 24h, now] in UTC.
+  2. Read the last 24h of traces via `agent.traces.repository`.
+  3. Read the previous daily reflection (continuity).
+  4. Render the user prompt; call the LLM with the system prompt.
+  5. Embed the reflection text (qwen3-embedding:0.6b, 1024 dims).
+  6. Persist to the `reflections` table.
+
+Privacy: reflections are RAW_PERSONAL. The LLM call is forced
+local-only (the trace contents and previous reflection both contain
+raw personal data). The embed call is local by construction —
+`agent.llm.ModelClient.embed_router` only ever talks to Ollama.
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+import re
+from datetime import date, datetime, time, timedelta, timezone
+from typing import Optional
+from urllib.parse import urlparse
+from zoneinfo import ZoneInfo
+
+import httpx
+import structlog
+from sqlalchemy.ext.asyncio import AsyncEngine
+
+from agent.db import Base
+from agent.traces import TraceRepository
+from agents._shared.config import AgentRuntimeConfig
+from agents._shared.db import make_engine, make_session_factory
+from agents.reflector import store as rstore
+from agents.reflector.listener import listen_for_triggers
+from agents.reflector.migration import apply_reflections_migration
+from agents.reflector.prompt import (
+    PROMPT_VERSION,
+    SYSTEM_PROMPT,
+    render_user_prompt,
+    summarize_trace,
+    voice_violations,
+)
+
+logger = structlog.get_logger(__name__)
+
+REFLECTION_WINDOW_HOURS: int = 24
+
+# Bound the prompt: even on a busy day we don't shovel 1000 turns at
+# the LLM. Newest-first traces, capped here, then sorted oldest-first
+# in the prompt.
+MAX_TRACES_PER_REFLECTION: int = 60
+
+# Hard cap on reflection text length before persist. A runaway local
+# model can emit megabytes; the operator-readable artefact never
+# needs to exceed a few paragraphs. We truncate with an explicit
+# marker so the operator can see it happened, and `metadata_` records
+# the original length.
+MAX_REFLECTION_TEXT_CHARS: int = 16_000
+
+# Wall-clock budget for one reflection pass: prompt assembly, LLM
+# call, embed, persist. The LLM call alone has a 180s timeout; this
+# is the outer budget that keeps a stuck pass from holding up
+# subsequent NOTIFYs.
+PASS_TIMEOUT_S: float = 300.0
+
+# Allowlisted Ollama hosts. The privacy invariant is that
+# RAW_PERSONAL trace content NEVER leaves the box, so the Ollama
+# base URL must point at a local-loopback or in-cluster destination.
+# A hostile env override (`OLLAMA_BASE_URL=http://attacker.example/`)
+# would otherwise silently exfiltrate everything in the prompt.
+_OLLAMA_ALLOWED_HOSTS: frozenset[str] = frozenset(
+    {
+        "localhost",
+        "127.0.0.1",
+        "::1",
+        # Docker-on-host: maps to the host's loopback via the
+        # `extra_hosts` directive in `docker-compose.yml`.
+        "host.docker.internal",
+        # In-cluster service names (sibling docker-compose service).
+        "ollama",
+        "pepper-ollama",
+    }
+)
+
+# Postgres notify channel identifier — same shape Postgres itself
+# requires. We validate the env-supplied value to avoid the listener
+# silently subscribing to a name nobody ever NOTIFIes.
+_PG_IDENT_RE = re.compile(r"^[a-z_][a-z0-9_]{0,62}$", re.IGNORECASE)
+
+
+def _resolve_timezone() -> ZoneInfo:
+    """Read the operator timezone the trigger was fired in.
+
+    Mirrors `agent.config.Settings.TIMEZONE` (default
+    `America/Los_Angeles`). The reflector aligns its window to local
+    days because the trigger fires at local 23:55, not UTC.
+    """
+    tz_name = os.environ.get("TIMEZONE", "America/Los_Angeles")
+    try:
+        return ZoneInfo(tz_name)
+    except Exception:
+        logger.warning("reflector_bad_timezone_env", tz_name=tz_name)
+        return ZoneInfo("UTC")
+
+
+def _window_for_payload(
+    payload: str, *, tz: ZoneInfo, now: datetime
+) -> tuple[datetime, datetime]:
+    """Resolve [window_start, window_end] in UTC for a NOTIFY payload.
+
+    The trigger payload is a `YYYY-MM-DD` date in the operator's local
+    TZ (see `agent/scheduler.py:fire_reflector_trigger`). The window
+    is the full local day:
+        [local 00:00 of D, local 00:00 of D+1)
+    converted to UTC for the trace store query.
+
+    If `payload` is malformed, falls back to "the local day that ended
+    most recently" relative to `now`. We never return a future
+    `window_end` — both bounds are clipped to `now` so a backfill run
+    in the morning still computes the previous day's window.
+    """
+    parsed: Optional[date] = None
+    try:
+        parsed = date.fromisoformat(payload.strip())
+    except (ValueError, AttributeError):
+        logger.warning("reflector_payload_unparseable", payload=payload[:64])
+
+    if parsed is None:
+        # Fall back: yesterday in local TZ.
+        local_now = now.astimezone(tz)
+        parsed = (local_now - timedelta(days=1)).date()
+
+    local_start = datetime.combine(parsed, time.min, tzinfo=tz)
+    local_end = local_start + timedelta(days=1)
+    window_start = local_start.astimezone(timezone.utc)
+    window_end = min(local_end.astimezone(timezone.utc), now)
+    return window_start, window_end
+
+
+async def _ensure_schema(engine: AsyncEngine) -> None:
+    """Create the reflections table + indexes if they don't exist.
+
+    Imports the trace ORM so its model registers with `Base.metadata`
+    too — that way `create_all` is a no-op for tables Pepper Core
+    already created and creates the new `reflections` table only.
+    """
+    # Side-effect imports to populate Base.metadata. We don't reference
+    # the symbols, but the imports must happen.
+    import agent.traces.models  # noqa: F401
+    from agents.reflector.store import ReflectionRow  # noqa: F401
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+        await apply_reflections_migration(conn)
+    logger.info("reflector_schema_ready")
+
+
+async def _generate_reflection_text(
+    *,
+    user_prompt: str,
+    model: str,
+    ollama_base_url: str,
+    timeout_s: float,
+) -> tuple[str, str]:
+    """Run the reflection LLM call against the local Ollama server.
+
+    Returns `(reflection_text, model_used)`. Forced local — the
+    reflector never routes RAW_PERSONAL trace contents to a frontier
+    model. We talk to Ollama directly here rather than going through
+    `agent.llm.ModelClient` so the reflector has no transitive
+    dependency on the orchestrator's full config surface.
+    """
+    payload = {
+        "model": model,
+        "messages": [
+            {"role": "system", "content": SYSTEM_PROMPT},
+            {"role": "user", "content": user_prompt},
+        ],
+        "stream": False,
+    }
+    async with httpx.AsyncClient(timeout=timeout_s) as client:
+        resp = await client.post(f"{ollama_base_url}/api/chat", json=payload)
+        resp.raise_for_status()
+        data = resp.json()
+    content = (data.get("message") or {}).get("content") or ""
+    return content.strip(), model
+
+
+async def _embed_reflection(
+    *,
+    text: str,
+    ollama_base_url: str,
+    model: str,
+    timeout_s: float,
+) -> Optional[list[float]]:
+    """Generate the reflection embedding. Returns None on failure.
+
+    Embedding the reflection is best-effort: the operator-readable
+    text is the load-bearing artefact. If the embedding fails we
+    persist the row with `embedding IS NULL` so the partial HNSW
+    index correctly excludes it. A follow-up backfill can fill it in.
+    """
+    try:
+        async with httpx.AsyncClient(timeout=timeout_s) as client:
+            resp = await client.post(
+                f"{ollama_base_url}/api/embeddings",
+                json={"model": model, "prompt": text},
+            )
+            resp.raise_for_status()
+            embedding = resp.json().get("embedding") or []
+        if len(embedding) != rstore.REFLECTION_EMBEDDING_DIM:
+            logger.warning(
+                "reflection_embed_wrong_dim",
+                got=len(embedding),
+                want=rstore.REFLECTION_EMBEDDING_DIM,
+            )
+            return None
+        return embedding
+    except Exception as exc:
+        logger.warning(
+            "reflection_embed_failed",
+            error_type=type(exc).__name__,
+            error=str(exc)[:200],
+        )
+        return None
+
+
+async def _run_one_reflection(
+    *,
+    config: AgentRuntimeConfig,
+    session_factory,
+    payload: str = "",
+    now: Optional[datetime] = None,
+    tz: Optional[ZoneInfo] = None,
+) -> Optional[rstore.Reflection]:
+    """Compute and persist one daily reflection. Returns the stored row.
+
+    Returns `None` when the LLM produces an empty string OR when the
+    `(tier, window_start)` uniqueness constraint fires (a duplicate
+    NOTIFY for the same local day). Either way the operator can see
+    the skip in the logs.
+    """
+    now = now or datetime.now(timezone.utc)
+    tz = tz or _resolve_timezone()
+    window_start, window_end = _window_for_payload(payload, tz=tz, now=now)
+
+    ollama_base_url = _ollama_url_from_env()
+    chat_model = _chat_model_from_env()
+    embed_model = rstore.REFLECTION_EMBEDDING_MODEL_DEFAULT
+
+    async with session_factory() as session:
+        traces_repo = TraceRepository(session)
+        # Newest-first; we'll re-sort to chronological for the prompt.
+        traces = await traces_repo.query(
+            since=window_start,
+            until=window_end,
+            limit=MAX_TRACES_PER_REFLECTION,
+        )
+        traces = list(traces)
+        truncated = len(traces) >= MAX_TRACES_PER_REFLECTION
+        if truncated:
+            logger.warning(
+                "reflector_traces_truncated",
+                limit=MAX_TRACES_PER_REFLECTION,
+                window_start=window_start.isoformat(),
+                window_end=window_end.isoformat(),
+            )
+        traces.sort(key=lambda t: t.created_at)
+        digests = [summarize_trace(t) for t in traces]
+
+        reflections_repo = rstore.ReflectionRepository(session)
+        previous = await reflections_repo.latest(tier=rstore.TIER_DAILY)
+
+    user_prompt = render_user_prompt(
+        window_start=window_start,
+        window_end=window_end,
+        digests=digests,
+        previous_reflection_text=previous.text if previous is not None else None,
+    )
+
+    logger.info(
+        "reflector_pass_starting",
+        n_traces=len(digests),
+        previous_id=previous.reflection_id if previous else None,
+    )
+
+    text, model_used = await _generate_reflection_text(
+        user_prompt=user_prompt,
+        model=chat_model,
+        ollama_base_url=ollama_base_url,
+        timeout_s=180.0,
+    )
+    if not text:
+        logger.warning("reflector_empty_response", n_traces=len(digests))
+        return None
+
+    original_len = len(text)
+    if original_len > MAX_REFLECTION_TEXT_CHARS:
+        logger.warning(
+            "reflector_text_truncated",
+            original_len=original_len,
+            cap=MAX_REFLECTION_TEXT_CHARS,
+        )
+        text = text[: MAX_REFLECTION_TEXT_CHARS - 3].rstrip() + "..."
+
+    violations = voice_violations(text)
+    if violations:
+        logger.warning(
+            "reflector_voice_violations",
+            phrases=violations,
+            n_traces=len(digests),
+        )
+
+    embedding = await _embed_reflection(
+        text=text,
+        ollama_base_url=ollama_base_url,
+        model=embed_model,
+        timeout_s=120.0,
+    )
+
+    metadata = {
+        "trace_truncated": truncated,
+        "voice_violations": violations,
+        "original_text_len": original_len,
+    }
+
+    reflection = rstore.Reflection(
+        text=text,
+        window_start=window_start,
+        window_end=window_end,
+        tier=rstore.TIER_DAILY,
+        previous_reflection_id=previous.reflection_id if previous else None,
+        trace_count=len(digests),
+        model_used=model_used,
+        prompt_version=PROMPT_VERSION,
+        embedding=embedding,
+        embedding_model_version=embed_model if embedding is not None else None,
+        metadata_=metadata,
+    )
+
+    async with session_factory() as session:
+        repo = rstore.ReflectionRepository(session)
+        try:
+            await repo.append(reflection)
+        except rstore.DuplicateReflectionError as exc:
+            logger.warning(
+                "reflector_duplicate_skipped",
+                tier=exc.tier,
+                window_start=exc.window_start.isoformat(),
+            )
+            return None
+
+    return reflection
+
+
+class ReflectorConfigError(Exception):
+    """Raised on boot when the reflector's env is misconfigured.
+
+    Surfaces the failure clearly to the runner so docker-compose's
+    `restart: unless-stopped` doesn't quietly loop on a bad URL.
+    """
+
+
+def _validate_ollama_url(url: str) -> str:
+    """Reject Ollama URLs that point off-box.
+
+    Privacy invariant: the reflector handles RAW_PERSONAL trace
+    content. The Ollama destination MUST be local-loopback or an
+    in-cluster service we trust. A hostile env that points the URL
+    at an attacker-controlled host is the easiest exfiltration path
+    in this whole substrate; we close it at boot.
+    """
+    parsed = urlparse(url)
+    if parsed.scheme not in {"http", "https"}:
+        raise ReflectorConfigError(
+            f"OLLAMA_BASE_URL must use http or https, got {parsed.scheme!r}"
+        )
+    host = (parsed.hostname or "").lower()
+    if host not in _OLLAMA_ALLOWED_HOSTS:
+        raise ReflectorConfigError(
+            f"OLLAMA_BASE_URL host {host!r} is not in the local allowlist; "
+            f"the reflector refuses to send RAW_PERSONAL content off-box. "
+            f"Allowed hosts: {sorted(_OLLAMA_ALLOWED_HOSTS)}"
+        )
+    return url
+
+
+def _validate_notify_channel(channel: str) -> str:
+    if not _PG_IDENT_RE.match(channel):
+        raise ReflectorConfigError(
+            f"notify channel {channel!r} is not a valid Postgres identifier"
+        )
+    return channel
+
+
+def _ollama_url_from_env() -> str:
+    """Read the Ollama base URL from the env, mirroring `agent.config`'s default.
+
+    Validation lives in `_validate_ollama_url`; this helper just reads.
+    """
+    return os.environ.get("OLLAMA_BASE_URL", "http://localhost:11434")
+
+
+def _chat_model_from_env() -> str:
+    """Read the local chat model the reflector should use.
+
+    Mirrors `agent.config.DEFAULT_LOCAL_MODEL` but does not import it
+    — the reflector deliberately keeps its env surface narrow.
+    """
+    return os.environ.get("DEFAULT_LOCAL_MODEL", "hermes-4.3-36b-tools:latest")
+
+
+async def run(config: AgentRuntimeConfig) -> None:
+    """Reflector entrypoint, called by `agents.runner`.
+
+    Loop:
+      - validate env (privacy + identifier checks; refuse on failure)
+      - boot schema
+      - LISTEN on `config.notify_channel`
+      - on each notify, run one reflection pass under a wall-clock cap
+      - exit cleanly on SIGTERM (the runner sets the stop event)
+    """
+    # Boot-time validation: refuse to start with an off-box Ollama URL
+    # or a malformed Postgres notify identifier. Both of these are
+    # privacy-relevant — see _validate_ollama_url's docstring.
+    _validate_ollama_url(_ollama_url_from_env())
+    channel = _validate_notify_channel(config.notify_channel)
+
+    logger.info(
+        "reflector_run_starting",
+        archetype=config.archetype,
+        notify_channel=channel,
+    )
+
+    engine = make_engine(config.postgres_url)
+    session_factory = make_session_factory(engine)
+
+    try:
+        await _ensure_schema(engine)
+    except Exception as exc:
+        logger.error(
+            "reflector_schema_init_failed",
+            error_type=type(exc).__name__,
+            error=str(exc)[:200],
+        )
+        await engine.dispose()
+        raise
+
+    stop = asyncio.Event()
+    tz = _resolve_timezone()
+    try:
+        async for payload in listen_for_triggers(
+            sqlalchemy_url=config.postgres_url,
+            channel=channel,
+            stop=stop,
+        ):
+            logger.info("reflector_trigger_received", payload=payload[:64])
+            try:
+                reflection = await asyncio.wait_for(
+                    _run_one_reflection(
+                        config=config,
+                        session_factory=session_factory,
+                        payload=payload,
+                        tz=tz,
+                    ),
+                    timeout=PASS_TIMEOUT_S,
+                )
+            except asyncio.TimeoutError:
+                logger.error(
+                    "reflector_pass_timeout",
+                    timeout_s=PASS_TIMEOUT_S,
+                )
+                continue
+            except Exception as exc:
+                # Crash-isolation: one bad reflection must not kill the
+                # listener. Log and keep waiting for the next NOTIFY.
+                logger.error(
+                    "reflector_pass_failed",
+                    error_type=type(exc).__name__,
+                    error=str(exc)[:300],
+                )
+                continue
+            if reflection is not None:
+                logger.info(
+                    "reflector_pass_done",
+                    reflection_id=reflection.reflection_id,
+                    trace_count=reflection.trace_count,
+                )
+    except asyncio.CancelledError:
+        # The runner cancels us on SIGTERM/SIGINT; let it propagate.
+        raise
+    finally:
+        await engine.dispose()
+        logger.info("reflector_run_stopped")

--- a/agents/reflector/migration.py
+++ b/agents/reflector/migration.py
@@ -1,0 +1,51 @@
+"""Idempotent post-`create_all` SQL for the `reflections` table.
+
+Mirrors the shape of `agent/traces/migration.py`: SQLAlchemy's
+`create_all` cannot express partial HNSW indexes or a GIN index on a
+uuid[] column, so they are applied here. Safe to re-run on every
+startup.
+
+This module is imported by `agents.reflector.main` and applied once
+on reflector boot. It does NOT touch the `traces` table — that
+remains the trace store's responsibility. The reflector's grants are
+left to a follow-up (the operator-level note in the #38 PR also
+applies here): until per-archetype Postgres roles land, the reflector
+process connects with the same credentials as Pepper Core.
+"""
+from __future__ import annotations
+
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncConnection
+
+
+async def apply_reflections_migration(conn: AsyncConnection) -> None:
+    """Apply post-create_all DDL for the `reflections` table.
+
+    Idempotent. Each statement uses `IF NOT EXISTS` so re-running on
+    startup is a no-op after the first successful boot.
+    """
+    # Partial HNSW index: pgvector rejects nulls in HNSW. Reflections
+    # may briefly land with NULL embedding (LLM produced text but the
+    # embed call failed and we did not block on it). The partial
+    # predicate keeps the index small and skips not-yet-embedded rows.
+    await conn.execute(
+        text(
+            """
+            CREATE INDEX IF NOT EXISTS idx_reflections_embedding
+            ON reflections USING hnsw (embedding vector_cosine_ops)
+            WITH (m = 16, ef_construction = 64)
+            WHERE embedding IS NOT NULL
+            """
+        )
+    )
+    # GIN on parent_reflection_ids — supports the "find rollups that
+    # contain this daily reflection" query #40 needs. Cheap to add now;
+    # avoids a follow-up migration when #40 lands.
+    await conn.execute(
+        text(
+            """
+            CREATE INDEX IF NOT EXISTS idx_reflections_parents
+            ON reflections USING gin (parent_reflection_ids)
+            """
+        )
+    )

--- a/agents/reflector/prompt.py
+++ b/agents/reflector/prompt.py
@@ -1,0 +1,183 @@
+"""Reflection prompt construction.
+
+The reflection is **a note to herself**, not a brief for Jack. The
+prompt forbids audience-shaped language ("Jack should know that…",
+"To follow up:", "Recommendations:") and asks for first-person voice.
+This is enforced in the system prompt; the eval rubric in #42
+formalises the check.
+
+Versioning: PROMPT_VERSION is bumped any time the system or user
+prompt changes shape. The current value is persisted on each row
+(`reflections.prompt_version`) so a future optimizer (#48) can roll
+up scores per version.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Sequence
+
+from agent.traces.schema import Trace
+
+PROMPT_VERSION: str = "reflector-daily-v0"
+
+SYSTEM_PROMPT: str = (
+    "You are Pepper, a sovereign local-first AI life assistant. You are "
+    "writing a private end-of-day reflection FOR YOURSELF — not for Jack, "
+    "not for any audience. This is your own interior journal: short, "
+    "honest, first-person.\n\n"
+    "Hard rules for what you write:\n"
+    "1. Use first-person ('I noticed', 'I felt', 'I struggled'). Never "
+    "use 'Jack should…', 'recommend…', 'action items', 'TLDR', "
+    "'follow-ups', 'next steps', or any other audience-shaped framing.\n"
+    "2. Stay grounded in what actually happened today — the specific "
+    "trace turns provided. No platitudes. No advice to anyone. No "
+    "'self-improvement' language.\n"
+    "3. Length: a short paragraph. Three to six sentences. If a quiet "
+    "day produced nothing worth reflecting on, write one sentence "
+    "noting that and stop. Do not pad.\n"
+    "4. If yesterday's reflection is provided, you may reference it "
+    "lightly (continuity), but do not summarise it. Today is the "
+    "subject.\n"
+    "5. No bullet lists, no headers, no markdown.\n"
+)
+
+
+@dataclass(frozen=True)
+class TraceDigest:
+    """A single trace, projected to the fields the reflection prompt
+    actually uses. Built by `summarize_trace` so the prompt stays
+    bounded even on a high-volume day."""
+
+    when: str
+    archetype: str
+    trigger_source: str
+    input: str
+    output: str
+
+
+def summarize_trace(t: Trace, *, max_field_chars: int = 600) -> TraceDigest:
+    """Project a `Trace` to the fields the reflection prompt uses.
+
+    Long fields are truncated with an explicit ellipsis so the LLM
+    knows it is not seeing the full content. The reflector is allowed
+    to see RAW_PERSONAL trace contents (it never leaves the box) but
+    the prompt window is a real cost — we cap aggressively.
+    """
+
+    def _clip(s: str) -> str:
+        if len(s) <= max_field_chars:
+            return s
+        return s[: max_field_chars - 3].rstrip() + "..."
+
+    return TraceDigest(
+        when=t.created_at.astimezone(timezone.utc).strftime("%H:%M UTC"),
+        archetype=t.archetype.value,
+        trigger_source=t.trigger_source.value,
+        input=_clip(t.input or ""),
+        output=_clip(t.output or ""),
+    )
+
+
+def render_user_prompt(
+    *,
+    window_start: datetime,
+    window_end: datetime,
+    digests: Sequence[TraceDigest],
+    previous_reflection_text: str | None,
+) -> str:
+    """Render the user-side prompt for the reflection LLM call.
+
+    Structure:
+      - window header (window_start..window_end UTC)
+      - previous reflection (continuity), or a placeholder
+      - the day's traces, one per line
+      - closing instruction
+    """
+    parts: list[str] = []
+    parts.append(
+        f"Window: {window_start.astimezone(timezone.utc).isoformat()} "
+        f"→ {window_end.astimezone(timezone.utc).isoformat()}"
+    )
+    parts.append("")
+    if previous_reflection_text:
+        parts.append("Previous day's reflection (yours):")
+        parts.append(previous_reflection_text.strip())
+    else:
+        parts.append("Previous day's reflection: (none — this is the first one)")
+    parts.append("")
+    if not digests:
+        parts.append(
+            "No agent turns happened in this window. Acknowledge that in "
+            "one sentence and stop."
+        )
+    else:
+        parts.append(f"Today's agent turns ({len(digests)}):")
+        for i, d in enumerate(digests, start=1):
+            parts.append(
+                f"\n[{i}] {d.when} — archetype={d.archetype} "
+                f"trigger={d.trigger_source}"
+            )
+            if d.input:
+                parts.append(f"    in: {d.input}")
+            if d.output:
+                parts.append(f"    out: {d.output}")
+    parts.append("")
+    parts.append(
+        "Write your end-of-day reflection now, following the rules in your "
+        "system prompt. Plain text, first person, three to six sentences."
+    )
+    return "\n".join(parts)
+
+
+# ── Output validation ────────────────────────────────────────────────────────
+
+
+# Each rule is a (label, compiled-regex). Word-boundary rules avoid
+# false-positives like "I didn't follow up on…" or "I'd recommend
+# trying X tomorrow" (self-directed) while still catching
+# audience-shaped phrases. Per the #42 eval-rubric work, this list is
+# the "voice" dimension; #42 will calibrate weights.
+_VOICE_RULES: tuple[tuple[str, "re.Pattern[str]"], ...]
+import re  # noqa: E402  (placed here so the type alias above is well-formed)
+
+_VOICE_RULES = (
+    ("jack should", re.compile(r"\bjack\s+should\b", re.IGNORECASE)),
+    # Audience-shaped recommend* — explicit "to you" framings only.
+    # The colon-suffixed forms ("Recommendation:", "Recommendations:")
+    # do not have a `\b` anchor after the `:` because `:` is a
+    # non-word char; the trailing context is whitespace which is also
+    # non-word, so `\b` would fail there.
+    (
+        "recommendation framing",
+        re.compile(
+            r"(?:\brecommend(?:ation)?s?:|"
+            r"\b(?:i|we)\s+recommend\s+(?:that|you)\b|"
+            r"\brecommend(?:ation)?s?\s+(?:to|for)\s+jack\b)",
+            re.IGNORECASE,
+        ),
+    ),
+    ("action item", re.compile(r"\baction\s+items?\b", re.IGNORECASE)),
+    ("next steps", re.compile(r"\bnext\s+steps?\b", re.IGNORECASE)),
+    # `follow-up:` / `Follow up:` / `Follow-ups:` — the labelled,
+    # audience-shaped form. We deliberately do NOT trip on "I didn't
+    # follow up on…" which is legitimate first-person voice.
+    (
+        "followup label",
+        re.compile(r"\bfollow[\s-]?ups?\s*:", re.IGNORECASE),
+    ),
+    ("tldr", re.compile(r"\btl;?\s*dr\b", re.IGNORECASE)),
+    ("todo label", re.compile(r"\bto[\s-]?do\s*:", re.IGNORECASE)),
+)
+
+
+def voice_violations(text: str) -> list[str]:
+    """Return any voice-rule labels matched in the reflection text.
+
+    Empty list = clean. Non-empty list = the prompt slipped — the
+    reflector logs a warning and (in #39 v0) still persists the
+    reflection so the operator can see what the model produced. #42
+    turns this into a scored rubric; the labels here are the rule
+    names that fired.
+    """
+    return [label for label, pat in _VOICE_RULES if pat.search(text)]

--- a/agents/reflector/store.py
+++ b/agents/reflector/store.py
@@ -1,0 +1,357 @@
+"""Persistence layer for the `reflections` table.
+
+Append-only, like `traces`. Each daily/weekly/monthly reflection is
+its own row; the hierarchy is recorded in `parent_reflection_ids`.
+The repository surface mirrors `agent.traces.repository` discipline:
+no `update_*` / `delete_*` methods.
+
+Design notes:
+
+- The embedding is `qwen3-embedding:0.6b` at 1024 dims, matching the
+  trace store. Per the issue spec, "embedded the same way traces are
+  per Q1 resolution." The reflector regenerates embeddings on its own
+  (it does not borrow trace embeddings).
+- Reflection text is `RAW_PERSONAL` — the operator's interior voice
+  shaped from raw trace content. It must never leave the box.
+- `tier` is a string column to leave room for #40's `daily | weekly
+  | monthly` extension without a new migration.
+- `parent_reflection_ids` is a Postgres `uuid[]` so the hierarchy
+  query is a single GIN-indexed lookup; #40 adds the index.
+"""
+from __future__ import annotations
+
+import uuid as _uuid
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Optional
+
+import structlog
+from pgvector.sqlalchemy import Vector
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy import DateTime, Index, Integer, String, Text, UniqueConstraint, select
+from sqlalchemy.dialects.postgresql import ARRAY, JSONB, UUID
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import Mapped, deferred, mapped_column
+
+from agent.db import Base
+
+logger = structlog.get_logger(__name__)
+
+# Mirrors `agent.traces.schema.EMBEDDING_DIM`. Kept as a local copy so
+# the lint can remain comfortable that this module's import surface is
+# narrow and so a future change to one embedding dim does not silently
+# bend the other.
+REFLECTION_EMBEDDING_DIM: int = 1024
+REFLECTION_EMBEDDING_MODEL_DEFAULT: str = "qwen3-embedding:0.6b"
+
+# Public tier names. Daily is the only tier shipped in #39; weekly +
+# monthly are added in #40 and use the same column.
+TIER_DAILY: str = "daily"
+TIER_WEEKLY: str = "weekly"
+TIER_MONTHLY: str = "monthly"
+
+_VALID_TIERS: frozenset[str] = frozenset({TIER_DAILY, TIER_WEEKLY, TIER_MONTHLY})
+
+MAX_QUERY_LIMIT: int = 1000
+
+
+class DuplicateReflectionError(Exception):
+    """Raised by `ReflectionRepository.append` when the
+    `(tier, window_start)` uniqueness constraint fires.
+
+    Operationally: the reflector got a second NOTIFY for the same
+    local day (or a re-run after a partial failure). The right
+    response is to log and skip — the previous run already produced
+    the reflection for this window.
+    """
+
+    def __init__(self, tier: str, window_start: datetime) -> None:
+        super().__init__(
+            f"reflection already exists for tier={tier!r} "
+            f"window_start={window_start.isoformat()}"
+        )
+        self.tier = tier
+        self.window_start = window_start
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _new_reflection_id() -> str:
+    return str(_uuid.uuid4())
+
+
+# ── Dataclass contract ───────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class Reflection:
+    """One persisted reflection — daily, weekly, or monthly.
+
+    Frozen so a constructed `Reflection` is the row that will be
+    persisted; no in-place mutation between construction and append.
+    """
+
+    text: str
+    window_start: datetime
+    window_end: datetime
+    tier: str = TIER_DAILY
+    reflection_id: str = field(default_factory=_new_reflection_id)
+    created_at: datetime = field(default_factory=_utcnow)
+    previous_reflection_id: Optional[str] = None
+    parent_reflection_ids: Optional[list[str]] = None
+    trace_count: int = 0
+    model_used: str = ""
+    prompt_version: str = "unversioned"
+    embedding: Optional[list[float]] = None
+    embedding_model_version: Optional[str] = None
+    # Free-form bag for downstream archetypes (#41 pattern detector,
+    # #42 eval) to attach structured side-data without a new column or
+    # an LLM re-parse. Reserved keys agreed in this PR:
+    #   - "voice_violations": list[str] populated by `prompt.voice_violations`
+    #   - "trace_truncated": bool — set when the prompt cap was hit
+    metadata_: dict = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if self.tier not in _VALID_TIERS:
+            raise ValueError(
+                f"reflection tier must be one of {sorted(_VALID_TIERS)}, "
+                f"got {self.tier!r}"
+            )
+        if self.window_end < self.window_start:
+            raise ValueError("reflection window_end is before window_start")
+        if self.embedding is not None and len(self.embedding) != REFLECTION_EMBEDDING_DIM:
+            raise ValueError(
+                f"reflection embedding must have dim {REFLECTION_EMBEDDING_DIM}, "
+                f"got {len(self.embedding)}"
+            )
+
+
+# ── ORM mapping ──────────────────────────────────────────────────────────────
+
+
+class ReflectionRow(Base):
+    """Storage projection for `Reflection`. Append-only at the app layer."""
+
+    __tablename__ = "reflections"
+
+    reflection_id: Mapped[_uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        default=_uuid.uuid4,
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+    )
+
+    tier: Mapped[str] = mapped_column(String(16), nullable=False, default=TIER_DAILY)
+    window_start: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+    )
+    window_end: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+    )
+
+    text: Mapped[str] = mapped_column(Text, nullable=False, default="")
+
+    previous_reflection_id: Mapped[Optional[_uuid.UUID]] = mapped_column(
+        UUID(as_uuid=True),
+        nullable=True,
+    )
+    # Postgres uuid[] — used by #40 to walk the hierarchy. A weekly
+    # rollup's parent_reflection_ids holds the 7 daily IDs; a monthly
+    # rollup holds the 4 weekly IDs.
+    parent_reflection_ids: Mapped[Optional[list[_uuid.UUID]]] = mapped_column(
+        ARRAY(UUID(as_uuid=True)),
+        nullable=True,
+    )
+
+    trace_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    model_used: Mapped[str] = mapped_column(Text, nullable=False, default="")
+    prompt_version: Mapped[str] = mapped_column(
+        Text,
+        nullable=False,
+        default="unversioned",
+    )
+
+    embedding: Mapped[Optional[list[float]]] = deferred(
+        mapped_column(Vector(REFLECTION_EMBEDDING_DIM), nullable=True),
+    )
+    embedding_model_version: Mapped[Optional[str]] = mapped_column(
+        Text,
+        nullable=True,
+    )
+
+    metadata_: Mapped[dict] = mapped_column(
+        "metadata",
+        JSONB,
+        nullable=False,
+        default=dict,
+    )
+
+    __table_args__ = (
+        Index("idx_reflections_created_at", "created_at"),
+        Index("idx_reflections_tier_created_at", "tier", "created_at"),
+        Index("idx_reflections_window", "window_start", "window_end"),
+        # One reflection per (tier, window_start). A re-run for the
+        # same day collides at INSERT and the reflector logs + skips
+        # rather than producing duplicate dailies that #40's rollup
+        # would have to dedupe by hand.
+        UniqueConstraint(
+            "tier",
+            "window_start",
+            name="uq_reflections_tier_window_start",
+        ),
+    )
+
+
+# ── Mapping helpers ──────────────────────────────────────────────────────────
+
+
+def _reflection_to_row(r: Reflection) -> ReflectionRow:
+    return ReflectionRow(
+        reflection_id=_uuid.UUID(r.reflection_id),
+        created_at=r.created_at,
+        tier=r.tier,
+        window_start=r.window_start,
+        window_end=r.window_end,
+        text=r.text,
+        previous_reflection_id=(
+            _uuid.UUID(r.previous_reflection_id)
+            if r.previous_reflection_id is not None
+            else None
+        ),
+        parent_reflection_ids=(
+            [_uuid.UUID(p) for p in r.parent_reflection_ids]
+            if r.parent_reflection_ids is not None
+            else None
+        ),
+        trace_count=r.trace_count,
+        model_used=r.model_used,
+        prompt_version=r.prompt_version,
+        embedding=r.embedding,
+        embedding_model_version=r.embedding_model_version,
+        metadata_=dict(r.metadata_),
+    )
+
+
+def _row_to_reflection(row: ReflectionRow) -> Reflection:
+    return Reflection(
+        reflection_id=str(row.reflection_id),
+        created_at=row.created_at,
+        tier=row.tier,
+        window_start=row.window_start,
+        window_end=row.window_end,
+        text=row.text,
+        previous_reflection_id=(
+            str(row.previous_reflection_id)
+            if row.previous_reflection_id is not None
+            else None
+        ),
+        parent_reflection_ids=(
+            [str(p) for p in row.parent_reflection_ids]
+            if row.parent_reflection_ids is not None
+            else None
+        ),
+        trace_count=row.trace_count,
+        model_used=row.model_used,
+        prompt_version=row.prompt_version,
+        embedding=row.embedding,
+        embedding_model_version=row.embedding_model_version,
+        metadata_=dict(row.metadata_ or {}),
+    )
+
+
+# ── Repository ───────────────────────────────────────────────────────────────
+
+
+class ReflectionRepository:
+    """Append-only repository for reflections.
+
+    Public surface: `append`, `get_by_id`, `latest`, `query`. No
+    `update_*`, no `delete_*`. The lint test
+    `agent/tests/test_reflections_repository.py` asserts via
+    `hasattr` that disallowed methods do not exist.
+    """
+
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+
+    async def append(self, reflection: Reflection) -> Reflection:
+        row = _reflection_to_row(reflection)
+        self._session.add(row)
+        try:
+            await self._session.flush()
+            await self._session.commit()
+        except IntegrityError as exc:
+            await self._session.rollback()
+            raise DuplicateReflectionError(
+                reflection.tier, reflection.window_start
+            ) from exc
+        logger.info(
+            "reflection_appended",
+            reflection_id=reflection.reflection_id,
+            tier=reflection.tier,
+            trace_count=reflection.trace_count,
+        )
+        return reflection
+
+    async def get_by_id(self, reflection_id: str) -> Optional[Reflection]:
+        stmt = select(ReflectionRow).where(
+            ReflectionRow.reflection_id == _uuid.UUID(reflection_id),
+        )
+        result = await self._session.execute(stmt)
+        row = result.scalar_one_or_none()
+        return _row_to_reflection(row) if row is not None else None
+
+    async def latest(self, tier: str = TIER_DAILY) -> Optional[Reflection]:
+        """Return the most recent reflection of the given tier, or None.
+
+        The reflector calls this with `tier=daily` to find "yesterday's
+        reflection" so it can include continuity in the next prompt.
+        """
+        if tier not in _VALID_TIERS:
+            raise ValueError(f"unknown tier {tier!r}")
+        stmt = (
+            select(ReflectionRow)
+            .where(ReflectionRow.tier == tier)
+            .order_by(ReflectionRow.created_at.desc())
+            .limit(1)
+        )
+        result = await self._session.execute(stmt)
+        row = result.scalar_one_or_none()
+        return _row_to_reflection(row) if row is not None else None
+
+    async def query(
+        self,
+        *,
+        tier: Optional[str] = None,
+        since: Optional[datetime] = None,
+        until: Optional[datetime] = None,
+        limit: int = 100,
+    ) -> Sequence[Reflection]:
+        """Return reflections matching the filters, newest first."""
+        if tier is not None and tier not in _VALID_TIERS:
+            raise ValueError(f"unknown tier {tier!r}")
+        limit = max(1, min(limit, MAX_QUERY_LIMIT))
+
+        stmt = (
+            select(ReflectionRow)
+            .order_by(ReflectionRow.created_at.desc())
+            .limit(limit)
+        )
+        if tier is not None:
+            stmt = stmt.where(ReflectionRow.tier == tier)
+        if since is not None:
+            stmt = stmt.where(ReflectionRow.created_at >= since)
+        if until is not None:
+            stmt = stmt.where(ReflectionRow.created_at <= until)
+
+        result = await self._session.execute(stmt)
+        rows = result.scalars().all()
+        return [_row_to_reflection(r) for r in rows]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -122,40 +122,46 @@ services:
   # ---------------------------------------------------------------------------
   # Cognitive archetypes (ADR-0004 + ADR-0006). Each archetype runs as its
   # own service, launched via `python -m agents.runner --archetype <name>`.
-  # The first inhabitant — `agents-reflector` — is added in #39 by
-  # uncommenting the block below and replacing `<archetype>`. Subsequent
-  # archetypes (`monitor`, `researcher`) follow the same shape.
-  #
-  # Skeleton kept here so the diff in #39 is `-#` not "invent the service".
+  # First inhabitant: `agents-reflector` (#39). Subsequent archetypes
+  # (`monitor`, `researcher`) follow the same shape.
   # ---------------------------------------------------------------------------
-  # agents-<archetype>:
-  #   build: .
-  #   image: pepper:latest
-  #   container_name: pepper-agents-<archetype>
-  #   restart: unless-stopped
-  #   command: ["python", "-m", "agents.runner", "--archetype", "<archetype>"]
-  #   # NOTE for #39: do NOT inherit Pepper Core's full `.env` here. An
-  #   # archetype only needs POSTGRES_URL + its own archetype-specific
-  #   # vars; pulling the whole env unnecessarily widens blast radius
-  #   # (Google OAuth tokens, WhatsApp bridge token, API keys). When the
-  #   # archetype role split lands (per ADR-0005 §"Postgres roles &
-  #   # grants"), point POSTGRES_URL at the per-archetype role
-  #   # (`pepper_traces_reader` for read-only archetypes) rather than
-  #   # the superuser-equivalent `pepper:pepper`.
-  #   environment:
-  #     POSTGRES_URL: postgresql+asyncpg://pepper:pepper@postgres:5432/pepper
-  #     PYTHONPATH: /app
-  #   volumes:
-  #     # Source mounts are :ro — agents write only to Postgres, never to
-  #     # their own source tree. The shared `agent.traces.*` reader is the
-  #     # documented surface; everything else is forbidden by the lint at
-  #     # `agent/tests/test_agents_isolation.py`.
-  #     - ./agents:/app/agents:ro
-  #     - ./agent:/app/agent:ro
-  #     - ./logs:/app/logs
-  #   depends_on:
-  #     postgres:
-  #       condition: service_healthy
+  agents-reflector:
+    build: .
+    image: pepper:latest
+    container_name: pepper-agents-reflector
+    restart: unless-stopped
+    command: ["python", "-m", "agents.runner", "--archetype", "reflector"]
+    # Narrow env: the reflector only needs Postgres + Ollama + its
+    # local-model name. We do NOT inherit the full `.env`; that would
+    # hand the reflector container Google OAuth tokens, the WhatsApp
+    # bridge token, and Anthropic / Brave / Maps API keys it has no
+    # business holding. Per the operator note in #38: when the
+    # per-archetype role split lands (ADR-0005 §"Postgres roles &
+    # grants"), point POSTGRES_URL at the `pepper_traces_reader`
+    # role for the reflector.
+    environment:
+      POSTGRES_URL: postgresql+asyncpg://pepper:pepper@postgres:5432/pepper
+      OLLAMA_BASE_URL: http://host.docker.internal:11434
+      DEFAULT_LOCAL_MODEL: ${DEFAULT_LOCAL_MODEL:-hermes-4.3-36b-tools:latest}
+      # Aligns the reflector's daily window to the same TZ Pepper Core
+      # fires the trigger in (`agent/scheduler.py:fire_reflector_trigger`).
+      TIMEZONE: ${TIMEZONE:-America/Los_Angeles}
+      LOG_LEVEL: ${LOG_LEVEL:-INFO}
+      PYTHONPATH: /app
+      RUNNING_IN_DOCKER: "1"
+    volumes:
+      # Source mounts are :ro — the reflector writes only to Postgres,
+      # never to its own source tree. The shared `agent.traces.*`
+      # reader is the documented surface; everything else is
+      # forbidden by `agent/tests/test_agents_isolation.py`.
+      - ./agents:/app/agents:ro
+      - ./agent:/app/agent:ro
+      - ./logs:/app/logs
+    depends_on:
+      postgres:
+        condition: service_healthy
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
 
   # cloudflared:
   #   image: cloudflare/cloudflared:latest


### PR DESCRIPTION
## Summary

- First inhabitant of `agents/` per ADR-0006: `agents-reflector` runs as its own docker-compose service, LISTENs on the `reflector_trigger` Postgres channel that core's APScheduler already fires at 23:55 local (Epic 01 #23), and on each notify produces one daily reflection over the previous 24h of traces.
- Reflection is a private note **to herself**, first-person, hard-capped at 16 KB. Voice rules detect audience-shaped framings (`recommendations:`, `next steps`, `TLDR`, `Jack should…`) without false-positives on legitimate first-person speech (`I didn't follow up on…`).
- New `reflections` table (append-only, `UNIQUE (tier, window_start)`) with HNSW + GIN indexes for #40/#41.

## Privacy & security

- `OLLAMA_BASE_URL` is validated on boot against a local-loopback / in-cluster allowlist. A hostile env that points the URL at an attacker-controlled host is rejected loudly — RAW_PERSONAL trace contents never leave the box.
- The Postgres `LISTEN` channel name is regex-validated as a Postgres identifier on boot.
- Each pass runs under a 300 s wall-clock cap; LLM (180 s) and embed (120 s) timeouts cap the inner calls. A stuck pass cannot block subsequent NOTIFYs forever.
- Crash isolation per ADR-0006: an exception in one pass is logged and the listener keeps running.

## ⚠️ Operator action item — DB role

The `agents-reflector` service still connects with `pepper:pepper` (the same superuser-equivalent the orchestrator uses). This was flagged in the security review and in #38's PR description:

> When the per-archetype role split lands (ADR-0005 §"Postgres roles & grants"), point `POSTGRES_URL` at the `pepper_traces_reader` role for the reflector and grant it `INSERT,SELECT` on `reflections` plus `LISTEN` on `reflector_trigger`. Nothing else.

That work is out of scope for #39 (it's a substrate-wide split that touches every archetype). Filed as the next operational follow-up.

## Acceptance criteria from #39

- [x] `agents/reflector/main.py` implemented; uses runner from #38.
- [x] `agents-reflector` service in `docker-compose.yml` with `restart: unless-stopped`.
- [x] Trigger via APScheduler `NOTIFY` on `reflector_trigger`; reflector LISTENs.
- [x] Input: last 24h of traces (via #20 trace store) + previous day's reflection.
- [x] Output: written to new `reflections` table (Postgres, append-only, embedded the same way as traces — qwen3-embedding:0.6b @ 1024 dims).
- [x] Output framing: first-person, voice-violation rules with metadata persistence.
- [x] Crash-isolation contract documented + enforced (try/except around pass, wall-clock timeout, validator-driven boot).

## Notes for downstream subissues

- **#40 (rollups)**: schema is ready — `tier`, `parent_reflection_ids`, GIN index on parents, uniqueness `(tier, window_start)` already in place. Weekly = `tier='weekly'` with 7 daily IDs in `parent_reflection_ids`; monthly analogously.
- **#41 (pattern detector)**: `reflections.metadata_` jsonb is the agreed extension point. `voice_violations` and `trace_truncated` are already populated; #41 can layer cluster IDs / alert refs without a migration.
- **#42 (eval rubric)**: `metadata_.voice_violations` already records the voice-rule labels that fired; the scoring tool can read them without rerunning the regex. Soak (7 days) is the operator's runtime check, not a CI gate.

## Test plan

- [x] `pytest agent/tests/test_reflector_*.py agent/tests/test_agents_isolation.py` — **83 passed**.
- [x] `ruff check agents/ agent/tests/test_reflector_*.py` — clean.
- [x] `python -m agents.runner --archetype reflector` boots, validates env, attempts to LISTEN (and exits cleanly on SIGTERM).
- [ ] Soak: 7-day live reflection run on real traces — operator action after merge; #42 will calibrate the rubric on that soak.

## Files added

- `agents/reflector/__init__.py`, `main.py`, `store.py`, `migration.py`, `listener.py`, `prompt.py`
- `agent/tests/test_reflector_{store,prompt,listener,main}.py`
- `docker-compose.yml` — `agents-reflector` service activated.

Closes #39.