### PR TITLE
agents/reflector: pattern detector + alerts UI (#41)

### DIFF
--- a/agent/main.py
+++ b/agent/main.py
@@ -82,6 +82,16 @@ from agent.memory_http import router as _memories_router  # noqa: E402
 
 app.include_router(_memories_router, prefix="/api")
 
+# Epic 04 (#41) — /reflector/alerts list + dismiss/file routes for the
+# pattern-detector UI panel. Same auth + localhost-bind posture; the
+# router lives under agents/reflector/ but is mounted by core because
+# core owns the FastAPI app. (Per ADR-0004, agents/ may not import
+# from agent.core.py or subsystems/, but core mounting an agent's
+# router does not violate that — the dependency points the right way.)
+from agents.reflector.http import router as _reflector_router  # noqa: E402
+
+app.include_router(_reflector_router, prefix="/api")
+
 
 class ChatRequest(BaseModel):
     message: str

--- a/agent/tests/test_reflector_alerts.py
+++ b/agent/tests/test_reflector_alerts.py
@@ -1,0 +1,104 @@
+"""Unit tests for `agents.reflector.alerts` — surface + dataclass guards."""
+from __future__ import annotations
+
+import inspect
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from agents.reflector.alerts import (
+    STATUS_DISMISSED,
+    STATUS_FILED,
+    STATUS_OPEN,
+    PatternAlert,
+    PatternAlertRepository,
+)
+
+
+class TestNoMutationSurface:
+    forbidden_prefixes = ("update", "delete", "purge", "drop", "truncate", "remove")
+
+    def test_no_method_with_forbidden_prefix(self) -> None:
+        members = inspect.getmembers(
+            PatternAlertRepository, predicate=inspect.isfunction
+        )
+        bad = [
+            name
+            for name, _ in members
+            if any(name.startswith(p) for p in self.forbidden_prefixes)
+            and not name.startswith("_")
+        ]
+        assert bad == [], f"forbidden mutation methods: {bad}"
+
+    def test_only_documented_public_methods(self) -> None:
+        public = sorted(
+            name
+            for name, _ in inspect.getmembers(
+                PatternAlertRepository, predicate=inspect.isfunction
+            )
+            if not name.startswith("_")
+        )
+        assert public == [
+            "append",
+            "get_by_id",
+            "list_by_status",
+            "list_open",
+            "set_status",
+        ]
+
+
+class TestPatternAlertGuards:
+    def _make(self, **overrides) -> PatternAlert:
+        now = datetime.now(timezone.utc)
+        defaults = dict(
+            trace_ids=["00000000-0000-0000-0000-000000000001"],
+            cluster_size=1,
+            window_start=now - timedelta(hours=24),
+            window_end=now,
+        )
+        defaults.update(overrides)
+        return PatternAlert(**defaults)
+
+    def test_default_status_is_open(self) -> None:
+        a = self._make()
+        assert a.status == STATUS_OPEN
+
+    @pytest.mark.parametrize("status", [STATUS_OPEN, STATUS_DISMISSED, STATUS_FILED])
+    def test_known_statuses_accepted(self, status: str) -> None:
+        a = self._make(status=status)
+        assert a.status == status
+
+    def test_unknown_status_rejected(self) -> None:
+        with pytest.raises(ValueError, match="status"):
+            self._make(status="archived")
+
+    def test_cluster_size_must_match_trace_ids(self) -> None:
+        with pytest.raises(ValueError, match="cluster_size"):
+            self._make(
+                trace_ids=["a", "b", "c"],
+                cluster_size=2,
+            )
+
+    def test_cluster_size_must_be_positive(self) -> None:
+        with pytest.raises(ValueError, match=">= 1"):
+            self._make(trace_ids=[], cluster_size=0)
+
+    @pytest.mark.parametrize("conf", [-0.1, 1.1, 2.0, -10.0])
+    def test_confidence_must_be_in_unit_interval(self, conf: float) -> None:
+        with pytest.raises(ValueError, match="confidence"):
+            self._make(confidence=conf)
+
+    def test_inverted_window_rejected(self) -> None:
+        now = datetime.now(timezone.utc)
+        with pytest.raises(ValueError, match="window_end"):
+            PatternAlert(
+                trace_ids=["a"],
+                cluster_size=1,
+                window_start=now,
+                window_end=now - timedelta(hours=1),
+            )
+
+    def test_frozen_alert_cannot_mutate(self) -> None:
+        a = self._make()
+        with pytest.raises(Exception):  # FrozenInstanceError
+            a.status = STATUS_DISMISSED  # type: ignore[misc]

--- a/agent/tests/test_reflector_pattern_detector.py
+++ b/agent/tests/test_reflector_pattern_detector.py
@@ -1,0 +1,288 @@
+"""Unit tests for `agents.reflector.pattern_detector`.
+
+The clustering math + low-quality filter are pure functions over the
+`Trace` dataclass, so they test directly without mocks. The
+`detect_patterns` entrypoint stubs the trace + alert repositories.
+"""
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from datetime import datetime, timezone
+from typing import Optional, Sequence
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from agent.error_classifier import DataSensitivity
+from agent.traces.schema import Archetype, Trace, TriggerSource
+from agents.reflector import alerts as ralerts
+from agents.reflector import pattern_detector as pd
+
+
+# ── Helpers ─────────────────────────────────────────────────────────────────
+
+
+_DIM = 1024
+
+
+def _emb(seed: int) -> list[float]:
+    """Deterministic 1024-dim unit-ish vector keyed on a seed.
+
+    Different seeds produce orthogonal-ish vectors; same seed
+    produces identical vectors. Lets tests build clusters without
+    needing a real embedder.
+    """
+    import random
+
+    rng = random.Random(seed)
+    return [rng.uniform(-1, 1) for _ in range(_DIM)]
+
+
+def _trace(
+    *,
+    seed: int,
+    user_reaction: Optional[dict] = None,
+    archetype: Archetype = Archetype.ORCHESTRATOR,
+    trigger_source: TriggerSource = TriggerSource.USER,
+    embedding: Optional[list[float]] = None,
+) -> Trace:
+    chosen_embedding = embedding if embedding is not None else _emb(seed)
+    return Trace(
+        trigger_source=trigger_source,
+        archetype=archetype,
+        input=f"in {seed}",
+        output=f"out {seed}",
+        data_sensitivity=DataSensitivity.LOCAL_ONLY,
+        embedding=chosen_embedding if chosen_embedding else None,
+        embedding_model_version=(
+            "qwen3-embedding:0.6b" if chosen_embedding else None
+        ),
+        user_reaction=user_reaction,
+    )
+
+
+# ── Cosine math ──────────────────────────────────────────────────────────────
+
+
+class TestCosineMath:
+    def test_identical_vectors(self) -> None:
+        v = [1.0, 2.0, 3.0]
+        assert pd._cosine(v, v) == pytest.approx(1.0)
+
+    def test_orthogonal_vectors(self) -> None:
+        a = [1.0, 0.0]
+        b = [0.0, 1.0]
+        assert pd._cosine(a, b) == pytest.approx(0.0)
+
+    def test_opposite_vectors(self) -> None:
+        a = [1.0, 0.0]
+        b = [-1.0, 0.0]
+        assert pd._cosine(a, b) == pytest.approx(-1.0)
+
+    @pytest.mark.parametrize("inputs", [([], [1.0]), ([1.0], []), ([1.0, 2.0], [1.0])])
+    def test_degenerate_inputs_return_zero(
+        self, inputs: tuple[list[float], list[float]]
+    ) -> None:
+        a, b = inputs
+        assert pd._cosine(a, b) == 0.0
+
+    def test_zero_norm_vector_returns_zero(self) -> None:
+        assert pd._cosine([0.0, 0.0], [1.0, 1.0]) == 0.0
+
+
+# ── Low-quality filter ──────────────────────────────────────────────────────
+
+
+class TestLowQualityFilter:
+    """Per `docs/trace-schema.md`, `thumbs` is numeric (-1/0/+1) and
+    `followup_correction` is boolean. The filter must read both
+    correctly."""
+
+    def test_thumbs_down_negative_is_low_quality(self) -> None:
+        t = _trace(seed=1, user_reaction={"thumbs": -1})
+        assert pd._is_low_quality(t)
+
+    def test_thumbs_up_positive_is_not_low_quality(self) -> None:
+        t = _trace(seed=1, user_reaction={"thumbs": 1})
+        assert not pd._is_low_quality(t)
+
+    def test_thumbs_zero_is_not_low_quality(self) -> None:
+        t = _trace(seed=1, user_reaction={"thumbs": 0})
+        assert not pd._is_low_quality(t)
+
+    def test_followup_correction_true_is_low_quality(self) -> None:
+        t = _trace(seed=1, user_reaction={"followup_correction": True})
+        assert pd._is_low_quality(t)
+
+    def test_followup_correction_false_is_not_low_quality(self) -> None:
+        t = _trace(seed=1, user_reaction={"followup_correction": False})
+        assert not pd._is_low_quality(t)
+
+    def test_no_reaction_is_not_low_quality(self) -> None:
+        t = _trace(seed=1, user_reaction=None)
+        assert not pd._is_low_quality(t)
+
+    def test_empty_reaction_is_not_low_quality(self) -> None:
+        t = _trace(seed=1, user_reaction={})
+        assert not pd._is_low_quality(t)
+
+
+# ── Clustering ──────────────────────────────────────────────────────────────
+
+
+class TestClusterTraces:
+    def test_identical_embeddings_cluster_together(self) -> None:
+        v = _emb(7)
+        traces = [_trace(seed=i, embedding=v) for i in range(5)]
+        clusters = pd.cluster_traces(traces, similarity_threshold=0.99)
+        assert len(clusters) == 1
+        assert len(clusters[0].members) == 5
+
+    def test_distinct_seeds_split_into_separate_clusters(self) -> None:
+        # With high seeds and a high threshold, random vectors do not
+        # cluster together. Exact cluster count is implementation-
+        # dependent on the rng draw, but it MUST be > 1.
+        traces = [_trace(seed=10 + i) for i in range(10)]
+        clusters = pd.cluster_traces(traces, similarity_threshold=0.95)
+        assert len(clusters) > 1
+
+    def test_traces_without_embedding_are_skipped(self) -> None:
+        traces = [
+            _trace(seed=1, embedding=[]),  # empty embedding → skipped
+            _trace(seed=2, embedding=[]),
+        ]
+        clusters = pd.cluster_traces(traces, similarity_threshold=0.5)
+        assert clusters == []
+
+    def test_low_threshold_collapses_everything(self) -> None:
+        # Any positive cosine clears threshold=-1.0, so all traces
+        # land in the first cluster regardless of similarity.
+        traces = [_trace(seed=20 + i) for i in range(6)]
+        clusters = pd.cluster_traces(traces, similarity_threshold=-1.0)
+        assert len(clusters) == 1
+        assert len(clusters[0].members) == 6
+
+
+# ── Cluster summarisers ────────────────────────────────────────────────────
+
+
+class TestSummariseCluster:
+    def test_summary_does_not_leak_trace_text(self) -> None:
+        v = _emb(99)
+        traces = [
+            _trace(seed=99, embedding=v, user_reaction={"thumbs": -1})
+            for _ in range(3)
+        ]
+        cluster = pd._Cluster(members=traces, centroid=v)
+        s = pd._summarise_cluster(cluster)
+        # The summary names archetype, trigger, reaction counts —
+        # but never the trace input/output. The trace inspector is
+        # the place to read content.
+        assert "in 99" not in s
+        assert "out 99" not in s
+        assert "Cluster of 3" in s
+        assert "thumbs-down" in s
+
+    def test_confidence_is_in_unit_interval(self) -> None:
+        v = _emb(50)
+        traces = [_trace(seed=50, embedding=v) for _ in range(4)]
+        cluster = pd._Cluster(members=traces, centroid=v)
+        c = pd._confidence(cluster)
+        assert 0.0 <= c <= 1.0
+
+
+# ── Entrypoint ──────────────────────────────────────────────────────────────
+
+
+def _factory_with(
+    *,
+    candidates: Sequence[Trace],
+    sink: list[ralerts.PatternAlert],
+):
+    """Build an async-context-managed session-factory stub.
+
+    Patches the trace + alert repositories so the real DB never
+    touches. Anything passed in `candidates` is returned by the
+    trace query; `sink` collects appended alerts.
+    """
+
+    @asynccontextmanager
+    async def _factory():
+        with (
+            patch("agents.reflector.pattern_detector.TraceRepository") as TR,
+            patch.object(ralerts, "PatternAlertRepository") as AR,
+        ):
+            tr = MagicMock()
+            tr.query = AsyncMock(return_value=list(candidates))
+            TR.return_value = tr
+
+            ar = MagicMock()
+
+            async def _append(alert):
+                sink.append(alert)
+                return alert
+
+            ar.append = AsyncMock(side_effect=_append)
+            AR.return_value = ar
+            yield None
+
+    return _factory
+
+
+@pytest.mark.asyncio
+class TestDetectPatternsEntrypoint:
+    async def test_no_low_quality_traces_files_no_alerts(self) -> None:
+        candidates = [_trace(seed=i, user_reaction={"thumbs": 1}) for i in range(5)]
+        sink: list[ralerts.PatternAlert] = []
+        factory = _factory_with(candidates=candidates, sink=sink)
+
+        out = await pd.detect_patterns(
+            window_start=datetime(2026, 5, 1, tzinfo=timezone.utc),
+            window_end=datetime(2026, 5, 2, tzinfo=timezone.utc),
+            session_factory=factory,
+        )
+        assert out == []
+        assert sink == []
+
+    async def test_three_thumbs_down_at_same_embedding_files_one_alert(self) -> None:
+        v = _emb(123)
+        candidates = [
+            _trace(seed=123, embedding=v, user_reaction={"thumbs": -1})
+            for _ in range(3)
+        ]
+        sink: list[ralerts.PatternAlert] = []
+        factory = _factory_with(candidates=candidates, sink=sink)
+
+        out = await pd.detect_patterns(
+            window_start=datetime(2026, 5, 1, tzinfo=timezone.utc),
+            window_end=datetime(2026, 5, 2, tzinfo=timezone.utc),
+            session_factory=factory,
+            similarity_threshold=0.99,
+        )
+        assert len(out) == 1
+        assert len(sink) == 1
+        assert sink[0].cluster_size == 3
+        assert sink[0].status == ralerts.STATUS_OPEN
+        # Trace IDs are recorded so the operator can drill in via
+        # the existing #34 trace inspector.
+        assert len(sink[0].trace_ids) == 3
+
+    async def test_clusters_below_min_size_are_not_filed(self) -> None:
+        v = _emb(7)
+        # Only 2 thumbs-down at the same embedding — below
+        # MIN_CLUSTER_SIZE=3.
+        candidates = [
+            _trace(seed=7, embedding=v, user_reaction={"thumbs": -1})
+            for _ in range(2)
+        ]
+        sink: list[ralerts.PatternAlert] = []
+        factory = _factory_with(candidates=candidates, sink=sink)
+
+        out = await pd.detect_patterns(
+            window_start=datetime(2026, 5, 1, tzinfo=timezone.utc),
+            window_end=datetime(2026, 5, 2, tzinfo=timezone.utc),
+            session_factory=factory,
+            similarity_threshold=0.99,
+        )
+        assert out == []
+        assert sink == []

--- a/agent/traces/repository.py
+++ b/agent/traces/repository.py
@@ -234,9 +234,17 @@ class TraceRepository:
             )
 
         if with_payload:
+            # Undefer ALL three deferred columns (assembled_context,
+            # tools_called, embedding). The docstring promises "the
+            # full row"; previously embedding was left deferred,
+            # which made `_row_to_trace`'s `r.embedding` access
+            # implicitly lazy-load and fail in async context.
+            # Discovered via #41's pattern detector consuming the
+            # vector outside the session block.
             stmt = stmt.options(
                 undefer(TraceRow.assembled_context),
                 undefer(TraceRow.tools_called),
+                undefer(TraceRow.embedding),
             )
             result = await self._session.execute(stmt)
             rows = result.scalars().all()

--- a/agents/reflector/alerts.py
+++ b/agents/reflector/alerts.py
@@ -1,0 +1,246 @@
+"""Persistence layer for `pattern_alerts` (#41).
+
+Stores cluster summaries the pattern detector surfaces after each
+nightly reflection. Each alert is a small piece of *operator-
+reviewable* output: trace_ids that triggered the cluster, the size
+and confidence, an optional LLM-or-detector-generated summary, and
+the operator's chosen status.
+
+Append-only at the application layer. The carve-out is a status
+update — operators can mark an alert as `dismissed` or `filed`
+(they took action on it). Update is the only post-insert mutation
+the repository exposes; everything else is write-once.
+
+The status update path mirrors the trace store's `set_user_reaction`
+carve-out from ADR-0005 — narrow, named, no generic update method.
+"""
+from __future__ import annotations
+
+import uuid as _uuid
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Optional
+
+import structlog
+from sqlalchemy import Float, Index, Integer, String, Text, select
+from sqlalchemy.dialects.postgresql import ARRAY, JSONB, UUID
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import Mapped, mapped_column
+
+from agent.db import Base
+
+logger = structlog.get_logger(__name__)
+
+STATUS_OPEN: str = "open"
+STATUS_DISMISSED: str = "dismissed"
+STATUS_FILED: str = "filed"
+
+_VALID_STATUSES: frozenset[str] = frozenset({STATUS_OPEN, STATUS_DISMISSED, STATUS_FILED})
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _new_alert_id() -> str:
+    return str(_uuid.uuid4())
+
+
+# ── Dataclass contract ───────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class PatternAlert:
+    """One persisted alert. Frozen — once constructed, only the
+    `status` column may change via the repository's status carve-out."""
+
+    trace_ids: list[str]
+    cluster_size: int
+    window_start: datetime
+    window_end: datetime
+    alert_id: str = field(default_factory=_new_alert_id)
+    created_at: datetime = field(default_factory=_utcnow)
+    confidence: float = 0.0
+    summary: str = ""
+    suggested_action: str = ""
+    status: str = STATUS_OPEN
+    metadata_: dict = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if self.status not in _VALID_STATUSES:
+            raise ValueError(
+                f"alert status must be one of {sorted(_VALID_STATUSES)}, "
+                f"got {self.status!r}"
+            )
+        if self.cluster_size != len(self.trace_ids):
+            raise ValueError(
+                f"cluster_size {self.cluster_size} does not match "
+                f"len(trace_ids) {len(self.trace_ids)}"
+            )
+        if self.cluster_size < 1:
+            raise ValueError("cluster_size must be >= 1")
+        if not (0.0 <= self.confidence <= 1.0):
+            raise ValueError(
+                f"confidence must be in [0.0, 1.0], got {self.confidence!r}"
+            )
+        if self.window_end < self.window_start:
+            raise ValueError("window_end is before window_start")
+
+
+# ── ORM mapping ──────────────────────────────────────────────────────────────
+
+
+class PatternAlertRow(Base):
+    """Storage projection for `PatternAlert`."""
+
+    __tablename__ = "pattern_alerts"
+
+    alert_id: Mapped[_uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        default=_uuid.uuid4,
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        nullable=False,
+    )
+    window_start: Mapped[datetime] = mapped_column(nullable=False)
+    window_end: Mapped[datetime] = mapped_column(nullable=False)
+    trace_ids: Mapped[list[_uuid.UUID]] = mapped_column(
+        ARRAY(UUID(as_uuid=True)),
+        nullable=False,
+    )
+    cluster_size: Mapped[int] = mapped_column(Integer, nullable=False)
+    confidence: Mapped[float] = mapped_column(Float, nullable=False, default=0.0)
+    summary: Mapped[str] = mapped_column(Text, nullable=False, default="")
+    suggested_action: Mapped[str] = mapped_column(Text, nullable=False, default="")
+    status: Mapped[str] = mapped_column(
+        String(16),
+        nullable=False,
+        default=STATUS_OPEN,
+    )
+    metadata_: Mapped[dict] = mapped_column(
+        "metadata",
+        JSONB,
+        nullable=False,
+        default=dict,
+    )
+
+    __table_args__ = (
+        Index("idx_pattern_alerts_created_at", "created_at"),
+        Index("idx_pattern_alerts_status", "status"),
+        Index("idx_pattern_alerts_window", "window_start", "window_end"),
+    )
+
+
+# ── Mapping helpers ──────────────────────────────────────────────────────────
+
+
+def _to_row(a: PatternAlert) -> PatternAlertRow:
+    return PatternAlertRow(
+        alert_id=_uuid.UUID(a.alert_id),
+        created_at=a.created_at,
+        window_start=a.window_start,
+        window_end=a.window_end,
+        trace_ids=[_uuid.UUID(t) for t in a.trace_ids],
+        cluster_size=a.cluster_size,
+        confidence=a.confidence,
+        summary=a.summary,
+        suggested_action=a.suggested_action,
+        status=a.status,
+        metadata_=dict(a.metadata_),
+    )
+
+
+def _from_row(row: PatternAlertRow) -> PatternAlert:
+    return PatternAlert(
+        alert_id=str(row.alert_id),
+        created_at=row.created_at,
+        window_start=row.window_start,
+        window_end=row.window_end,
+        trace_ids=[str(t) for t in row.trace_ids],
+        cluster_size=row.cluster_size,
+        confidence=row.confidence,
+        summary=row.summary,
+        suggested_action=row.suggested_action,
+        status=row.status,
+        metadata_=dict(row.metadata_ or {}),
+    )
+
+
+# ── Repository ───────────────────────────────────────────────────────────────
+
+
+class PatternAlertRepository:
+    """Append-only with one carve-out: `set_status` flips an alert
+    between `open / dismissed / filed`. No generic `update_*`,
+    no `delete_*`. The lint test asserts the public surface."""
+
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+
+    async def append(self, alert: PatternAlert) -> PatternAlert:
+        row = _to_row(alert)
+        self._session.add(row)
+        await self._session.flush()
+        await self._session.commit()
+        logger.info(
+            "pattern_alert_appended",
+            alert_id=alert.alert_id,
+            cluster_size=alert.cluster_size,
+        )
+        return alert
+
+    async def get_by_id(self, alert_id: str) -> Optional[PatternAlert]:
+        stmt = select(PatternAlertRow).where(
+            PatternAlertRow.alert_id == _uuid.UUID(alert_id),
+        )
+        result = await self._session.execute(stmt)
+        row = result.scalar_one_or_none()
+        return _from_row(row) if row is not None else None
+
+    async def list_open(self, limit: int = 100) -> Sequence[PatternAlert]:
+        """Return open alerts, newest first. UI default view."""
+        return await self._list_with_status(STATUS_OPEN, limit=limit)
+
+    async def list_by_status(
+        self, status: str, limit: int = 100
+    ) -> Sequence[PatternAlert]:
+        if status not in _VALID_STATUSES:
+            raise ValueError(f"unknown status {status!r}")
+        return await self._list_with_status(status, limit=limit)
+
+    async def _list_with_status(
+        self, status: str, *, limit: int
+    ) -> Sequence[PatternAlert]:
+        limit = max(1, min(limit, 1000))
+        stmt = (
+            select(PatternAlertRow)
+            .where(PatternAlertRow.status == status)
+            .order_by(PatternAlertRow.created_at.desc())
+            .limit(limit)
+        )
+        result = await self._session.execute(stmt)
+        rows = result.scalars().all()
+        return [_from_row(r) for r in rows]
+
+    async def set_status(self, alert_id: str, status: str) -> bool:
+        """Flip an alert's status. Returns True if an alert moved.
+
+        The single named-mutation surface — there is no generic
+        `update`. New statuses are added by extending `_VALID_STATUSES`
+        + this method, not by exposing arbitrary writes.
+        """
+        if status not in _VALID_STATUSES:
+            raise ValueError(f"unknown status {status!r}")
+        stmt = select(PatternAlertRow).where(
+            PatternAlertRow.alert_id == _uuid.UUID(alert_id),
+        )
+        result = await self._session.execute(stmt)
+        row = result.scalar_one_or_none()
+        if row is None:
+            return False
+        row.status = status
+        await self._session.commit()
+        logger.info("pattern_alert_status_changed", alert_id=alert_id, status=status)
+        return True

--- a/agents/reflector/http.py
+++ b/agents/reflector/http.py
@@ -1,0 +1,191 @@
+"""FastAPI router for the reflector's pattern alerts (#41).
+
+Exposes:
+
+- `GET  /api/reflector/alerts`               — list alerts (filter by status)
+- `POST /api/reflector/alerts/{id}/dismiss`  — operator dismisses an alert
+- `POST /api/reflector/alerts/{id}/file`     — operator marks an alert as filed
+
+Privacy posture mirrors `agent/traces/http.py`:
+
+1. **API-key required** via `require_api_key`.
+2. **Localhost bind by default** when `PEPPER_BIND_LOCALHOST_ONLY` is
+   true. Alerts surface trace_ids and a one-line detector-generated
+   summary; they do NOT carry raw trace text. Even so, "which turns
+   are on the failure-mode list" is information that should not leave
+   the box without explicit operator opt-in.
+3. **No DELETE.** Status flips are the only mutation; the audit
+   trail (created_at + the existing structlog line on every status
+   change) is the recoverable record.
+"""
+from __future__ import annotations
+
+import ipaddress
+from typing import Optional
+
+import structlog
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from pydantic import BaseModel, Field
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from agent.auth import require_api_key
+from agent.db import get_db
+from agents.reflector import alerts as ralerts
+
+logger = structlog.get_logger(__name__)
+
+router = APIRouter(prefix="/reflector", tags=["reflector"])
+
+
+# ── Localhost guard ──────────────────────────────────────────────────────────
+
+
+def _client_is_loopback(request: Request) -> bool:
+    host = request.client.host if request.client else ""
+    if not host:
+        return False
+    if host in {"localhost"} or host.startswith("127."):
+        return True
+    try:
+        return ipaddress.ip_address(host).is_loopback
+    except ValueError:
+        return False
+
+
+async def _enforce_localhost_bind(request: Request) -> None:
+    from agent.config import settings
+
+    bind_localhost = getattr(settings, "PEPPER_BIND_LOCALHOST_ONLY", True)
+    if bind_localhost and not _client_is_loopback(request):
+        host = request.client.host if request.client else "<unknown>"
+        logger.warning(
+            "reflector_alerts_non_loopback_denied",
+            client_host=host,
+            path=str(request.url.path),
+        )
+        raise HTTPException(
+            status_code=403,
+            detail=(
+                "/api/reflector is bound to localhost. Set "
+                "PEPPER_BIND_LOCALHOST_ONLY=false AND wire session-level "
+                "auth before exposing externally."
+            ),
+        )
+
+
+# ── Response models ──────────────────────────────────────────────────────────
+
+
+class AlertOut(BaseModel):
+    alert_id: str
+    created_at: str
+    window_start: str
+    window_end: str
+    trace_ids: list[str]
+    cluster_size: int
+    confidence: float
+    summary: str
+    suggested_action: str
+    status: str
+    metadata: dict = Field(default_factory=dict)
+
+
+class AlertListResponse(BaseModel):
+    alerts: list[AlertOut]
+
+
+class StatusUpdateResponse(BaseModel):
+    ok: bool
+    alert_id: str
+    status: str
+
+
+def _to_out(alert: ralerts.PatternAlert) -> AlertOut:
+    return AlertOut(
+        alert_id=alert.alert_id,
+        created_at=alert.created_at.isoformat(),
+        window_start=alert.window_start.isoformat(),
+        window_end=alert.window_end.isoformat(),
+        trace_ids=alert.trace_ids,
+        cluster_size=alert.cluster_size,
+        confidence=alert.confidence,
+        summary=alert.summary,
+        suggested_action=alert.suggested_action,
+        status=alert.status,
+        metadata=alert.metadata_,
+    )
+
+
+# ── Routes ───────────────────────────────────────────────────────────────────
+
+
+@router.get("/alerts", response_model=AlertListResponse)
+async def list_alerts(
+    request: Request,
+    status: Optional[str] = Query(
+        default="open",
+        description=(
+            "Filter by status. One of `open`, `dismissed`, `filed`, or "
+            "`all` (returns the most recent across statuses)."
+        ),
+    ),
+    limit: int = Query(default=100, ge=1, le=1000),
+    db: AsyncSession = Depends(get_db),
+    _key_hash: str = Depends(require_api_key),
+) -> AlertListResponse:
+    await _enforce_localhost_bind(request)
+
+    repo = ralerts.PatternAlertRepository(db)
+    if status == "all":
+        # Stitch a small union — list_open + list_by_status calls are
+        # cheap and we cap at `limit` total. Newest-first across all
+        # buckets.
+        rows = []
+        for s in (ralerts.STATUS_OPEN, ralerts.STATUS_FILED, ralerts.STATUS_DISMISSED):
+            rows.extend(await repo.list_by_status(s, limit=limit))
+        rows.sort(key=lambda a: a.created_at, reverse=True)
+        rows = rows[:limit]
+    elif status in {ralerts.STATUS_OPEN, ralerts.STATUS_DISMISSED, ralerts.STATUS_FILED}:
+        rows = list(await repo.list_by_status(status, limit=limit))
+    else:
+        raise HTTPException(
+            status_code=400,
+            detail=f"unknown status filter {status!r}",
+        )
+
+    return AlertListResponse(alerts=[_to_out(r) for r in rows])
+
+
+@router.post("/alerts/{alert_id}/dismiss", response_model=StatusUpdateResponse)
+async def dismiss_alert(
+    alert_id: str,
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+    _key_hash: str = Depends(require_api_key),
+) -> StatusUpdateResponse:
+    await _enforce_localhost_bind(request)
+    return await _set_status(alert_id, ralerts.STATUS_DISMISSED, db)
+
+
+@router.post("/alerts/{alert_id}/file", response_model=StatusUpdateResponse)
+async def file_alert(
+    alert_id: str,
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+    _key_hash: str = Depends(require_api_key),
+) -> StatusUpdateResponse:
+    await _enforce_localhost_bind(request)
+    return await _set_status(alert_id, ralerts.STATUS_FILED, db)
+
+
+async def _set_status(
+    alert_id: str, status: str, db: AsyncSession
+) -> StatusUpdateResponse:
+    repo = ralerts.PatternAlertRepository(db)
+    try:
+        ok = await repo.set_status(alert_id, status)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+    if not ok:
+        raise HTTPException(status_code=404, detail="alert not found")
+    return StatusUpdateResponse(ok=True, alert_id=alert_id, status=status)

--- a/agents/reflector/main.py
+++ b/agents/reflector/main.py
@@ -35,10 +35,12 @@ from agent.db import Base
 from agent.traces import TraceRepository
 from agents._shared.config import AgentRuntimeConfig
 from agents._shared.db import make_engine, make_session_factory
+from agents.reflector import alerts as _alerts  # noqa: F401  side-effect import for ORM registration
 from agents.reflector import rollup as _rollup
 from agents.reflector import store as rstore
 from agents.reflector.listener import listen_for_triggers
 from agents.reflector.migration import apply_reflections_migration
+from agents.reflector.pattern_detector import detect_patterns
 from agents.reflector.prompt import (
     PROMPT_VERSION,
     SYSTEM_PROMPT,
@@ -162,6 +164,7 @@ async def _ensure_schema(engine: AsyncEngine) -> None:
     # Side-effect imports to populate Base.metadata. We don't reference
     # the symbols, but the imports must happen.
     import agent.traces.models  # noqa: F401
+    from agents.reflector.alerts import PatternAlertRow  # noqa: F401
     from agents.reflector.store import ReflectionRow  # noqa: F401
 
     async with engine.begin() as conn:
@@ -381,6 +384,23 @@ async def _run_one_reflection(
                 window_start=exc.window_start.isoformat(),
             )
             return None
+
+    # Pattern detection runs AFTER the reflection persists (#41 spec:
+    # "Pattern detector runs nightly after the reflector"). It is
+    # best-effort: a detector failure must not invalidate the day's
+    # reflection. The reflector still returns the reflection.
+    try:
+        await detect_patterns(
+            window_start=window_start,
+            window_end=window_end,
+            session_factory=session_factory,
+        )
+    except Exception as exc:
+        logger.error(
+            "pattern_detector_failed",
+            error_type=type(exc).__name__,
+            error=str(exc)[:300],
+        )
 
     return reflection
 

--- a/agents/reflector/migration.py
+++ b/agents/reflector/migration.py
@@ -1,4 +1,4 @@
-"""Idempotent post-`create_all` SQL for the `reflections` table.
+"""Idempotent post-`create_all` SQL for the reflector's tables.
 
 Mirrors the shape of `agent/traces/migration.py`: SQLAlchemy's
 `create_all` cannot express partial HNSW indexes or a GIN index on a
@@ -11,6 +11,13 @@ remains the trace store's responsibility. The reflector's grants are
 left to a follow-up (the operator-level note in the #38 PR also
 applies here): until per-archetype Postgres roles land, the reflector
 process connects with the same credentials as Pepper Core.
+
+Tables covered:
+- `reflections` (#39 / #40) — partial HNSW on embedding, GIN on
+  parent_reflection_ids.
+- `pattern_alerts` (#41) — GIN on trace_ids[] so the trace-inspector
+  reverse lookup ("which alerts mention this trace?") is one
+  indexed query.
 """
 from __future__ import annotations
 
@@ -19,7 +26,7 @@ from sqlalchemy.ext.asyncio import AsyncConnection
 
 
 async def apply_reflections_migration(conn: AsyncConnection) -> None:
-    """Apply post-create_all DDL for the `reflections` table.
+    """Apply post-create_all DDL for the reflector's own tables.
 
     Idempotent. Each statement uses `IF NOT EXISTS` so re-running on
     startup is a no-op after the first successful boot.
@@ -46,6 +53,18 @@ async def apply_reflections_migration(conn: AsyncConnection) -> None:
             """
             CREATE INDEX IF NOT EXISTS idx_reflections_parents
             ON reflections USING gin (parent_reflection_ids)
+            """
+        )
+    )
+    # #41: pattern_alerts.trace_ids is uuid[]. GIN supports the
+    # @> containment operator the trace inspector will use to find
+    # alerts that mention a given trace ("is this turn part of any
+    # surfaced cluster?").
+    await conn.execute(
+        text(
+            """
+            CREATE INDEX IF NOT EXISTS idx_pattern_alerts_trace_ids
+            ON pattern_alerts USING gin (trace_ids)
             """
         )
     )

--- a/agents/reflector/pattern_detector.py
+++ b/agents/reflector/pattern_detector.py
@@ -1,0 +1,295 @@
+"""Recurring failure-mode detection (#41 / monitor_operative pattern).
+
+Runs after the daily reflection persists. Pulls "low-quality" traces
+from the day — ones the operator thumbs-downed or corrected via a
+followup — and clusters them by embedding similarity. Each cluster
+of size >= MIN_CLUSTER_SIZE becomes a `pattern_alerts` row.
+
+Design choices for v0 (per the issue spec, "default recommendation:
+start with embedding clustering — cheaper, deterministic — add LLM
+pass only if clustering misses obvious patterns"):
+
+- Greedy cosine clustering. Each trace either joins the existing
+  cluster whose centroid is most similar (above SIMILARITY_THRESHOLD)
+  or starts its own.
+- No LLM-generated summary in v0; the alert summary is a deterministic
+  one-line description naming archetype + size + dominant trigger
+  source. The operator clicks the alert in the UI to see the actual
+  trace contents (via the existing #34 trace inspector). #42 may
+  layer an LLM summary on top once the clustering is calibrated.
+- No external clustering library. We compute cosine similarity
+  manually from the embedding vectors already on each trace row.
+  Avoids pulling sklearn/scipy into the agents/ dependency surface.
+"""
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Optional, Sequence
+
+import structlog
+
+from agent.traces import Trace, TraceRepository
+from agents.reflector import alerts as ralerts
+
+logger = structlog.get_logger(__name__)
+
+# Embedding similarity (cosine) above this counts as "the same shape
+# of failure". Tuned conservatively so unrelated turns do not collapse
+# into one cluster; the operator can lower it after the first soak
+# week if too many true clusters split. The issue spec asks for a
+# manual review of the first week of alerts to calibrate.
+SIMILARITY_THRESHOLD: float = 0.85
+
+# Issue spec: surface clusters with >= 3 members.
+MIN_CLUSTER_SIZE: int = 3
+
+# Bounded scan: even on a busy day we don't pull thousands of traces
+# into memory for the cluster pass. The repository's MAX_QUERY_LIMIT
+# is the hard cap; this is the per-pass soft cap.
+MAX_TRACES_PER_DETECTION: int = 200
+
+
+# ── Cosine similarity helpers ────────────────────────────────────────────────
+
+
+def _dot(a: Sequence[float], b: Sequence[float]) -> float:
+    return sum(x * y for x, y in zip(a, b))
+
+
+def _norm(v: Sequence[float]) -> float:
+    return math.sqrt(sum(x * x for x in v))
+
+
+def _cosine(a: Sequence[float], b: Sequence[float]) -> float:
+    """Cosine similarity in [-1, 1]. Returns 0.0 on degenerate inputs."""
+    if not a or not b or len(a) != len(b):
+        return 0.0
+    na = _norm(a)
+    nb = _norm(b)
+    if na == 0.0 or nb == 0.0:
+        return 0.0
+    return _dot(a, b) / (na * nb)
+
+
+# ── Clustering ───────────────────────────────────────────────────────────────
+
+
+@dataclass
+class _Cluster:
+    """In-progress cluster as we scan traces. Centroid is the running
+    mean of member embeddings, recomputed cheaply on each addition."""
+
+    members: list[Trace]
+    centroid: list[float]
+
+    def add(self, trace: Trace) -> None:
+        # Caller has verified `trace.embedding is not None`.
+        emb = trace.embedding or []
+        n = len(self.members)
+        # Running mean: c_new = c_old * n/(n+1) + emb / (n+1).
+        scale_old = n / (n + 1)
+        scale_new = 1.0 / (n + 1)
+        self.centroid = [
+            self.centroid[i] * scale_old + emb[i] * scale_new
+            for i in range(len(self.centroid))
+        ]
+        self.members.append(trace)
+
+
+def cluster_traces(
+    traces: Sequence[Trace],
+    *,
+    similarity_threshold: float = SIMILARITY_THRESHOLD,
+) -> list[_Cluster]:
+    """Greedy cosine clustering of traces with embeddings.
+
+    Order-dependent (a different ordering can produce different
+    clusters). The order from the repository is newest-first; we
+    accept this for v0 — calibration in week one will tell us
+    whether to switch to a stable seed or a proper k-means.
+    """
+    clusters: list[_Cluster] = []
+    for t in traces:
+        if not t.embedding:
+            continue
+        # Find the most-similar existing cluster.
+        best_idx: Optional[int] = None
+        best_sim = -1.0
+        for i, c in enumerate(clusters):
+            sim = _cosine(t.embedding, c.centroid)
+            if sim > best_sim:
+                best_sim = sim
+                best_idx = i
+        if best_idx is not None and best_sim >= similarity_threshold:
+            clusters[best_idx].add(t)
+        else:
+            clusters.append(_Cluster(members=[t], centroid=list(t.embedding)))
+    return clusters
+
+
+# ── Trace selection ──────────────────────────────────────────────────────────
+
+
+def _is_low_quality(trace: Trace) -> bool:
+    """The "low-quality" filter the issue spec calls out:
+
+    - explicit thumbs-down on the user_reaction, OR
+    - followup flagged as a correction.
+
+    Per `docs/trace-schema.md`, `thumbs` is numeric (`-1 | 0 | +1 |
+    null`) and `followup_correction` is a boolean. Negative thumbs
+    is the thumbs-down case; we accept any negative value defensively
+    in case the encoding broadens later.
+    """
+    reaction = trace.user_reaction or {}
+    thumbs = reaction.get("thumbs")
+    if isinstance(thumbs, (int, float)) and thumbs < 0:
+        return True
+    if reaction.get("followup_correction") is True:
+        return True
+    return False
+
+
+# ── Summary builder ──────────────────────────────────────────────────────────
+
+
+def _summarise_cluster(cluster: _Cluster) -> str:
+    """One-line description of a cluster.
+
+    No LLM, no trace contents — just deterministic facts the operator
+    can use to decide whether to click in. The trace inspector (#34)
+    is the place to read the actual content.
+    """
+    members = cluster.members
+    archetypes = sorted({m.archetype.value for m in members})
+    triggers = sorted({m.trigger_source.value for m in members})
+    thumbs_down = 0
+    followup_corrections = 0
+    for m in members:
+        reaction = m.user_reaction or {}
+        thumbs = reaction.get("thumbs")
+        if isinstance(thumbs, (int, float)) and thumbs < 0:
+            thumbs_down += 1
+        if reaction.get("followup_correction") is True:
+            followup_corrections += 1
+    reactions_summary = (
+        f"{thumbs_down}× thumbs-down, "
+        f"{followup_corrections}× followup-correction"
+    )
+    return (
+        f"Cluster of {len(members)} similar low-quality turns "
+        f"({reactions_summary}); archetype={','.join(archetypes)}; "
+        f"trigger={','.join(triggers)}."
+    )
+
+
+def _suggest_action(cluster: _Cluster) -> str:
+    """Operator-facing hint about how to act on the alert.
+
+    Mirrors the workflow from the issue spec: dismiss / file as a
+    deterministic-intercept candidate / file as an optimizer target.
+    """
+    return (
+        "Review the linked traces. If they share a clear failure "
+        "shape, file as either a deterministic-intercept candidate "
+        "(see agent/core.py health-metric intercept) or as an "
+        "optimizer target for E5 (#44). Otherwise dismiss."
+    )
+
+
+def _confidence(cluster: _Cluster) -> float:
+    """Average pairwise cosine to the centroid, clipped to [0, 1].
+
+    Crude but useful for ranking: a cluster whose members are tightly
+    packed gets a higher score than one whose members are barely
+    above the threshold. The UI sorts by confidence so the operator
+    sees the strongest patterns first.
+    """
+    if not cluster.members:
+        return 0.0
+    sims: list[float] = []
+    for m in cluster.members:
+        if not m.embedding:
+            continue
+        sims.append(_cosine(m.embedding, cluster.centroid))
+    if not sims:
+        return 0.0
+    avg = sum(sims) / len(sims)
+    return max(0.0, min(1.0, avg))
+
+
+# ── Detector entrypoint ──────────────────────────────────────────────────────
+
+
+async def detect_patterns(
+    *,
+    window_start: datetime,
+    window_end: datetime,
+    session_factory,
+    similarity_threshold: float = SIMILARITY_THRESHOLD,
+    min_cluster_size: int = MIN_CLUSTER_SIZE,
+    max_traces: int = MAX_TRACES_PER_DETECTION,
+) -> list[ralerts.PatternAlert]:
+    """Run a single pattern-detection pass over a trace window.
+
+    Returns the list of `PatternAlert` objects the detector
+    persisted. Empty list = no clusters of size >= min_cluster_size.
+    """
+    async with session_factory() as session:
+        traces_repo = TraceRepository(session)
+        # All trace turns in the window. The detector reads only
+        # `user_reaction` and `embedding`; no raw text leaves the
+        # box. We deliberately do NOT filter by `data_sensitivity`
+        # — failure modes can recur on sanitized turns too (a
+        # hallucination on a public-data lookup is still a
+        # hallucination), and the issue spec doesn't restrict.
+        candidates = await traces_repo.query(
+            since=window_start,
+            until=window_end,
+            limit=max_traces,
+            with_payload=True,
+        )
+
+    low_quality = [t for t in candidates if _is_low_quality(t)]
+    logger.info(
+        "pattern_detector_starting",
+        n_candidates=len(candidates),
+        n_low_quality=len(low_quality),
+        window_start=window_start.isoformat(),
+        window_end=window_end.isoformat(),
+    )
+    if not low_quality:
+        return []
+
+    clusters = cluster_traces(low_quality, similarity_threshold=similarity_threshold)
+
+    persisted: list[ralerts.PatternAlert] = []
+    async with session_factory() as session:
+        repo = ralerts.PatternAlertRepository(session)
+        for c in clusters:
+            if len(c.members) < min_cluster_size:
+                continue
+            alert = ralerts.PatternAlert(
+                trace_ids=[m.trace_id for m in c.members],
+                cluster_size=len(c.members),
+                window_start=window_start,
+                window_end=window_end,
+                confidence=_confidence(c),
+                summary=_summarise_cluster(c),
+                suggested_action=_suggest_action(c),
+                metadata_={
+                    "similarity_threshold": similarity_threshold,
+                    "centroid_norm": _norm(c.centroid),
+                },
+            )
+            await repo.append(alert)
+            persisted.append(alert)
+
+    logger.info(
+        "pattern_detector_done",
+        n_clusters_total=len(clusters),
+        n_alerts_filed=len(persisted),
+    )
+    return persisted

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -5,9 +5,10 @@ import Status from './components/Status'
 import LifeContext from './components/LifeContext'
 import Relationships from './components/Relationships'
 import Traces from './components/Traces'
+import ReflectorAlerts from './components/ReflectorAlerts'
 import { logInfo } from './logger'
 
-type Tab = 'chat' | 'status' | 'context' | 'relationships' | 'traces'
+type Tab = 'chat' | 'status' | 'context' | 'relationships' | 'traces' | 'alerts'
 
 export default function App() {
   const [tab, setTab] = useState<Tab>('chat')
@@ -31,6 +32,17 @@ export default function App() {
       {tab === 'context' && <LifeContext />}
       {tab === 'relationships' && <Relationships />}
       {tab === 'traces' && <Traces />}
+      {tab === 'alerts' && (
+        <ReflectorAlerts
+          onOpenTrace={(traceId) => {
+            // Set the hash that Traces.tsx watches AND switch tabs
+            // in one motion. Without this the user clicks a trace
+            // chip in the alert panel and nothing visible happens.
+            window.location.hash = `#/traces/${traceId}/context`
+            setTab('traces')
+          }}
+        />
+      )}
     </Layout>
   )
 }

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -289,4 +289,35 @@ export const api = {
   // the trace inspector to expand a memory row from its provenance ID.
   getMemory: (memoryId: string | number) =>
     req<MemoryDetail>(`/memories/${memoryId}`),
+
+  // Epic 04 (#41) — pattern detector alerts panel.
+  listReflectorAlerts: (status: 'open' | 'dismissed' | 'filed' | 'all' = 'open') =>
+    req<{ alerts: ReflectorAlert[] }>(`/reflector/alerts?status=${status}`),
+
+  dismissReflectorAlert: (alertId: string) =>
+    req<{ ok: boolean; alert_id: string; status: string }>(
+      `/reflector/alerts/${alertId}/dismiss`,
+      { method: 'POST' },
+    ),
+
+  fileReflectorAlert: (alertId: string) =>
+    req<{ ok: boolean; alert_id: string; status: string }>(
+      `/reflector/alerts/${alertId}/file`,
+      { method: 'POST' },
+    ),
+}
+
+// Epic 04 (#41) — pattern detector alerts.
+export interface ReflectorAlert {
+  alert_id: string
+  created_at: string
+  window_start: string
+  window_end: string
+  trace_ids: string[]
+  cluster_size: number
+  confidence: number
+  summary: string
+  suggested_action: string
+  status: 'open' | 'dismissed' | 'filed'
+  metadata: Record<string, unknown>
 }

--- a/web/src/components/Layout.tsx
+++ b/web/src/components/Layout.tsx
@@ -1,7 +1,7 @@
 import { ReactNode } from 'react'
 import { logInfo } from '../logger'
 
-type Tab = 'chat' | 'status' | 'context' | 'relationships' | 'traces'
+type Tab = 'chat' | 'status' | 'context' | 'relationships' | 'traces' | 'alerts'
 
 interface Props {
   tab: Tab
@@ -68,7 +68,7 @@ export default function Layout({ tab, onTabChange, children }: Props) {
         <span style={styles.logo}>Pepper</span>
         <span style={styles.dot} title="online" />
         <nav style={styles.tabs}>
-          {(['chat', 'status', 'context', 'relationships', 'traces'] as Tab[]).map((t) => (
+          {(['chat', 'status', 'context', 'relationships', 'traces', 'alerts'] as Tab[]).map((t) => (
             <button
               key={t}
               style={styles.tab(tab === t)}
@@ -85,7 +85,9 @@ export default function Layout({ tab, onTabChange, children }: Props) {
                 ? 'Life Context'
                 : t === 'relationships'
                 ? 'Relationships'
-                : 'Traces'}
+                : t === 'traces'
+                ? 'Traces'
+                : 'Alerts'}
             </button>
           ))}
         </nav>

--- a/web/src/components/ReflectorAlerts.tsx
+++ b/web/src/components/ReflectorAlerts.tsx
@@ -1,0 +1,276 @@
+import { useEffect, useMemo, useState } from 'react'
+import { api, ReflectorAlert } from '../api'
+import { logError, logInfo } from '../logger'
+
+type StatusFilter = 'open' | 'dismissed' | 'filed' | 'all'
+
+const styles = {
+  root: {
+    display: 'flex',
+    flexDirection: 'column' as const,
+    height: '100%',
+    overflow: 'hidden',
+    color: '#e0e0e0',
+  },
+  header: {
+    padding: '16px 20px',
+    borderBottom: '1px solid #1e1e1e',
+    background: '#0d0d0d',
+  },
+  title: { fontSize: '14px', fontWeight: 600, marginBottom: '4px' },
+  hint: { fontSize: '12px', color: '#888' },
+  filterRow: {
+    display: 'flex',
+    gap: '8px',
+    marginTop: '12px',
+  },
+  filterButton: (active: boolean) => ({
+    padding: '6px 12px',
+    borderRadius: '6px',
+    border: '1px solid #2a2a2a',
+    background: active ? '#4a9eff22' : 'transparent',
+    color: active ? '#4a9eff' : '#888',
+    cursor: 'pointer',
+    fontSize: '12px',
+    fontFamily: 'inherit',
+  }),
+  list: {
+    flex: 1,
+    overflow: 'auto',
+    padding: '12px 20px',
+  },
+  alertCard: {
+    background: '#111',
+    border: '1px solid #1e1e1e',
+    borderRadius: '6px',
+    padding: '14px 16px',
+    marginBottom: '12px',
+  },
+  alertHeader: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'baseline',
+    marginBottom: '6px',
+  },
+  summary: { fontSize: '13px', fontWeight: 600 },
+  meta: { fontSize: '11px', color: '#777' },
+  badge: (status: ReflectorAlert['status']) => ({
+    display: 'inline-block',
+    padding: '2px 8px',
+    borderRadius: '4px',
+    fontSize: '10px',
+    fontWeight: 600,
+    background:
+      status === 'open' ? '#facc1522' : status === 'filed' ? '#22c55e22' : '#52525222',
+    color:
+      status === 'open' ? '#facc15' : status === 'filed' ? '#22c55e' : '#a1a1aa',
+    marginLeft: '8px',
+    textTransform: 'uppercase' as const,
+    letterSpacing: '0.05em',
+  }),
+  suggestion: {
+    fontSize: '12px',
+    color: '#aaa',
+    marginTop: '8px',
+    lineHeight: 1.5,
+  },
+  traceList: {
+    display: 'flex',
+    flexWrap: 'wrap' as const,
+    gap: '6px',
+    marginTop: '10px',
+  },
+  traceLink: {
+    fontSize: '11px',
+    fontFamily: 'monospace',
+    padding: '3px 8px',
+    background: '#1f2937',
+    color: '#9ca3af',
+    borderRadius: '4px',
+    textDecoration: 'none',
+    cursor: 'pointer',
+    border: '1px solid #2a2a2a',
+  },
+  actions: {
+    display: 'flex',
+    gap: '8px',
+    marginTop: '12px',
+  },
+  button: {
+    padding: '6px 12px',
+    borderRadius: '4px',
+    border: '1px solid #2a2a2a',
+    background: 'transparent',
+    color: '#9ca3af',
+    cursor: 'pointer',
+    fontSize: '12px',
+    fontFamily: 'inherit',
+  },
+  empty: {
+    padding: '40px 20px',
+    textAlign: 'center' as const,
+    color: '#666',
+    fontSize: '13px',
+  },
+  error: {
+    padding: '16px',
+    color: '#ef4444',
+    fontSize: '12px',
+  },
+}
+
+interface Props {
+  /** Open a trace in the inspector. Caller is responsible for
+   * switching to the Traces tab AND setting the URL hash; the
+   * panel just calls back with the trace id. */
+  onOpenTrace?: (traceId: string) => void
+}
+
+export default function ReflectorAlerts({ onOpenTrace }: Props = {}) {
+  const [filter, setFilter] = useState<StatusFilter>('open')
+  const [alerts, setAlerts] = useState<ReflectorAlert[] | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [busy, setBusy] = useState<Record<string, boolean>>({})
+
+  const load = useMemo(
+    () => async (which: StatusFilter) => {
+      setError(null)
+      try {
+        const res = await api.listReflectorAlerts(which)
+        setAlerts(res.alerts)
+      } catch (exc) {
+        logError('alerts', 'list_failed', { exc })
+        setError(`Failed to load alerts: ${(exc as Error).message}`)
+        setAlerts([])
+      }
+    },
+    [],
+  )
+
+  useEffect(() => {
+    logInfo('alerts', 'panel_mounted', { filter })
+    void load(filter)
+  }, [filter, load])
+
+  const handleAction = async (
+    alert: ReflectorAlert,
+    action: 'dismiss' | 'file',
+  ) => {
+    setBusy((b) => ({ ...b, [alert.alert_id]: true }))
+    try {
+      if (action === 'dismiss') {
+        await api.dismissReflectorAlert(alert.alert_id)
+      } else {
+        await api.fileReflectorAlert(alert.alert_id)
+      }
+      logInfo('alerts', 'status_changed', {
+        alertId: alert.alert_id,
+        action,
+      })
+      await load(filter)
+    } catch (exc) {
+      logError('alerts', 'status_change_failed', { exc, alertId: alert.alert_id })
+      setError(`Action failed: ${(exc as Error).message}`)
+    } finally {
+      setBusy((b) => {
+        const next = { ...b }
+        delete next[alert.alert_id]
+        return next
+      })
+    }
+  }
+
+  return (
+    <div style={styles.root}>
+      <div style={styles.header}>
+        <div style={styles.title}>Reflector alerts</div>
+        <div style={styles.hint}>
+          Recurring failure-mode clusters surfaced by the nightly pattern
+          detector. Each alert links to the underlying traces — review,
+          then dismiss or mark as filed.
+        </div>
+        <div style={styles.filterRow}>
+          {(['open', 'filed', 'dismissed', 'all'] as StatusFilter[]).map((f) => (
+            <button
+              key={f}
+              style={styles.filterButton(filter === f)}
+              onClick={() => setFilter(f)}
+            >
+              {f}
+            </button>
+          ))}
+        </div>
+      </div>
+      {error && <div style={styles.error}>{error}</div>}
+      <div style={styles.list}>
+        {alerts === null ? (
+          <div style={styles.empty}>Loading…</div>
+        ) : alerts.length === 0 ? (
+          <div style={styles.empty}>
+            {filter === 'open'
+              ? 'No open alerts. The pattern detector has not surfaced any recurring failures yet.'
+              : `No ${filter} alerts.`}
+          </div>
+        ) : (
+          alerts.map((a) => (
+            <div key={a.alert_id} style={styles.alertCard}>
+              <div style={styles.alertHeader}>
+                <div style={styles.summary}>
+                  {a.summary}
+                  <span style={styles.badge(a.status)}>{a.status}</span>
+                </div>
+                <div style={styles.meta}>
+                  conf {a.confidence.toFixed(2)} ·{' '}
+                  {new Date(a.created_at).toLocaleString()}
+                </div>
+              </div>
+              <div style={styles.suggestion}>{a.suggested_action}</div>
+              <div style={styles.traceList}>
+                {a.trace_ids.map((tid) => (
+                  <a
+                    key={tid}
+                    style={styles.traceLink}
+                    href={`#/traces/${tid}/context`}
+                    onClick={(e) => {
+                      e.preventDefault()
+                      logInfo('alerts', 'trace_link_clicked', { traceId: tid })
+                      if (onOpenTrace) {
+                        onOpenTrace(tid)
+                      } else {
+                        // Fallback when the panel is rendered standalone
+                        // (e.g. tests) — set the hash; the user must
+                        // switch tabs manually.
+                        window.location.hash = `#/traces/${tid}/context`
+                      }
+                    }}
+                    title={tid}
+                  >
+                    {tid.slice(0, 8)}
+                  </a>
+                ))}
+              </div>
+              {a.status === 'open' && (
+                <div style={styles.actions}>
+                  <button
+                    style={styles.button}
+                    onClick={() => handleAction(a, 'file')}
+                    disabled={!!busy[a.alert_id]}
+                  >
+                    File (took action)
+                  </button>
+                  <button
+                    style={styles.button}
+                    onClick={() => handleAction(a, 'dismiss')}
+                    disabled={!!busy[a.alert_id]}
+                  >
+                    Dismiss
+                  </button>
+                </div>
+              )}
+            </div>
+          ))
+        )}
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

- Recurring failure-mode detection runs after each daily reflection (per spec). Greedy cosine clustering over the day's traces, filtered to "low-quality" (negative thumbs OR followup-correction). Clusters of size >= 3 become `pattern_alerts` rows for operator review. **No auto-action** — operator dismisses or files each alert.
- New web UI tab `Alerts` with click-through to the existing trace inspector (#34).

## What's in here

- **`agents/reflector/alerts.py`** — `PatternAlert` dataclass + `PatternAlertRow` + repository. Append-only with one named carve-out: `set_status` flips an alert between `open / dismissed / filed`. Public surface asserted in tests.
- **`agents/reflector/pattern_detector.py`** — clustering math + low-quality filter + summariser. Per-cluster summary names archetype + trigger + reaction counts; **never trace text**. Trace IDs are the only thing that links to the underlying content (via the existing inspector).
- **`agents/reflector/http.py`** — `/api/reflector/alerts` list (filter by status) + `dismiss` + `file`. Mirrors the `/api/traces` posture (localhost-bind + `require_api_key`, no DELETE).
- **`agents/reflector/main.py`** — calls `detect_patterns` after each daily reflection lands. Best-effort: a detector failure logs and is swallowed; the reflection still returns.
- **`agents/reflector/migration.py`** — adds GIN on `pattern_alerts.trace_ids[]` so the trace inspector can ask "is this turn part of any open alert?" in one indexed lookup.
- **`agent/main.py`** — mounts the alerts router under `/api`.
- **`web/src/components/ReflectorAlerts.tsx`** + `api.ts` + `App.tsx` + `Layout.tsx` — minimal panel with status filter, alert cards (summary, confidence, suggested action), and clickable trace-id chips. Click-through routes via a callback prop that lifts the tab switch + hash set into the parent (App.tsx).

## Bugs caught and fixed during review

- **`thumbs` encoding** — first cut compared `thumbs == "down"`, but `docs/trace-schema.md` defines `thumbs` as numeric (-1/0/+1). Detector silently never fired the thumbs-down branch on real data. Now compares to negative integer.
- **Deferred `embedding` column** — `TraceRepository.query(with_payload=True)` undeferred only `assembled_context` and `tools_called`, not `embedding`. Reading `t.embedding` outside the session block from the pattern detector would have raised `MissingGreenlet` at first use. The docstring already promised "the full row"; implementation now matches.
- **Trace-link routing** — first cut set `#traces:{tid}` (wrong format) and didn't switch tabs. Replaced with a `onOpenTrace` callback that the parent uses to switch tab + set `#/traces/{id}/context` (the format Traces.tsx already watches).
- **Over-narrow `data_sensitivity` filter** — initial code restricted clustering to `LOCAL_ONLY`, but a hallucination on a sanitized turn is still a hallucination. Filter dropped.

## Acceptance criteria from #41

- [x] Pattern detector runs nightly after the reflector.
- [x] Alerts visible in the UI.
- [x] Operator can take action on each alert (dismiss / file).
- [x] No auto-application of suggested actions.

## Test plan

- [x] **Cosine math**: identical / orthogonal / opposite / degenerate / zero-norm cases.
- [x] **Low-quality filter**: numeric thumbs (-1, 0, +1), boolean followup_correction, none/empty reaction.
- [x] **Clustering**: identical embeddings collapse, distinct seeds split, missing embedding skipped, low threshold collapses everything.
- [x] **Summariser**: never leaks trace text; confidence in [0, 1].
- [x] **Entrypoint**: zero low-quality → 0 alerts; 3 thumbs-down at one embedding → 1 alert; below-min-cluster → 0 alerts.
- [x] **Repository**: no-mutation surface (only `append`, `get_by_id`, `list_open`, `list_by_status`, `set_status`); dataclass guards (status enum, cluster-size matches trace_ids, confidence in unit interval, frozen).
- [x] `pytest agent/tests/test_reflector_*.py agent/tests/test_traces_repository.py agent/tests/test_agents_isolation.py` — 154 passing.
- [x] `ruff check` — clean.
- [ ] Live end-to-end: requires real low-quality traces in the trace store; operator action after merge.

## Notes for downstream subissues

- **#42 (eval rubric)**: alerts already record `metadata.similarity_threshold` and `metadata.centroid_norm`; #42's calibration soak can read those fields directly.
- **Future**: an LLM-generated cluster summary (current spec mentions this as a follow-up if clustering misses obvious patterns) can layer on top of the existing one-line summary without schema change.

Closes #41.