### PR TITLE
agents/reflector: weekly + monthly rollups (#40)

### DIFF
--- a/agent/scheduler.py
+++ b/agent/scheduler.py
@@ -22,11 +22,15 @@ from agent.commitment_followup import CommitmentFollowup
 from agent.models import AuditLog
 from agent.traces import TriggerSource
 
-# Postgres NOTIFY channel used to signal end-of-day to the reflector
-# process (#39). The payload is intentionally signal-only — no trace
-# contents — so the LISTEN client can never interpret the channel as
-# a content sink.
+# Postgres NOTIFY channels used to signal cadence-bounded work to the
+# reflector process. The daily channel (#39) fires at 23:55 local; the
+# weekly + monthly rollup channels (#40) fire on Sunday 23:55 and on
+# day-1 00:05 respectively. Payloads are intentionally signal-only —
+# a date string in the format `YYYY-MM-DD` (local TZ) — so the LISTEN
+# client can never interpret the channel as a content sink.
 REFLECTOR_TRIGGER_CHANNEL = "reflector_trigger"
+REFLECTOR_WEEKLY_CHANNEL = "reflector_weekly_trigger"
+REFLECTOR_MONTHLY_CHANNEL = "reflector_monthly_trigger"
 
 logger = structlog.get_logger()
 
@@ -97,6 +101,33 @@ class PepperScheduler:
             self.fire_reflector_trigger,
             CronTrigger(hour=23, minute=55),
             id="reflector_trigger",
+            replace_existing=True,
+        )
+        # Epic 04 (#40): weekly rollup trigger. Fires MONDAY 00:15
+        # local — *not* Sunday 23:55. The reflector's daily pass
+        # (180 s LLM cap, 300 s wall-clock) needs to land Sunday's
+        # daily before the weekly query runs. Co-firing them in the
+        # same minute would race: the weekly might roll up only six
+        # dailies (Mon-Sat) if it dequeued first. 20 minutes after
+        # the Sunday daily is comfortable headroom.
+        # Payload is the SUNDAY date (today_local minus one day) so
+        # the rollup window calculation matches "the week that just
+        # ended."
+        self._scheduler.add_job(
+            self.fire_reflector_weekly_trigger,
+            CronTrigger(day_of_week=0, hour=0, minute=15),
+            id="reflector_weekly_trigger",
+            replace_existing=True,
+        )
+        # Epic 04 (#40): monthly rollup trigger. Fires day 1 of each
+        # month at 00:15 local — 20 minutes after the day-1 daily
+        # would have started running (and any in-flight Sunday weekly
+        # has finished). Covers the previous month. Payload is
+        # signal-only (the day-1 date string).
+        self._scheduler.add_job(
+            self.fire_reflector_monthly_trigger,
+            CronTrigger(day=1, hour=0, minute=15),
+            id="reflector_monthly_trigger",
             replace_existing=True,
         )
         # Epic 01 (#21): nightly trace compression. Promotes
@@ -320,45 +351,85 @@ class PepperScheduler:
             )
             return {"ok": False, "error": type(exc).__name__}
 
-    async def fire_reflector_trigger(self) -> bool:
-        """Fire the end-of-day Postgres NOTIFY for the reflector (#39).
+    async def _fire_reflector_notify(
+        self, channel: str, audit_kind: str, *, payload_date_offset_days: int = 0
+    ) -> bool:
+        """Common path: NOTIFY <channel>, '<YYYY-MM-DD>' in local TZ.
 
-        Payload format: `<YYYY-MM-DD>` in the local timezone — a fixed,
-        signal-only string. The reflector LISTENs on this channel and
-        kicks off its daily window query. Trace contents are NEVER
-        included in the payload. Returns True on success, False on
-        error (job is best-effort and never raises).
+        Payload is signal-only. The channel name is interpolated into
+        the literal NOTIFY SQL; all `channel` callers below are
+        compile-time constants, so there is no user-supplied input
+        here. Date payload is generated server-side and escaped for
+        the single-quoted literal as defence in depth.
+
+        `payload_date_offset_days` lets the weekly trigger send the
+        Sunday-of-the-just-ended-week even though the cron itself
+        fires on Monday 00:15 (#40 race-fix). Defaults to 0
+        (today's date in local TZ).
         """
         if self.pepper.db_factory is None:
-            logger.info("reflector_trigger_skipped", reason="no_db_factory")
+            logger.info("reflector_trigger_skipped", reason="no_db_factory", channel=channel)
             return False
         tz = ZoneInfo(self.config.TIMEZONE)
-        payload = datetime.now(tz).strftime("%Y-%m-%d")
+        when = datetime.now(tz) + timedelta(days=payload_date_offset_days)
+        payload = when.strftime("%Y-%m-%d")
         try:
             async with self.pepper.db_factory() as session:
-                # NOTIFY needs literal SQL — no bind parameters allowed
-                # in NOTIFY's payload position. The payload is a fixed-
-                # format date string we generated ourselves; no user
-                # input flows into this SQL.
                 escaped = payload.replace("'", "''")
                 await session.execute(
-                    text(f"NOTIFY {REFLECTOR_TRIGGER_CHANNEL}, '{escaped}'"),
+                    text(f"NOTIFY {channel}, '{escaped}'"),
                 )
                 await session.commit()
             logger.info(
                 "reflector_trigger_fired",
-                channel=REFLECTOR_TRIGGER_CHANNEL,
+                channel=channel,
                 payload=payload,
             )
-            await self._audit("reflector_trigger", payload)
+            await self._audit(audit_kind, payload)
             return True
         except Exception as exc:
             logger.warning(
                 "reflector_trigger_failed",
+                channel=channel,
                 error_type=type(exc).__name__,
                 error=str(exc)[:200],
             )
             return False
+
+    async def fire_reflector_trigger(self) -> bool:
+        """Fire the end-of-day Postgres NOTIFY for the reflector (#39).
+
+        Cron: every day at 23:55 local. Payload = today's date.
+        """
+        return await self._fire_reflector_notify(
+            REFLECTOR_TRIGGER_CHANNEL, "reflector_trigger"
+        )
+
+    async def fire_reflector_weekly_trigger(self) -> bool:
+        """Fire the Monday-00:15 weekly rollup NOTIFY (#40).
+
+        Cron fires on Monday 00:15 local — *not* Sunday 23:55 — so
+        Sunday's daily reflection has time to land first (race-fix
+        from #40 review). The payload is therefore yesterday's date
+        (Sunday) so `weekly_window_for_payload` reads the Sunday at
+        the end of the week the rollup covers.
+        """
+        return await self._fire_reflector_notify(
+            REFLECTOR_WEEKLY_CHANNEL,
+            "reflector_weekly_trigger",
+            payload_date_offset_days=-1,
+        )
+
+    async def fire_reflector_monthly_trigger(self) -> bool:
+        """Fire the day-1 00:15 monthly rollup NOTIFY (#40).
+
+        Cron fires on the 1st of the month at 00:15 local. Payload =
+        today's date (the 1st), which the rollup interprets as
+        "cover the previous month."
+        """
+        return await self._fire_reflector_notify(
+            REFLECTOR_MONTHLY_CHANNEL, "reflector_monthly_trigger"
+        )
 
     def get_status(self) -> dict:
         return {

--- a/agent/tests/test_reflector_main.py
+++ b/agent/tests/test_reflector_main.py
@@ -465,6 +465,28 @@ class TestValidators:
             rmain._validate_notify_channel(channel)
 
 
+@pytest.mark.asyncio
+class TestRunBootValidation:
+    """Boot-time refusal to subscribe a daily channel onto a rollup
+    channel — closes the env-override foot-gun the #40 review found."""
+
+    @pytest.mark.parametrize(
+        "colliding",
+        [rmain.WEEKLY_CHANNEL, rmain.MONTHLY_CHANNEL],
+    )
+    async def test_daily_channel_collision_with_rollup_is_refused(
+        self, colliding: str
+    ) -> None:
+        cfg = rmain.AgentRuntimeConfig(
+            archetype="reflector",
+            postgres_url="postgresql+asyncpg://test/test",
+            log_level="DEBUG",
+            notify_channel=colliding,
+        )
+        with pytest.raises(rmain.ReflectorConfigError, match="collides"):
+            await rmain.run(cfg)
+
+
 class TestWindowForPayload:
     def test_well_formed_utc_payload(self) -> None:
         ws, we = rmain._window_for_payload(

--- a/agent/tests/test_reflector_rollup.py
+++ b/agent/tests/test_reflector_rollup.py
@@ -1,0 +1,344 @@
+"""Unit tests for `agents.reflector.rollup` — windowing + pipeline.
+
+Stubs the LLM + embed callables so the pipeline runs without a model
+or DB. Covers:
+  - weekly window resolution from a Sunday payload (UTC + non-UTC TZ)
+  - monthly window resolution from a 1st-of-month payload
+  - end-to-end rollup: 7 daily children → 1 weekly with parents linked
+  - empty period: 0 children → 'quiet week' single-line reflection
+  - duplicate-window collision is logged and skipped
+"""
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from datetime import datetime, timedelta, timezone
+from typing import Optional, Sequence
+from unittest.mock import AsyncMock, MagicMock, patch
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from agents.reflector import rollup as rrollup
+from agents.reflector import store as rstore
+
+
+# ── Window helpers ──────────────────────────────────────────────────────────
+
+
+class TestWeeklyWindowForPayload:
+    def test_sunday_utc_payload_aligns_monday_to_next_monday(self) -> None:
+        # 2026-05-03 is a Sunday.
+        ws, we = rrollup.weekly_window_for_payload(
+            "2026-05-03",
+            tz=ZoneInfo("UTC"),
+            now=datetime(2026, 5, 4, 12, 0, tzinfo=timezone.utc),
+        )
+        assert ws == datetime(2026, 4, 27, 0, 0, tzinfo=timezone.utc)  # Mon
+        assert we == datetime(2026, 5, 4, 0, 0, tzinfo=timezone.utc)  # next Mon
+
+    def test_sunday_west_coast_payload_aligns_to_local_week(self) -> None:
+        tz = ZoneInfo("America/Los_Angeles")  # PDT, UTC-7
+        ws, we = rrollup.weekly_window_for_payload(
+            "2026-05-03",
+            tz=tz,
+            now=datetime(2026, 5, 5, 0, 0, tzinfo=timezone.utc),
+        )
+        # Local Monday 2026-04-27 00:00 PDT = 07:00Z
+        assert ws == datetime(2026, 4, 27, 7, 0, tzinfo=timezone.utc)
+        assert we == datetime(2026, 5, 4, 7, 0, tzinfo=timezone.utc)
+
+    def test_window_end_clipped_to_now(self) -> None:
+        tz = ZoneInfo("UTC")
+        # If we trigger Sunday 23:59 and now is mid-Sunday, window_end
+        # should clip back to now.
+        now = datetime(2026, 5, 3, 18, 0, tzinfo=timezone.utc)
+        ws, we = rrollup.weekly_window_for_payload("2026-05-03", tz=tz, now=now)
+        assert we == now
+
+    def test_malformed_payload_falls_back_to_yesterday(self) -> None:
+        tz = ZoneInfo("UTC")
+        now = datetime(2026, 5, 4, 12, 0, tzinfo=timezone.utc)
+        ws, we = rrollup.weekly_window_for_payload("not-a-date", tz=tz, now=now)
+        # Yesterday in UTC = 2026-05-03 (Sunday); calendar-week
+        # window is Mon 2026-04-27 .. Mon 2026-05-04.
+        assert ws == datetime(2026, 4, 27, 0, 0, tzinfo=timezone.utc)
+        assert we == datetime(2026, 5, 4, 0, 0, tzinfo=timezone.utc)
+
+    def test_non_sunday_payload_aligns_to_iso_week(self) -> None:
+        # 2026-04-29 is a Wednesday. The calendar-week answer is the
+        # Mon..Mon window containing that Wednesday: 2026-04-27 →
+        # 2026-05-04. (The previous defensive branch produced a
+        # misaligned 7-day window — that branch is gone.)
+        ws, we = rrollup.weekly_window_for_payload(
+            "2026-04-29",
+            tz=ZoneInfo("UTC"),
+            now=datetime(2026, 5, 5, 0, 0, tzinfo=timezone.utc),
+        )
+        assert ws == datetime(2026, 4, 27, 0, 0, tzinfo=timezone.utc)
+        assert we == datetime(2026, 5, 4, 0, 0, tzinfo=timezone.utc)
+
+
+class TestMonthlyWindowForPayload:
+    def test_first_of_month_payload(self) -> None:
+        ws, we = rrollup.monthly_window_for_payload(
+            "2026-05-01",
+            tz=ZoneInfo("UTC"),
+            now=datetime(2026, 5, 1, 12, 0, tzinfo=timezone.utc),
+        )
+        # Covers all of April 2026.
+        assert ws == datetime(2026, 4, 1, 0, 0, tzinfo=timezone.utc)
+        assert we == datetime(2026, 5, 1, 0, 0, tzinfo=timezone.utc)
+
+    def test_january_wraps_to_december_of_prev_year(self) -> None:
+        ws, we = rrollup.monthly_window_for_payload(
+            "2027-01-01",
+            tz=ZoneInfo("UTC"),
+            now=datetime(2027, 1, 2, 12, 0, tzinfo=timezone.utc),
+        )
+        assert ws == datetime(2026, 12, 1, 0, 0, tzinfo=timezone.utc)
+        assert we == datetime(2027, 1, 1, 0, 0, tzinfo=timezone.utc)
+
+    def test_local_tz_offset_applied(self) -> None:
+        tz = ZoneInfo("America/Los_Angeles")  # PDT, UTC-7 in May
+        ws, we = rrollup.monthly_window_for_payload(
+            "2026-05-01",
+            tz=tz,
+            now=datetime(2026, 5, 2, 0, 0, tzinfo=timezone.utc),
+        )
+        # April 1 00:00 PDT = 07:00Z; May 1 00:00 PDT = 07:00Z.
+        assert ws == datetime(2026, 4, 1, 7, 0, tzinfo=timezone.utc)
+        assert we == datetime(2026, 5, 1, 7, 0, tzinfo=timezone.utc)
+
+
+# ── Pipeline tests ──────────────────────────────────────────────────────────
+
+
+def _daily(
+    *,
+    text: str,
+    window_start: datetime,
+) -> rstore.Reflection:
+    return rstore.Reflection(
+        text=text,
+        window_start=window_start,
+        window_end=window_start + timedelta(days=1),
+        tier=rstore.TIER_DAILY,
+    )
+
+
+def _weekly(
+    *,
+    text: str,
+    window_start: datetime,
+) -> rstore.Reflection:
+    return rstore.Reflection(
+        text=text,
+        window_start=window_start,
+        window_end=window_start + timedelta(days=7),
+        tier=rstore.TIER_WEEKLY,
+    )
+
+
+def _make_session_factory(
+    *,
+    children: Sequence[rstore.Reflection],
+    previous: Optional[rstore.Reflection],
+    appended: list[rstore.Reflection],
+    raise_duplicate: bool = False,
+):
+    @asynccontextmanager
+    async def _factory():
+        with patch.object(rstore, "ReflectionRepository") as RR:
+            rr = MagicMock()
+            # Rollups read children via window-based query, NOT
+            # created_at-based query — that's the whole point of #40's
+            # late-backfill correctness fix.
+            rr.query_by_window = AsyncMock(return_value=list(children))
+            rr.latest = AsyncMock(return_value=previous)
+
+            async def _append(reflection):
+                if raise_duplicate:
+                    raise rstore.DuplicateReflectionError(
+                        reflection.tier, reflection.window_start
+                    )
+                appended.append(reflection)
+                return reflection
+
+            rr.append = AsyncMock(side_effect=_append)
+            RR.return_value = rr
+            yield None
+
+    return _factory
+
+
+@pytest.mark.asyncio
+class TestWeeklyRollupPipeline:
+    async def test_seven_dailies_become_one_weekly(self) -> None:
+        # Build 7 dailies covering Mon..Sun in UTC.
+        week_start = datetime(2026, 4, 27, 0, 0, tzinfo=timezone.utc)
+        children = [
+            _daily(
+                text=f"day {i}",
+                window_start=week_start + timedelta(days=i),
+            )
+            for i in range(7)
+        ]
+        appended: list[rstore.Reflection] = []
+        factory = _make_session_factory(
+            children=children, previous=None, appended=appended
+        )
+
+        async def _chat(*, system_prompt, user_prompt, model, timeout_s):
+            return ("the week leaned quiet, with a steady rhythm.", "test-model")
+
+        async def _embed(*, text, model, timeout_s):
+            return [0.0] * rstore.REFLECTION_EMBEDDING_DIM
+
+        result = await rrollup.run_weekly_rollup(
+            payload="2026-05-03",  # Sunday
+            session_factory=factory,
+            chat_fn=_chat,
+            embed_fn=_embed,
+            chat_model="test-model",
+            chat_timeout_s=10.0,
+            embed_timeout_s=10.0,
+            tz=ZoneInfo("UTC"),
+            now=datetime(2026, 5, 4, 0, 0, tzinfo=timezone.utc),
+        )
+
+        assert result is not None
+        assert len(appended) == 1
+        stored = appended[0]
+        assert stored.tier == rstore.TIER_WEEKLY
+        assert stored.parent_reflection_ids is not None
+        assert len(stored.parent_reflection_ids) == 7
+        assert stored.window_start == datetime(2026, 4, 27, 0, 0, tzinfo=timezone.utc)
+        assert stored.metadata_["child_count"] == 7
+        assert stored.metadata_["child_tier"] == rstore.TIER_DAILY
+
+    async def test_quiet_week_produces_short_reflection(self) -> None:
+        appended: list[rstore.Reflection] = []
+        factory = _make_session_factory(
+            children=[], previous=None, appended=appended
+        )
+
+        async def _chat(*, system_prompt, user_prompt, model, timeout_s):
+            # Emulate what the prompt requests for an empty period.
+            return ("a quiet week.", "test-model")
+
+        async def _embed(*, text, model, timeout_s):
+            return None
+
+        result = await rrollup.run_weekly_rollup(
+            payload="2026-05-03",
+            session_factory=factory,
+            chat_fn=_chat,
+            embed_fn=_embed,
+            chat_model="test-model",
+            chat_timeout_s=10.0,
+            embed_timeout_s=10.0,
+            tz=ZoneInfo("UTC"),
+            now=datetime(2026, 5, 4, 0, 0, tzinfo=timezone.utc),
+        )
+
+        assert result is not None
+        assert appended[0].metadata_["child_count"] == 0
+        assert appended[0].parent_reflection_ids is None
+
+    async def test_duplicate_weekly_window_is_skipped(self) -> None:
+        appended: list[rstore.Reflection] = []
+        factory = _make_session_factory(
+            children=[], previous=None, appended=appended, raise_duplicate=True
+        )
+
+        async def _chat(*, system_prompt, user_prompt, model, timeout_s):
+            return ("a quiet week.", "test-model")
+
+        async def _embed(*, text, model, timeout_s):
+            return None
+
+        result = await rrollup.run_weekly_rollup(
+            payload="2026-05-03",
+            session_factory=factory,
+            chat_fn=_chat,
+            embed_fn=_embed,
+            chat_model="test-model",
+            chat_timeout_s=10.0,
+            embed_timeout_s=10.0,
+            tz=ZoneInfo("UTC"),
+            now=datetime(2026, 5, 4, 0, 0, tzinfo=timezone.utc),
+        )
+        # Repository raises DuplicateReflectionError → rollup returns None.
+        assert result is None
+        assert appended == []
+
+    async def test_empty_response_is_skipped(self) -> None:
+        appended: list[rstore.Reflection] = []
+        factory = _make_session_factory(
+            children=[], previous=None, appended=appended
+        )
+
+        async def _chat(*, system_prompt, user_prompt, model, timeout_s):
+            return ("", "test-model")
+
+        async def _embed(*, text, model, timeout_s):
+            return None
+
+        result = await rrollup.run_weekly_rollup(
+            payload="2026-05-03",
+            session_factory=factory,
+            chat_fn=_chat,
+            embed_fn=_embed,
+            chat_model="test-model",
+            chat_timeout_s=10.0,
+            embed_timeout_s=10.0,
+            tz=ZoneInfo("UTC"),
+            now=datetime(2026, 5, 4, 0, 0, tzinfo=timezone.utc),
+        )
+        assert result is None
+        assert appended == []
+
+
+@pytest.mark.asyncio
+class TestMonthlyRollupPipeline:
+    async def test_four_weeklies_become_one_monthly(self) -> None:
+        # April 2026 weeklies, in UTC.
+        weekly_starts = [
+            datetime(2026, 3, 30, 0, 0, tzinfo=timezone.utc),  # week of Mar30-Apr5
+            datetime(2026, 4, 6, 0, 0, tzinfo=timezone.utc),
+            datetime(2026, 4, 13, 0, 0, tzinfo=timezone.utc),
+            datetime(2026, 4, 20, 0, 0, tzinfo=timezone.utc),
+        ]
+        children = [
+            _weekly(text=f"week starting {ws.date()}", window_start=ws)
+            for ws in weekly_starts
+        ]
+        appended: list[rstore.Reflection] = []
+        factory = _make_session_factory(
+            children=children, previous=None, appended=appended
+        )
+
+        async def _chat(*, system_prompt, user_prompt, model, timeout_s):
+            return ("April held a steadier tempo than March did.", "test-model")
+
+        async def _embed(*, text, model, timeout_s):
+            return None
+
+        result = await rrollup.run_monthly_rollup(
+            payload="2026-05-01",  # rollup covers April 2026
+            session_factory=factory,
+            chat_fn=_chat,
+            embed_fn=_embed,
+            chat_model="test-model",
+            chat_timeout_s=10.0,
+            embed_timeout_s=10.0,
+            tz=ZoneInfo("UTC"),
+            now=datetime(2026, 5, 1, 1, 0, tzinfo=timezone.utc),
+        )
+
+        assert result is not None
+        stored = appended[0]
+        assert stored.tier == rstore.TIER_MONTHLY
+        assert stored.window_start == datetime(2026, 4, 1, 0, 0, tzinfo=timezone.utc)
+        assert stored.metadata_["child_count"] == 4
+        assert stored.metadata_["child_tier"] == rstore.TIER_WEEKLY

--- a/agent/tests/test_reflector_store.py
+++ b/agent/tests/test_reflector_store.py
@@ -45,7 +45,13 @@ class TestNoMutationSurface:
             if not name.startswith("_")
         )
         # If this list grows, the no-mutation discipline must be re-checked.
-        assert public == ["append", "get_by_id", "latest", "query"]
+        assert public == [
+            "append",
+            "get_by_id",
+            "latest",
+            "query",
+            "query_by_window",
+        ]
 
 
 class TestReflectionDataclassGuards:

--- a/agent/tests/test_scheduler_trace_emission.py
+++ b/agent/tests/test_scheduler_trace_emission.py
@@ -158,3 +158,45 @@ class TestReflectorTrigger:
         # ADR-0005 / #23 spec name. If anyone renames the channel they
         # must update both the scheduler and the reflector LISTEN side.
         assert REFLECTOR_TRIGGER_CHANNEL == "reflector_trigger"
+
+
+class TestReflectorRollupTriggers:
+    """#40: weekly + monthly rollup NOTIFYs share the daily channel's
+    contract (signal-only date payload, fail-soft on DB error)."""
+
+    @pytest.mark.asyncio
+    async def test_weekly_fires_on_documented_channel(self) -> None:
+        from agent.scheduler import REFLECTOR_WEEKLY_CHANNEL
+
+        pepper = _make_pepper(with_db=True)
+        sch = PepperScheduler(pepper, _make_config())
+        ok = await sch.fire_reflector_weekly_trigger()
+        assert ok is True
+        assert len(pepper._executed_sql) == 1
+        sql = pepper._executed_sql[0]
+        assert sql.startswith(f"NOTIFY {REFLECTOR_WEEKLY_CHANNEL}")
+        assert "trace" not in sql.lower()
+        assert "SELECT" not in sql
+
+    @pytest.mark.asyncio
+    async def test_monthly_fires_on_documented_channel(self) -> None:
+        from agent.scheduler import REFLECTOR_MONTHLY_CHANNEL
+
+        pepper = _make_pepper(with_db=True)
+        sch = PepperScheduler(pepper, _make_config())
+        ok = await sch.fire_reflector_monthly_trigger()
+        assert ok is True
+        sql = pepper._executed_sql[0]
+        assert sql.startswith(f"NOTIFY {REFLECTOR_MONTHLY_CHANNEL}")
+
+    def test_rollup_channel_names_are_pinned(self) -> None:
+        from agent.scheduler import (
+            REFLECTOR_MONTHLY_CHANNEL,
+            REFLECTOR_WEEKLY_CHANNEL,
+        )
+
+        # If anyone renames these, the reflector LISTEN side
+        # (`agents/reflector/main.py: WEEKLY_CHANNEL` /
+        # `MONTHLY_CHANNEL`) must move in lockstep.
+        assert REFLECTOR_WEEKLY_CHANNEL == "reflector_weekly_trigger"
+        assert REFLECTOR_MONTHLY_CHANNEL == "reflector_monthly_trigger"

--- a/agents/reflector/listener.py
+++ b/agents/reflector/listener.py
@@ -1,9 +1,13 @@
-"""Postgres `LISTEN/NOTIFY` client for the reflector trigger.
+"""Postgres `LISTEN/NOTIFY` client for the reflector triggers.
 
-The reflector subscribes to a single channel (default
-`reflector_trigger`). Pepper Core's APScheduler fires one NOTIFY per
-day at end-of-day with a date-string payload (see
-`agent/scheduler.py:fire_reflector_trigger`).
+The reflector subscribes to one or more channels — daily at minimum
+(`reflector_trigger`), plus weekly + monthly rollup channels added in
+#40 (`reflector_weekly_trigger`, `reflector_monthly_trigger`). Pepper
+Core's APScheduler fires one NOTIFY per cadence:
+
+- daily: 23:55 local (Epic 01 #23)
+- weekly: Sunday 23:55 local (#40)
+- monthly: day-1 00:05 local (#40)
 
 The connection is opened with raw asyncpg, NOT through SQLAlchemy:
 LISTEN holds an idle connection forever, which is incompatible with
@@ -18,12 +22,12 @@ Failure modes:
   this happens more than once per minute, revisit supervision.
 - Notify payload is malformed → we log and ignore; the reflector
   uses its own clock for the window, not the payload, so a bad
-  payload only loses the trigger for that day.
+  payload only loses the trigger for that cadence.
 """
 from __future__ import annotations
 
 import asyncio
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Iterable
 
 import asyncpg
 import structlog
@@ -45,19 +49,24 @@ def _to_libpq_url(sqlalchemy_url: str) -> str:
 async def listen_for_triggers(
     *,
     sqlalchemy_url: str,
-    channel: str,
+    channels: Iterable[str],
     stop: asyncio.Event,
-) -> AsyncIterator[str]:
-    """Yield each NOTIFY payload received on `channel` until `stop` is set.
+) -> AsyncIterator[tuple[str, str]]:
+    """Yield each NOTIFY as (channel, payload) until `stop` is set.
 
-    Opens a dedicated asyncpg connection, registers a listener, and
-    streams payloads. The function exits cleanly when `stop` is set
-    (the runner sets it on SIGTERM/SIGINT) or when the connection
-    drops. Re-establishing on drop is the operator's responsibility
-    (docker `restart: unless-stopped`).
+    Opens a single dedicated asyncpg connection and registers a
+    listener for every channel in `channels`. Yields a tuple so the
+    caller can dispatch by cadence (daily / weekly / monthly).
+
+    Exits cleanly when `stop` is set (the runner sets it on
+    SIGTERM/SIGINT) or when the connection drops; re-establishing is
+    the operator's responsibility (docker `restart: unless-stopped`).
     """
     libpq_url = _to_libpq_url(sqlalchemy_url)
-    queue: asyncio.Queue[str] = asyncio.Queue()
+    queue: asyncio.Queue[tuple[str, str]] = asyncio.Queue()
+    channel_list = list(channels)
+    if not channel_list:
+        raise ValueError("listen_for_triggers requires at least one channel")
 
     def _on_notify(
         connection: asyncpg.Connection,
@@ -65,16 +74,17 @@ async def listen_for_triggers(
         ch: str,
         payload: str,
     ) -> None:
-        # Callbacks run in the asyncpg loop; queue.put_nowait is
-        # async-safe because asyncpg notify dispatch is sync.
+        # asyncpg invokes this callback synchronously from the
+        # connection's event loop; queue.put_nowait is safe.
         try:
-            queue.put_nowait(payload)
+            queue.put_nowait((ch, payload))
         except asyncio.QueueFull:  # pragma: no cover — unbounded queue
             logger.warning("reflector_listener_queue_full", channel=ch)
 
     conn = await asyncpg.connect(libpq_url)
-    await conn.add_listener(channel, _on_notify)
-    logger.info("reflector_listener_started", channel=channel)
+    for ch in channel_list:
+        await conn.add_listener(ch, _on_notify)
+    logger.info("reflector_listener_started", channels=channel_list)
 
     try:
         while not stop.is_set():
@@ -88,12 +98,13 @@ async def listen_for_triggers(
                 t.cancel()
             if stop_task in done:
                 break
-            payload = payload_task.result()
-            yield payload
+            ch, payload = payload_task.result()
+            yield ch, payload
     finally:
-        try:
-            await conn.remove_listener(channel, _on_notify)
-        except Exception:  # pragma: no cover — best-effort
-            pass
+        for ch in channel_list:
+            try:
+                await conn.remove_listener(ch, _on_notify)
+            except Exception:  # pragma: no cover — best-effort
+                pass
         await conn.close()
-        logger.info("reflector_listener_stopped", channel=channel)
+        logger.info("reflector_listener_stopped", channels=channel_list)

--- a/agents/reflector/main.py
+++ b/agents/reflector/main.py
@@ -35,6 +35,7 @@ from agent.db import Base
 from agent.traces import TraceRepository
 from agents._shared.config import AgentRuntimeConfig
 from agents._shared.db import make_engine, make_session_factory
+from agents.reflector import rollup as _rollup
 from agents.reflector import store as rstore
 from agents.reflector.listener import listen_for_triggers
 from agents.reflector.migration import apply_reflections_migration
@@ -63,10 +64,12 @@ MAX_TRACES_PER_REFLECTION: int = 60
 MAX_REFLECTION_TEXT_CHARS: int = 16_000
 
 # Wall-clock budget for one reflection pass: prompt assembly, LLM
-# call, embed, persist. The LLM call alone has a 180s timeout; this
-# is the outer budget that keeps a stuck pass from holding up
-# subsequent NOTIFYs.
-PASS_TIMEOUT_S: float = 300.0
+# call, embed, persist. The LLM and embed calls each carry their own
+# inner timeouts (180/240s chat, 120s embed). This outer budget must
+# be at least chat+embed+headroom or a fully-used inner pair would
+# cancel the rollup mid-embed and silently drop the row. Monthly
+# chat=240s + embed=120s + ~60s headroom = 420s.
+PASS_TIMEOUT_S: float = 420.0
 
 # Allowlisted Ollama hosts. The privacy invariant is that
 # RAW_PERSONAL trace content NEVER leaves the box, so the Ollama
@@ -91,6 +94,13 @@ _OLLAMA_ALLOWED_HOSTS: frozenset[str] = frozenset(
 # requires. We validate the env-supplied value to avoid the listener
 # silently subscribing to a name nobody ever NOTIFIes.
 _PG_IDENT_RE = re.compile(r"^[a-z_][a-z0-9_]{0,62}$", re.IGNORECASE)
+
+# Per-cadence rollup channels. Names are fixed (not env-tunable) so
+# `agent/scheduler.py` can reference them as compile-time constants.
+# The daily channel is still env-tunable via `notify_channel` because
+# that contract was set in #39.
+WEEKLY_CHANNEL: str = "reflector_weekly_trigger"
+MONTHLY_CHANNEL: str = "reflector_monthly_trigger"
 
 
 def _resolve_timezone() -> ZoneInfo:
@@ -160,25 +170,25 @@ async def _ensure_schema(engine: AsyncEngine) -> None:
     logger.info("reflector_schema_ready")
 
 
-async def _generate_reflection_text(
+async def _ollama_chat(
     *,
+    system_prompt: str,
     user_prompt: str,
     model: str,
     ollama_base_url: str,
     timeout_s: float,
 ) -> tuple[str, str]:
-    """Run the reflection LLM call against the local Ollama server.
+    """Talk to local Ollama. Returns `(content, model_used)`.
 
-    Returns `(reflection_text, model_used)`. Forced local — the
-    reflector never routes RAW_PERSONAL trace contents to a frontier
-    model. We talk to Ollama directly here rather than going through
-    `agent.llm.ModelClient` so the reflector has no transitive
-    dependency on the orchestrator's full config surface.
+    Forced local — the reflector never routes RAW_PERSONAL content to
+    a frontier model. The function is parametric on system + user
+    prompt so daily / weekly / monthly all flow through the same
+    code path.
     """
     payload = {
         "model": model,
         "messages": [
-            {"role": "system", "content": SYSTEM_PROMPT},
+            {"role": "system", "content": system_prompt},
             {"role": "user", "content": user_prompt},
         ],
         "stream": False,
@@ -189,6 +199,23 @@ async def _generate_reflection_text(
         data = resp.json()
     content = (data.get("message") or {}).get("content") or ""
     return content.strip(), model
+
+
+async def _generate_reflection_text(
+    *,
+    user_prompt: str,
+    model: str,
+    ollama_base_url: str,
+    timeout_s: float,
+) -> tuple[str, str]:
+    """Daily-reflection LLM call. Convenience wrapper around _ollama_chat."""
+    return await _ollama_chat(
+        system_prompt=SYSTEM_PROMPT,
+        user_prompt=user_prompt,
+        model=model,
+        ollama_base_url=ollama_base_url,
+        timeout_s=timeout_s,
+    )
 
 
 async def _embed_reflection(
@@ -415,26 +442,121 @@ def _chat_model_from_env() -> str:
     return os.environ.get("DEFAULT_LOCAL_MODEL", "hermes-4.3-36b-tools:latest")
 
 
+def _make_rollup_adapters(*, ollama_base_url: str):
+    """Build the chat/embed callables `agents.reflector.rollup` expects.
+
+    The rollup module is decoupled from `httpx` for testability; this
+    factory binds the live local-Ollama URL into closures that match
+    the keyword shape `rollup._run_rollup` invokes them with.
+    """
+
+    async def _chat_fn(
+        *,
+        system_prompt: str,
+        user_prompt: str,
+        model: str,
+        timeout_s: float,
+    ) -> tuple[str, str]:
+        return await _ollama_chat(
+            system_prompt=system_prompt,
+            user_prompt=user_prompt,
+            model=model,
+            ollama_base_url=ollama_base_url,
+            timeout_s=timeout_s,
+        )
+
+    async def _embed_fn(
+        *, text: str, model: str, timeout_s: float
+    ) -> Optional[list[float]]:
+        return await _embed_reflection(
+            text=text,
+            ollama_base_url=ollama_base_url,
+            model=model,
+            timeout_s=timeout_s,
+        )
+
+    return _chat_fn, _embed_fn
+
+
+async def _dispatch_trigger(
+    *,
+    channel: str,
+    payload: str,
+    config: AgentRuntimeConfig,
+    session_factory,
+    tz: ZoneInfo,
+    ollama_base_url: str,
+    daily_channel: str,
+) -> Optional[rstore.Reflection]:
+    """Route a single (channel, payload) pair to the right pipeline."""
+    if channel == daily_channel:
+        return await _run_one_reflection(
+            config=config,
+            session_factory=session_factory,
+            payload=payload,
+            tz=tz,
+        )
+
+    chat_fn, embed_fn = _make_rollup_adapters(ollama_base_url=ollama_base_url)
+    chat_model = _chat_model_from_env()
+    if channel == WEEKLY_CHANNEL:
+        return await _rollup.run_weekly_rollup(
+            payload=payload,
+            session_factory=session_factory,
+            chat_fn=chat_fn,
+            embed_fn=embed_fn,
+            chat_model=chat_model,
+            chat_timeout_s=180.0,
+            embed_timeout_s=120.0,
+            tz=tz,
+        )
+    if channel == MONTHLY_CHANNEL:
+        return await _rollup.run_monthly_rollup(
+            payload=payload,
+            session_factory=session_factory,
+            chat_fn=chat_fn,
+            embed_fn=embed_fn,
+            chat_model=chat_model,
+            chat_timeout_s=240.0,
+            embed_timeout_s=120.0,
+            tz=tz,
+        )
+    logger.warning("reflector_unknown_channel", channel=channel)
+    return None
+
+
 async def run(config: AgentRuntimeConfig) -> None:
     """Reflector entrypoint, called by `agents.runner`.
 
     Loop:
       - validate env (privacy + identifier checks; refuse on failure)
       - boot schema
-      - LISTEN on `config.notify_channel`
-      - on each notify, run one reflection pass under a wall-clock cap
+      - LISTEN on the daily channel + the weekly + monthly rollup channels
+      - on each notify, dispatch by channel under a wall-clock cap
       - exit cleanly on SIGTERM (the runner sets the stop event)
     """
     # Boot-time validation: refuse to start with an off-box Ollama URL
     # or a malformed Postgres notify identifier. Both of these are
     # privacy-relevant — see _validate_ollama_url's docstring.
-    _validate_ollama_url(_ollama_url_from_env())
-    channel = _validate_notify_channel(config.notify_channel)
+    ollama_base_url = _validate_ollama_url(_ollama_url_from_env())
+    daily_channel = _validate_notify_channel(config.notify_channel)
+    if daily_channel in {WEEKLY_CHANNEL, MONTHLY_CHANNEL}:
+        # An env override that aliases the daily channel onto a rollup
+        # channel would make `_dispatch_trigger` route every notify
+        # to the daily branch — silently skipping all rollup work.
+        raise ReflectorConfigError(
+            f"daily notify channel {daily_channel!r} collides with a "
+            f"rollup channel; pick a different value for "
+            f"PEPPER_AGENT_REFLECTOR_NOTIFY_CHANNEL"
+        )
+    weekly_channel = _validate_notify_channel(WEEKLY_CHANNEL)
+    monthly_channel = _validate_notify_channel(MONTHLY_CHANNEL)
+    channels = [daily_channel, weekly_channel, monthly_channel]
 
     logger.info(
         "reflector_run_starting",
         archetype=config.archetype,
-        notify_channel=channel,
+        channels=channels,
     )
 
     engine = make_engine(config.postgres_url)
@@ -454,25 +576,33 @@ async def run(config: AgentRuntimeConfig) -> None:
     stop = asyncio.Event()
     tz = _resolve_timezone()
     try:
-        async for payload in listen_for_triggers(
+        async for channel, payload in listen_for_triggers(
             sqlalchemy_url=config.postgres_url,
-            channel=channel,
+            channels=channels,
             stop=stop,
         ):
-            logger.info("reflector_trigger_received", payload=payload[:64])
+            logger.info(
+                "reflector_trigger_received",
+                channel=channel,
+                payload=payload[:64],
+            )
             try:
                 reflection = await asyncio.wait_for(
-                    _run_one_reflection(
+                    _dispatch_trigger(
+                        channel=channel,
+                        payload=payload,
                         config=config,
                         session_factory=session_factory,
-                        payload=payload,
                         tz=tz,
+                        ollama_base_url=ollama_base_url,
+                        daily_channel=daily_channel,
                     ),
                     timeout=PASS_TIMEOUT_S,
                 )
             except asyncio.TimeoutError:
                 logger.error(
                     "reflector_pass_timeout",
+                    channel=channel,
                     timeout_s=PASS_TIMEOUT_S,
                 )
                 continue
@@ -481,6 +611,7 @@ async def run(config: AgentRuntimeConfig) -> None:
                 # listener. Log and keep waiting for the next NOTIFY.
                 logger.error(
                     "reflector_pass_failed",
+                    channel=channel,
                     error_type=type(exc).__name__,
                     error=str(exc)[:300],
                 )
@@ -488,6 +619,8 @@ async def run(config: AgentRuntimeConfig) -> None:
             if reflection is not None:
                 logger.info(
                     "reflector_pass_done",
+                    channel=channel,
+                    tier=reflection.tier,
                     reflection_id=reflection.reflection_id,
                     trace_count=reflection.trace_count,
                 )

--- a/agents/reflector/prompt.py
+++ b/agents/reflector/prompt.py
@@ -20,6 +20,8 @@ from typing import Sequence
 from agent.traces.schema import Trace
 
 PROMPT_VERSION: str = "reflector-daily-v0"
+PROMPT_VERSION_WEEKLY: str = "reflector-weekly-v0"
+PROMPT_VERSION_MONTHLY: str = "reflector-monthly-v0"
 
 SYSTEM_PROMPT: str = (
     "You are Pepper, a sovereign local-first AI life assistant. You are "
@@ -40,6 +42,44 @@ SYSTEM_PROMPT: str = (
     "lightly (continuity), but do not summarise it. Today is the "
     "subject.\n"
     "5. No bullet lists, no headers, no markdown.\n"
+)
+
+SYSTEM_PROMPT_WEEKLY: str = (
+    "You are Pepper. You are writing a private end-of-week reflection "
+    "FOR YOURSELF, looking back across the seven daily reflections "
+    "below. Same voice as the dailies — first-person, no audience.\n\n"
+    "Hard rules for the weekly:\n"
+    "1. First-person voice. Never 'Jack should…', 'recommend…', "
+    "'action items', 'TLDR', 'follow-ups', 'next steps'.\n"
+    "2. IDENTIFY THEMES. Do NOT concatenate or paraphrase the dailies "
+    "in order. Look for what actually recurred across the week — a "
+    "feeling that came back, a pattern in the work, a friction that "
+    "showed up more than once. If nothing recurred, say so honestly.\n"
+    "3. Length: one short paragraph. Three to six sentences. Quiet "
+    "weeks get one sentence and a stop.\n"
+    "4. No bullet lists, no headers, no markdown.\n"
+    "5. If a previous weekly reflection is provided, you may "
+    "reference it lightly (continuity across weeks), but the present "
+    "week is the subject.\n"
+)
+
+SYSTEM_PROMPT_MONTHLY: str = (
+    "You are Pepper. You are writing a private end-of-month reflection "
+    "FOR YOURSELF, looking back across the four (give or take) weekly "
+    "reflections below. Same voice as the dailies and weeklies — "
+    "first-person, no audience.\n\n"
+    "Hard rules for the monthly:\n"
+    "1. First-person voice. Never 'Jack should…', 'recommend…', "
+    "'action items', 'TLDR', 'follow-ups', 'next steps'.\n"
+    "2. IDENTIFY THEMES that held across the month, not week-by-week "
+    "summaries. What changed shape over the month? What faded? What "
+    "showed up new? What stayed exactly the same?\n"
+    "3. Length: one paragraph. Four to seven sentences. The horizon "
+    "is longer than the weekly so a little more length is fine, but "
+    "do not pad.\n"
+    "4. No bullet lists, no headers, no markdown.\n"
+    "5. If a previous monthly reflection is provided, you may "
+    "reference it lightly (continuity across months).\n"
 )
 
 
@@ -126,6 +166,67 @@ def render_user_prompt(
     parts.append(
         "Write your end-of-day reflection now, following the rules in your "
         "system prompt. Plain text, first person, three to six sentences."
+    )
+    return "\n".join(parts)
+
+
+# ── Rollup prompt rendering ──────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class ReflectionDigest:
+    """One child reflection projected to the fields a rollup prompt uses.
+
+    Mirrors `TraceDigest` but for the previous-tier reflections that
+    feed weekly/monthly rollups.
+    """
+
+    date: str  # local-day window_start, "YYYY-MM-DD"
+    text: str
+
+
+def render_rollup_prompt(
+    *,
+    tier_label: str,
+    window_start: datetime,
+    window_end: datetime,
+    children: Sequence[ReflectionDigest],
+    previous_rollup_text: str | None,
+) -> str:
+    """Render the user-side prompt for a weekly or monthly rollup.
+
+    `tier_label` is "week" or "month" — purely a vocabulary hint for
+    the LLM. The system prompt enforces the voice rules; this helper
+    just lays out the inputs.
+    """
+    parts: list[str] = []
+    parts.append(
+        f"{tier_label.capitalize()} window: "
+        f"{window_start.astimezone(timezone.utc).isoformat()} → "
+        f"{window_end.astimezone(timezone.utc).isoformat()}"
+    )
+    parts.append("")
+    if previous_rollup_text:
+        parts.append(f"Previous {tier_label}'s reflection (yours):")
+        parts.append(previous_rollup_text.strip())
+    else:
+        parts.append(f"Previous {tier_label}'s reflection: (none — first one)")
+    parts.append("")
+    if not children:
+        parts.append(
+            f"There are no child reflections in this {tier_label}. "
+            "Acknowledge that in one sentence and stop."
+        )
+    else:
+        parts.append(f"Child reflections ({len(children)}):")
+        for i, c in enumerate(children, start=1):
+            parts.append(f"\n[{i}] {c.date}")
+            parts.append(f"    {c.text.strip()}")
+    parts.append("")
+    parts.append(
+        f"Write your end-of-{tier_label} reflection now. Identify "
+        "themes that recurred — do not concatenate. Plain text, "
+        "first person, follow the length rules in the system prompt."
     )
     return "\n".join(parts)
 

--- a/agents/reflector/rollup.py
+++ b/agents/reflector/rollup.py
@@ -1,0 +1,349 @@
+"""Weekly + monthly rollups (#40).
+
+Hierarchical reflection: weekly summarises the seven daily reflections
+in a local-week window; monthly summarises the weekly reflections in
+a local-month window. Same voice rules and persistence shape as the
+daily reflector (#39); the schema added in #39 already carries the
+`tier`, `parent_reflection_ids`, and `metadata_` columns these need.
+
+Triggers come from APScheduler in core via the same NOTIFY mechanism
+as the daily, but on dedicated channels to keep cadence dispatch
+explicit and to dodge the Sunday 23:55 race the daily already
+occupies:
+
+  - `reflector_weekly_trigger`  — Monday 00:15 local (covers prev week)
+  - `reflector_monthly_trigger` — 1st of month 00:15 local (covers prev month)
+
+The payload is a `YYYY-MM-DD` date in local TZ. For weekly, the
+scheduler sends YESTERDAY's date (the Sunday at the end of the week
+the rollup covers); for monthly, the scheduler sends the 1st of the
+new month and the rollup interprets that as "previous calendar
+month."
+
+Voice rules carry over from #39: the rollup persists the violation
+labels into `metadata_.voice_violations` so #42's eval rubric can
+score the rollup tier without re-running the regex.
+
+PRIVACY: `chat_fn` is injected to keep this module testable; in
+production it MUST come from `agents.reflector.main._make_rollup_adapters`,
+which closes over a boot-validated Ollama URL. Constructing a
+`chat_fn` from any other source would defeat the local-only
+guarantee on RAW_PERSONAL reflection content.
+"""
+from __future__ import annotations
+
+from datetime import date, datetime, time, timedelta, timezone
+from typing import Optional, Sequence
+from zoneinfo import ZoneInfo
+
+import structlog
+
+from agents.reflector import store as rstore
+from agents.reflector.prompt import (
+    PROMPT_VERSION_MONTHLY,
+    PROMPT_VERSION_WEEKLY,
+    SYSTEM_PROMPT_MONTHLY,
+    SYSTEM_PROMPT_WEEKLY,
+    ReflectionDigest,
+    render_rollup_prompt,
+    voice_violations,
+)
+
+logger = structlog.get_logger(__name__)
+
+# Hard cap on rollup text length, mirrors MAX_REFLECTION_TEXT_CHARS
+# in main.py. Defined here to avoid importing main into rollup (which
+# would create a circular import once main imports rollup).
+MAX_ROLLUP_TEXT_CHARS: int = 24_000
+
+# Bound the number of children we feed the LLM. Weekly is bounded by
+# 7; monthly by ~5. We cap at the next-tier worst case so a backfill
+# run does not silently overflow the prompt.
+MAX_CHILDREN_PER_ROLLUP: int = 32
+
+
+# ── Window resolution ────────────────────────────────────────────────────────
+
+
+def weekly_window_for_payload(
+    payload: str, *, tz: ZoneInfo, now: datetime
+) -> tuple[datetime, datetime]:
+    """Resolve the [Mon 00:00, next Mon 00:00) calendar-week window in UTC.
+
+    Trigger fires Monday 00:15 local with `payload =` yesterday's
+    date (the Sunday at the end of the week we roll up). For any
+    `payload` date, we anchor on the Monday of that date's
+    calendar week — i.e. the most recent Monday on or before
+    `parsed` — and walk seven days forward.
+
+    This is the calendar-week answer regardless of which weekday
+    `parsed` is, so a backfill or manual replay with an arbitrary
+    date still produces a Mon..Sun window aligned to that date's
+    own ISO week.
+    """
+    parsed = _parse_payload_date(payload, tz=tz, now=now)
+    monday = parsed - timedelta(days=parsed.weekday())
+    local_start = datetime.combine(monday, time.min, tzinfo=tz)
+    local_end = local_start + timedelta(days=7)
+    return _to_utc_clipped(local_start, local_end, now)
+
+
+def monthly_window_for_payload(
+    payload: str, *, tz: ZoneInfo, now: datetime
+) -> tuple[datetime, datetime]:
+    """Resolve the [first-of-prev-month, first-of-this-month) window in UTC.
+
+    Trigger fires on the 1st of month N+1 with payload = that day's
+    `YYYY-MM-DD`. The month we roll up is month N — i.e. everything
+    strictly before the trigger date. Window is `[first-of-N 00:00
+    local, first-of-(N+1) 00:00 local)` converted to UTC and clipped
+    to `now`.
+    """
+    parsed = _parse_payload_date(payload, tz=tz, now=now)
+    if parsed.day == 1:
+        first_of_this = parsed
+    else:
+        # Defensive fallback: align to the first of `parsed`'s month.
+        first_of_this = parsed.replace(day=1)
+    if first_of_this.month == 1:
+        first_of_prev = first_of_this.replace(year=first_of_this.year - 1, month=12)
+    else:
+        first_of_prev = first_of_this.replace(month=first_of_this.month - 1)
+    local_start = datetime.combine(first_of_prev, time.min, tzinfo=tz)
+    local_end = datetime.combine(first_of_this, time.min, tzinfo=tz)
+    return _to_utc_clipped(local_start, local_end, now)
+
+
+def _parse_payload_date(payload: str, *, tz: ZoneInfo, now: datetime) -> date:
+    """Parse a `YYYY-MM-DD` date; fall back to yesterday in `tz`."""
+    try:
+        return date.fromisoformat(payload.strip())
+    except (ValueError, AttributeError):
+        logger.warning("rollup_payload_unparseable", payload=payload[:64])
+        local_now = now.astimezone(tz)
+        return (local_now - timedelta(days=1)).date()
+
+
+def _to_utc_clipped(
+    local_start: datetime, local_end: datetime, now: datetime
+) -> tuple[datetime, datetime]:
+    window_start = local_start.astimezone(timezone.utc)
+    window_end = min(local_end.astimezone(timezone.utc), now)
+    return window_start, window_end
+
+
+# ── Child digest projection ──────────────────────────────────────────────────
+
+
+def _digest_children(
+    children: Sequence[rstore.Reflection], *, tz: ZoneInfo
+) -> list[ReflectionDigest]:
+    """Project child reflections to (date, text) for the rollup prompt."""
+    digests: list[ReflectionDigest] = []
+    for child in children:
+        local_start = child.window_start.astimezone(tz)
+        digests.append(
+            ReflectionDigest(
+                date=local_start.date().isoformat(),
+                text=child.text,
+            )
+        )
+    return digests
+
+
+# ── Rollup runners ───────────────────────────────────────────────────────────
+
+
+async def _run_rollup(
+    *,
+    tier: str,
+    tier_label: str,
+    system_prompt: str,
+    prompt_version: str,
+    parent_tier: str,
+    window_start: datetime,
+    window_end: datetime,
+    session_factory,
+    chat_fn,
+    embed_fn,
+    chat_model: str,
+    chat_timeout_s: float,
+    embed_timeout_s: float,
+    text_cap: int,
+    tz: ZoneInfo,
+) -> Optional[rstore.Reflection]:
+    """Shared rollup pipeline. Returns the persisted Reflection or None.
+
+    `chat_fn` and `embed_fn` are pluggable so tests can stub them
+    without monkey-patching httpx. They share the shape of the
+    helpers used in `agents.reflector.main`.
+    """
+    async with session_factory() as session:
+        repo = rstore.ReflectionRepository(session)
+        # Children are reflections of the parent tier whose
+        # `window_start` falls inside [window_start, window_end). We
+        # filter on `window_start` (not `created_at`) so a daily that
+        # was backfilled or written late still counts toward its
+        # actual week / month.
+        children = await repo.query_by_window(
+            tier=parent_tier,
+            window_start_gte=window_start,
+            window_start_lt=window_end,
+            limit=MAX_CHILDREN_PER_ROLLUP,
+        )
+        children = list(children)
+        previous = await repo.latest(tier=tier)
+
+    digests = _digest_children(children, tz=tz)
+    user_prompt = render_rollup_prompt(
+        tier_label=tier_label,
+        window_start=window_start,
+        window_end=window_end,
+        children=digests,
+        previous_rollup_text=previous.text if previous is not None else None,
+    )
+
+    logger.info(
+        "rollup_pass_starting",
+        tier=tier,
+        n_children=len(digests),
+        previous_id=previous.reflection_id if previous else None,
+    )
+
+    text, model_used = await chat_fn(
+        system_prompt=system_prompt,
+        user_prompt=user_prompt,
+        model=chat_model,
+        timeout_s=chat_timeout_s,
+    )
+    if not text:
+        logger.warning("rollup_empty_response", tier=tier, n_children=len(digests))
+        return None
+
+    original_len = len(text)
+    if original_len > text_cap:
+        logger.warning(
+            "rollup_text_truncated",
+            tier=tier,
+            original_len=original_len,
+            cap=text_cap,
+        )
+        text = text[: text_cap - 3].rstrip() + "..."
+
+    violations = voice_violations(text)
+    if violations:
+        logger.warning(
+            "rollup_voice_violations", tier=tier, phrases=violations
+        )
+
+    embedding = await embed_fn(
+        text=text,
+        model=rstore.REFLECTION_EMBEDDING_MODEL_DEFAULT,
+        timeout_s=embed_timeout_s,
+    )
+
+    metadata = {
+        "voice_violations": violations,
+        "original_text_len": original_len,
+        "child_count": len(digests),
+        "child_tier": parent_tier,
+    }
+
+    reflection = rstore.Reflection(
+        text=text,
+        window_start=window_start,
+        window_end=window_end,
+        tier=tier,
+        previous_reflection_id=previous.reflection_id if previous else None,
+        parent_reflection_ids=[c.reflection_id for c in children] or None,
+        trace_count=sum(c.trace_count for c in children),
+        model_used=model_used,
+        prompt_version=prompt_version,
+        embedding=embedding,
+        embedding_model_version=(
+            rstore.REFLECTION_EMBEDDING_MODEL_DEFAULT if embedding is not None else None
+        ),
+        metadata_=metadata,
+    )
+
+    async with session_factory() as session:
+        repo = rstore.ReflectionRepository(session)
+        try:
+            await repo.append(reflection)
+        except rstore.DuplicateReflectionError as exc:
+            logger.warning(
+                "rollup_duplicate_skipped",
+                tier=exc.tier,
+                window_start=exc.window_start.isoformat(),
+            )
+            return None
+
+    return reflection
+
+
+async def run_weekly_rollup(
+    *,
+    payload: str,
+    session_factory,
+    chat_fn,
+    embed_fn,
+    chat_model: str,
+    chat_timeout_s: float,
+    embed_timeout_s: float,
+    text_cap: int = MAX_ROLLUP_TEXT_CHARS,
+    tz: ZoneInfo,
+    now: Optional[datetime] = None,
+) -> Optional[rstore.Reflection]:
+    now = now or datetime.now(timezone.utc)
+    window_start, window_end = weekly_window_for_payload(payload, tz=tz, now=now)
+    return await _run_rollup(
+        tier=rstore.TIER_WEEKLY,
+        tier_label="week",
+        system_prompt=SYSTEM_PROMPT_WEEKLY,
+        prompt_version=PROMPT_VERSION_WEEKLY,
+        parent_tier=rstore.TIER_DAILY,
+        window_start=window_start,
+        window_end=window_end,
+        session_factory=session_factory,
+        chat_fn=chat_fn,
+        embed_fn=embed_fn,
+        chat_model=chat_model,
+        chat_timeout_s=chat_timeout_s,
+        embed_timeout_s=embed_timeout_s,
+        text_cap=text_cap,
+        tz=tz,
+    )
+
+
+async def run_monthly_rollup(
+    *,
+    payload: str,
+    session_factory,
+    chat_fn,
+    embed_fn,
+    chat_model: str,
+    chat_timeout_s: float,
+    embed_timeout_s: float,
+    text_cap: int = MAX_ROLLUP_TEXT_CHARS,
+    tz: ZoneInfo,
+    now: Optional[datetime] = None,
+) -> Optional[rstore.Reflection]:
+    now = now or datetime.now(timezone.utc)
+    window_start, window_end = monthly_window_for_payload(payload, tz=tz, now=now)
+    return await _run_rollup(
+        tier=rstore.TIER_MONTHLY,
+        tier_label="month",
+        system_prompt=SYSTEM_PROMPT_MONTHLY,
+        prompt_version=PROMPT_VERSION_MONTHLY,
+        parent_tier=rstore.TIER_WEEKLY,
+        window_start=window_start,
+        window_end=window_end,
+        session_factory=session_factory,
+        chat_fn=chat_fn,
+        embed_fn=embed_fn,
+        chat_model=chat_model,
+        chat_timeout_s=chat_timeout_s,
+        embed_timeout_s=embed_timeout_s,
+        text_cap=text_cap,
+        tz=tz,
+    )

--- a/agents/reflector/store.py
+++ b/agents/reflector/store.py
@@ -273,10 +273,10 @@ def _row_to_reflection(row: ReflectionRow) -> Reflection:
 class ReflectionRepository:
     """Append-only repository for reflections.
 
-    Public surface: `append`, `get_by_id`, `latest`, `query`. No
-    `update_*`, no `delete_*`. The lint test
-    `agent/tests/test_reflections_repository.py` asserts via
-    `hasattr` that disallowed methods do not exist.
+    Public surface: `append`, `get_by_id`, `latest`, `query`,
+    `query_by_window`. No `update_*`, no `delete_*`. The lint test
+    `agent/tests/test_reflector_store.py` asserts via `inspect` that
+    disallowed methods do not exist.
     """
 
     def __init__(self, session: AsyncSession) -> None:
@@ -335,7 +335,13 @@ class ReflectionRepository:
         until: Optional[datetime] = None,
         limit: int = 100,
     ) -> Sequence[Reflection]:
-        """Return reflections matching the filters, newest first."""
+        """Return reflections matching the filters, newest first.
+
+        `since` / `until` filter on `created_at` — i.e. when the row
+        was *written*, not when its window covers. Use
+        `query_by_window` for rollups (which need "reflections whose
+        window starts inside [a, b)").
+        """
         if tier is not None and tier not in _VALID_TIERS:
             raise ValueError(f"unknown tier {tier!r}")
         limit = max(1, min(limit, MAX_QUERY_LIMIT))
@@ -352,6 +358,42 @@ class ReflectionRepository:
         if until is not None:
             stmt = stmt.where(ReflectionRow.created_at <= until)
 
+        result = await self._session.execute(stmt)
+        rows = result.scalars().all()
+        return [_row_to_reflection(r) for r in rows]
+
+    async def query_by_window(
+        self,
+        *,
+        tier: str,
+        window_start_gte: datetime,
+        window_start_lt: datetime,
+        limit: int = 100,
+    ) -> Sequence[Reflection]:
+        """Return reflections whose `window_start` is in `[gte, lt)`.
+
+        Required by #40's rollups: the weekly rollup needs the seven
+        dailies that COVER Mon..Sun, even if one of them was written
+        late (backfill, retry after a crash, etc.). Filtering on
+        `created_at` would silently drop those rows.
+
+        `tier` is required: rollups always look at exactly one
+        previous-tier set (daily-for-weekly, weekly-for-monthly). Sort
+        is ascending on `window_start` so callers consume children in
+        chronological order without re-sorting.
+        """
+        if tier not in _VALID_TIERS:
+            raise ValueError(f"unknown tier {tier!r}")
+        limit = max(1, min(limit, MAX_QUERY_LIMIT))
+
+        stmt = (
+            select(ReflectionRow)
+            .where(ReflectionRow.tier == tier)
+            .where(ReflectionRow.window_start >= window_start_gte)
+            .where(ReflectionRow.window_start < window_start_lt)
+            .order_by(ReflectionRow.window_start.asc())
+            .limit(limit)
+        )
         result = await self._session.execute(stmt)
         rows = result.scalars().all()
         return [_row_to_reflection(r) for r in rows]


### PR DESCRIPTION
## Summary

- Hierarchical reflection per Generative Agents (Park et al, 2304.03442): weekly summarises 7 dailies, monthly summarises ~4 weeklies. Same voice and persistence shape as #39; the schema in #39 already carried `tier`, `parent_reflection_ids`, and `metadata_` — no migration needed.
- Two new APScheduler cron jobs in `agent/scheduler.py` fire `reflector_weekly_trigger` (Monday 00:15 local) and `reflector_monthly_trigger` (1st of month 00:15 local) on dedicated channels. The reflector LISTENs on all three.

## What's in here

- **`agents/reflector/rollup.py`** — `run_weekly_rollup` / `run_monthly_rollup` share a common pipeline that reads previous-tier children within the window, prompts for THEMES (not concatenation), embeds the result, and persists with `parent_reflection_ids` linking the hierarchy.
- **`agents/reflector/store.py`** — `query_by_window` filters on `window_start` rather than `created_at` so a daily that was backfilled or written late still counts toward its actual week / month. Public surface is now 5 methods (`append`, `get_by_id`, `latest`, `query`, `query_by_window`); the no-mutation test asserts the exact list.
- **`agents/reflector/listener.py`** — multi-channel listener: signature `channel:str` → `channels:Iterable[str]`, yields `(channel, payload)` tuples through one asyncpg connection.
- **`agents/reflector/main.py`** — channel-based dispatch (daily → `_run_one_reflection`, weekly/monthly → rollup runners). New boot-time refusal when the env-tunable daily channel collides with `WEEKLY_CHANNEL` or `MONTHLY_CHANNEL`. `PASS_TIMEOUT_S` raised from 300s → 420s so the monthly's chat (240s) + embed (120s) + headroom fits inside the outer cap.
- **`agent/scheduler.py`** — `_fire_reflector_notify` factored from the existing daily method; two new fire methods. The weekly fires Monday 00:15 with payload = yesterday's date (the Sunday) so the rollup window calculation lines up cleanly; the monthly fires day-1 00:15 with payload = today's date.

## Race-fix from review (#40 critical finding)

The first cut of #40 had the weekly fire Sunday 23:55 in the same minute as the daily — same-channel-listener serialises NOTIFYs, but **order is arbitrary**. If the weekly dequeued first, Sunday's daily wasn't written yet and the rollup would include only Mon-Sat. Fix: weekly is now Monday 00:15, monthly is day-1 00:15, well after the prior daily has landed.

The companion fix is the `created_at` → `window_start` filter switch (`query_by_window`): even with the timing fix, a backfilled or retried daily is now correctly counted toward its actual week/month, not the day it happened to land in the DB.

## Acceptance criteria from #40

- [x] `agents/reflector/rollup.py` with `WeeklyRollup` and `MonthlyRollup`-equivalent runners.
- [x] `WeeklyRollup.run`: reads 7 daily reflections in window, writes 1 weekly reflection. Triggered Monday night (00:15 local) via the same NOTIFY mechanism.
- [x] `MonthlyRollup.run`: reads weekly reflections, writes 1 monthly. Triggered first day of month (00:15 local).
- [x] `tier` and `parent_reflection_ids` link the hierarchy (already in #39's schema).
- [x] Rollup prompts emphasise themes, not concatenation (`SYSTEM_PROMPT_WEEKLY` / `SYSTEM_PROMPT_MONTHLY` rule 2).
- [x] First-person, to-herself framing (voice rules carry over from #39; violations recorded in `metadata_.voice_violations`).

## Test plan

- [x] **Unit (window math):** weekly + monthly window resolution from a payload date in UTC and West Coast TZ; year-boundary wraps Jan→Dec/prev-year; non-Sunday weekly payload aligns to ISO calendar week.
- [x] **Unit (pipeline):** 7 dailies → 1 weekly with `parent_reflection_ids` linked; 4 weeklies → 1 monthly; quiet-period (zero children) produces a 'quiet week' reflection rather than an error; empty LLM response → skipped (returns None); duplicate-window collision → logged + skipped.
- [x] **Boot validation:** daily `notify_channel` colliding with rollup channel raises `ReflectorConfigError` before any LISTEN.
- [x] **Scheduler:** weekly + monthly fire methods NOTIFY the documented channels with signal-only date payloads; channel constants are pinned in tests so a rename forces both sides to move together.
- [x] `pytest agent/tests/test_reflector_*.py agent/tests/test_scheduler_trace_emission.py` — 109 passing.
- [x] `ruff check` — clean.
- [ ] Live end-to-end Sunday/Monday rollup — operator action after merge, when the next Sunday rolls around.

## Notes for downstream subissues

- **#41 (pattern detector):** `metadata_` jsonb is already the agreed extension point; rollups currently populate `voice_violations`, `original_text_len`, `child_count`, `child_tier`. #41 can attach `cluster_ids` / `alert_ids` without a migration.
- **#42 (eval rubric):** prompt-version constants are tier-distinct (`reflector-daily-v0`, `reflector-weekly-v0`, `reflector-monthly-v0`) so the scoring tool can group by tier.

Closes #40.