### PR TITLE
agents/reflector: eval rubric + scoring tool (#42)

### DIFF
--- a/agent/tests/test_reflector_eval.py
+++ b/agent/tests/test_reflector_eval.py
@@ -1,0 +1,257 @@
+"""Unit tests for `agents.reflector.eval` — rubric tool (#42).
+
+Live LLM-judge calls require a frontier API key + the explicit
+opt-in flag, so those tests are skipped by default. The dataclass
+guards, prompt rendering, JSON parsing, and the privacy gate all
+test directly.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import patch
+
+import pytest
+
+from agents.reflector import eval as ev
+from agents.reflector import store as rstore
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+
+def _ref(
+    *,
+    text: str = "i felt unhurried today.",
+    tier: str = rstore.TIER_DAILY,
+    metadata: dict | None = None,
+) -> rstore.Reflection:
+    now = datetime.now(timezone.utc)
+    return rstore.Reflection(
+        text=text,
+        window_start=now - timedelta(hours=24),
+        window_end=now,
+        tier=tier,
+        metadata_=metadata or {},
+    )
+
+
+def _ctx(
+    *,
+    reflection: rstore.Reflection | None = None,
+    previous: rstore.Reflection | None = None,
+    digests: list[str] | None = None,
+    violations: list[str] | None = None,
+) -> ev.ReflectionContext:
+    return ev.ReflectionContext(
+        reflection=reflection or _ref(),
+        previous_reflection=previous,
+        trace_digests=digests or [],
+        voice_violations=violations or [],
+    )
+
+
+# ── Dataclass guards ────────────────────────────────────────────────────────
+
+
+class TestRubricScoreGuards:
+    def test_constructs_in_range(self) -> None:
+        s = ev.RubricScore(
+            reflection_id="r1",
+            coherence=2,
+            novelty=2,
+            grounded_in_traces=3,
+            self_framing=3,
+            length_appropriateness=2,
+        )
+        assert s.total == 12
+
+    @pytest.mark.parametrize("dim", ev.DIMENSIONS)
+    def test_out_of_range_dimension_rejected(self, dim: str) -> None:
+        kwargs = {d: 1 for d in ev.DIMENSIONS}
+        kwargs[dim] = 5  # > 3
+        with pytest.raises(ValueError, match=dim):
+            ev.RubricScore(reflection_id="r", **kwargs)
+
+    def test_unknown_mode_rejected(self) -> None:
+        with pytest.raises(ValueError, match="mode"):
+            ev.RubricScore(
+                reflection_id="r",
+                coherence=0,
+                novelty=0,
+                grounded_in_traces=0,
+                self_framing=0,
+                length_appropriateness=0,
+                mode="strict",
+            )
+
+
+# ── Manual mode rendering ───────────────────────────────────────────────────
+
+
+class TestRenderManualPrompt:
+    def test_includes_reflection_text(self) -> None:
+        ctx = _ctx(reflection=_ref(text="i noticed it was a quiet day."))
+        prompt = ev.render_manual_prompt(ctx)
+        assert "i noticed it was a quiet day." in prompt
+
+    def test_includes_each_dimension(self) -> None:
+        ctx = _ctx()
+        prompt = ev.render_manual_prompt(ctx)
+        for dim in ev.DIMENSIONS:
+            assert f"- {dim}: __" in prompt
+
+    def test_no_previous_reflection_is_handled(self) -> None:
+        ctx = _ctx(previous=None)
+        prompt = ev.render_manual_prompt(ctx)
+        assert "Previous reflection: (none — first one)" in prompt
+
+    def test_previous_reflection_included(self) -> None:
+        prev = _ref(text="yesterday was busier.")
+        ctx = _ctx(previous=prev)
+        prompt = ev.render_manual_prompt(ctx)
+        assert "yesterday was busier." in prompt
+
+    def test_voice_violations_surfaced(self) -> None:
+        ctx = _ctx(violations=["tldr", "jack should"])
+        prompt = ev.render_manual_prompt(ctx)
+        assert "tldr" in prompt
+        assert "jack should" in prompt
+
+    def test_quiet_window_acknowledged(self) -> None:
+        ctx = _ctx(digests=[])
+        prompt = ev.render_manual_prompt(ctx)
+        assert "(no traces — quiet day)" in prompt
+
+
+# ── Judge response parsing ──────────────────────────────────────────────────
+
+
+class TestParseJudgeResponse:
+    def test_bare_json(self) -> None:
+        body = (
+            '{"coherence":2, "novelty":1, "grounded_in_traces":3, '
+            '"self_framing":3, "length_appropriateness":2, "notes":"ok"}'
+        )
+        out = ev.parse_judge_response(body)
+        assert out["coherence"] == 2
+        assert out["notes"] == "ok"
+
+    def test_fenced_json(self) -> None:
+        body = (
+            "Sure, here is the score:\n"
+            "```json\n"
+            '{"coherence":1, "novelty":1, "grounded_in_traces":1, '
+            '"self_framing":1, "length_appropriateness":1, "notes":""}\n'
+            "```"
+        )
+        out = ev.parse_judge_response(body)
+        assert out["self_framing"] == 1
+
+    def test_missing_json_raises(self) -> None:
+        with pytest.raises(ValueError, match="no JSON"):
+            ev.parse_judge_response("just prose, no scores at all")
+
+    def test_nested_object_with_prose_around(self) -> None:
+        """The cheap `\\{[^{}]*\\}` regex would have matched the inner
+        `{}` (notes value) and missed the right object. Balanced-brace
+        scan finds the top-level object even when the model wraps it
+        in extra prose."""
+        body = (
+            "Here is my analysis of the reflection:\n\n"
+            '{"coherence":3, "novelty":2, "grounded_in_traces":2, '
+            '"self_framing":3, "length_appropriateness":3, '
+            '"notes":"strong on {grounded} dim, weaker novelty"}\n\n'
+            "Hope that helps."
+        )
+        out = ev.parse_judge_response(body)
+        assert out["coherence"] == 3
+        # The notes substring contains literal `{grounded}` braces —
+        # the balanced-brace scanner must skip them inside the string.
+        assert "grounded" in out["notes"]
+
+    def test_whole_string_json_round_trip(self) -> None:
+        # When the model obeys "JSON only", the cheapest path
+        # succeeds: the whole content is the JSON.
+        body = '{"coherence":1,"novelty":1,"grounded_in_traces":1,"self_framing":1,"length_appropriateness":1,"notes":"x"}'
+        out = ev.parse_judge_response(body)
+        assert out["coherence"] == 1
+
+
+# ── Frontier gate ───────────────────────────────────────────────────────────
+
+
+class TestFrontierGate:
+    def test_default_off(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv(ev.FRONTIER_GATE_ENV, raising=False)
+        assert ev.is_frontier_judge_enabled() is False
+
+    @pytest.mark.parametrize("val", ["true", "TRUE", "1", "yes", "on", "  true  "])
+    def test_truthy_values_enable(
+        self, monkeypatch: pytest.MonkeyPatch, val: str
+    ) -> None:
+        monkeypatch.setenv(ev.FRONTIER_GATE_ENV, val)
+        assert ev.is_frontier_judge_enabled() is True
+
+    @pytest.mark.parametrize("val", ["false", "no", "0", "", "off", "maybe"])
+    def test_falsy_values_disable(
+        self, monkeypatch: pytest.MonkeyPatch, val: str
+    ) -> None:
+        monkeypatch.setenv(ev.FRONTIER_GATE_ENV, val)
+        assert ev.is_frontier_judge_enabled() is False
+
+
+# ── LLM-judge mode privacy gate ─────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+class TestScoreWithLlmGated:
+    async def test_refuses_without_explicit_optin(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv(ev.FRONTIER_GATE_ENV, raising=False)
+        with pytest.raises(SystemExit, match=ev.FRONTIER_GATE_ENV):
+            await ev.score_with_llm(_ctx())
+
+    async def test_proceeds_with_explicit_optin_and_clamps_response(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv(ev.FRONTIER_GATE_ENV, "true")
+
+        # The response under test deliberately includes an
+        # out-of-range score (5) and a non-int (None) to verify
+        # `_clip` defends downstream consumers.
+        canned = {
+            "content": (
+                '{"coherence":2, "novelty":5, "grounded_in_traces":3, '
+                '"self_framing":3, "length_appropriateness":null, '
+                '"notes":"clamped"}'
+            ),
+            "model_used": "claude-test-model",
+            "latency_ms": 100,
+        }
+
+        # Stub the lazy-imported ModelClient so the test never needs
+        # a real frontier key. The patch targets `agent.llm` which
+        # is what `score_with_llm` imports inside the function.
+        from unittest.mock import AsyncMock, MagicMock
+
+        fake_client = MagicMock()
+        fake_client.chat = AsyncMock(return_value=canned)
+
+        with (
+            patch("agent.llm.ModelClient", return_value=fake_client),
+            patch(
+                "agent.config.settings",
+                MagicMock(DEFAULT_FRONTIER_MODEL="claude-test-model"),
+            ),
+        ):
+            score = await ev.score_with_llm(_ctx())
+
+        assert score.mode == "llm-judge"
+        assert score.coherence == 2
+        # 5 clamps to 3.
+        assert score.novelty == 3
+        # null/None falls through to 0.
+        assert score.length_appropriateness == 0
+        assert score.notes == "clamped"
+        assert 0 <= score.total <= 15

--- a/agents/reflector/eval.py
+++ b/agents/reflector/eval.py
@@ -1,0 +1,460 @@
+"""Eval rubric scoring tool (#42).
+
+Implements the rubric in `docs/reflection-eval-rubric.md`. Two
+modes:
+
+- **Manual** — emits a prompt template the operator copies into a
+  reviewer prompt or fills in by hand.
+- **LLM-judge** — sends the reflection text to a frontier model
+  with the rubric in the prompt and parses back JSON scores.
+
+LLM-judge mode is gated by the env flag
+`PEPPER_REFLECTION_EVAL_USE_FRONTIER` (default `false`). The flag
+exists because the reflection text — even though it is a
+structured-summary artefact, not raw personal data — compresses raw
+content. Sending it to a frontier model is inside the privacy
+invariant per `docs/GUARDRAILS.md`, but the operator opts in
+explicitly.
+
+Operator usage::
+
+    python -m agents.reflector.eval --mode manual --reflection-id <uuid>
+    python -m agents.reflector.eval --mode llm-judge --reflection-id <uuid>
+
+The CLI prints the rendered prompt (manual mode) or the parsed
+scores (llm-judge mode) to stdout. Persistence of scores is a
+deferred follow-up — see `docs/reflection-eval-rubric.md` §"Manual
+mode".
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import re
+import sys
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from typing import Optional
+
+import structlog
+
+from agent.error_classifier import DataSensitivity
+from agent.traces import TraceRepository
+from agents._shared.config import load_runtime_config
+from agents._shared.db import make_engine, make_session_factory
+from agents.reflector import store as rstore
+from agents.reflector.prompt import summarize_trace
+
+logger = structlog.get_logger(__name__)
+
+
+FRONTIER_GATE_ENV = "PEPPER_REFLECTION_EVAL_USE_FRONTIER"
+
+# Score values are sums of five 0–3 dimensions. Anything outside
+# [0, 15] indicates a parser error or a deliberately malformed
+# response.
+MIN_TOTAL: int = 0
+MAX_TOTAL: int = 15
+
+DIMENSIONS: tuple[str, ...] = (
+    "coherence",
+    "novelty",
+    "grounded_in_traces",
+    "self_framing",
+    "length_appropriateness",
+)
+
+
+# ── Score dataclass ─────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class RubricScore:
+    """One scored reflection. All scores are integers in [0, 3]."""
+
+    reflection_id: str
+    coherence: int
+    novelty: int
+    grounded_in_traces: int
+    self_framing: int
+    length_appropriateness: int
+    notes: str = ""
+    mode: str = "manual"  # "manual" | "llm-judge"
+    judge_model: Optional[str] = None
+    scored_at: datetime = field(
+        default_factory=lambda: datetime.now(timezone.utc)
+    )
+
+    def __post_init__(self) -> None:
+        for dim in DIMENSIONS:
+            v = getattr(self, dim)
+            if not isinstance(v, int) or not (0 <= v <= 3):
+                raise ValueError(
+                    f"dimension {dim!r} must be int in [0, 3], got {v!r}"
+                )
+        if self.mode not in {"manual", "llm-judge"}:
+            raise ValueError(f"unknown mode {self.mode!r}")
+
+    @property
+    def total(self) -> int:
+        return sum(getattr(self, d) for d in DIMENSIONS)
+
+
+# ── Reflection + window context loaders ─────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class ReflectionContext:
+    """Everything the rubric needs to score one reflection.
+
+    Built once by the eval CLI; passed into both the manual and
+    llm-judge paths.
+    """
+
+    reflection: rstore.Reflection
+    previous_reflection: Optional[rstore.Reflection]
+    trace_digests: list[str]
+    voice_violations: list[str]
+
+
+async def load_context(
+    reflection_id: str, *, postgres_url: str
+) -> ReflectionContext:
+    engine = make_engine(postgres_url)
+    factory = make_session_factory(engine)
+    try:
+        async with factory() as session:
+            reflections_repo = rstore.ReflectionRepository(session)
+            reflection = await reflections_repo.get_by_id(reflection_id)
+            if reflection is None:
+                raise SystemExit(f"reflection {reflection_id!r} not found")
+
+            # Find the immediately-prior reflection of the same tier
+            # for novelty grounding.
+            previous = None
+            if reflection.previous_reflection_id:
+                previous = await reflections_repo.get_by_id(
+                    reflection.previous_reflection_id
+                )
+
+            traces_repo = TraceRepository(session)
+            traces = await traces_repo.query(
+                since=reflection.window_start,
+                until=reflection.window_end,
+                limit=200,
+                with_payload=True,
+            )
+            digests = []
+            for t in sorted(traces, key=lambda x: x.created_at):
+                d = summarize_trace(t)
+                digests.append(
+                    f"[{d.when}] in: {d.input[:200]} | out: {d.output[:200]}"
+                )
+    finally:
+        await engine.dispose()
+
+    violations = list(reflection.metadata_.get("voice_violations", []) or [])
+
+    return ReflectionContext(
+        reflection=reflection,
+        previous_reflection=previous,
+        trace_digests=digests,
+        voice_violations=violations,
+    )
+
+
+# ── Manual mode prompt ──────────────────────────────────────────────────────
+
+
+def render_manual_prompt(ctx: ReflectionContext) -> str:
+    r = ctx.reflection
+    parts: list[str] = []
+    parts.append(
+        "# Reflection scoring sheet "
+        "(rubric: docs/reflection-eval-rubric.md)\n"
+    )
+    parts.append(f"reflection_id: {r.reflection_id}")
+    parts.append(f"tier:           {r.tier}")
+    parts.append(f"window_start:   {r.window_start.isoformat()}")
+    parts.append(f"window_end:     {r.window_end.isoformat()}")
+    parts.append(f"prompt_version: {r.prompt_version}")
+    parts.append(f"model_used:     {r.model_used}")
+    parts.append("")
+    parts.append("## Reflection text\n")
+    parts.append(r.text)
+    parts.append("")
+    if ctx.previous_reflection is not None:
+        parts.append("## Previous reflection (for novelty check)\n")
+        parts.append(ctx.previous_reflection.text)
+        parts.append("")
+    else:
+        parts.append("## Previous reflection: (none — first one)")
+        parts.append("")
+    parts.append("## Voice violations recorded by the reflector\n")
+    if ctx.voice_violations:
+        parts.append(", ".join(ctx.voice_violations))
+    else:
+        parts.append("(none)")
+    parts.append("")
+    parts.append("## Trace digests in window\n")
+    if ctx.trace_digests:
+        parts.append("\n".join(ctx.trace_digests))
+    else:
+        parts.append("(no traces — quiet day)")
+    parts.append("")
+    parts.append("## Scoring (each 0–3, see rubric)\n")
+    for dim in DIMENSIONS:
+        parts.append(f"- {dim}: __")
+    parts.append("- notes: __")
+    parts.append("")
+    parts.append("Total: __ / 15")
+    return "\n".join(parts)
+
+
+# ── LLM-judge mode ──────────────────────────────────────────────────────────
+
+
+_JUDGE_SYSTEM = (
+    "You are a strict, fair reviewer scoring a private end-of-day "
+    "reflection against a 5-dimension rubric. Each dimension is "
+    "0-3. Read the inputs carefully, score honestly, and emit JSON "
+    "ONLY — no prose around it.\n\n"
+    "Dimensions:\n"
+    "1. coherence: single voice, internal consistency.\n"
+    "2. novelty: surfaces something not in the previous reflection.\n"
+    "3. grounded_in_traces: each non-trivial claim traces back to "
+    "the window's traces.\n"
+    "4. self_framing: written to herself, first-person, no "
+    "audience-shaped framing. The detector flags these specifically: "
+    "'Jack should…', 'TLDR' / 'TL;DR', 'Recommendations:' / 'I "
+    "recommend that you', 'action items', 'next steps', "
+    "'Follow-up:' / 'Followups:', 'TODO:' / 'To-do:'. Mirror those "
+    "exactly when scoring this dimension.\n"
+    "5. length_appropriateness: matches the day's content.\n\n"
+    "Output exactly this JSON, no prose, no markdown fence:\n"
+    '{"coherence":0-3, "novelty":0-3, "grounded_in_traces":0-3, '
+    '"self_framing":0-3, "length_appropriateness":0-3, '
+    '"notes":"<one short sentence on the lowest-scoring dimension>"}'
+)
+
+
+def render_judge_user_prompt(ctx: ReflectionContext) -> str:
+    """Build the user-side prompt for the frontier judge.
+
+    Reuses the manual prompt rendering for inputs and replaces the
+    blank scoring sheet with a request for the JSON response.
+    """
+    parts: list[str] = []
+    r = ctx.reflection
+    parts.append(f"reflection_id: {r.reflection_id}")
+    parts.append(f"tier: {r.tier}")
+    parts.append("")
+    parts.append("--- REFLECTION TEXT ---")
+    parts.append(r.text)
+    parts.append("")
+    if ctx.previous_reflection is not None:
+        parts.append("--- PREVIOUS REFLECTION (for novelty) ---")
+        parts.append(ctx.previous_reflection.text)
+        parts.append("")
+    parts.append("--- VOICE VIOLATIONS RECORDED BY REFLECTOR ---")
+    parts.append(", ".join(ctx.voice_violations) if ctx.voice_violations else "(none)")
+    parts.append("")
+    parts.append("--- TRACE DIGESTS IN WINDOW ---")
+    parts.append("\n".join(ctx.trace_digests) if ctx.trace_digests else "(quiet day)")
+    parts.append("")
+    parts.append("Score now. JSON only.")
+    return "\n".join(parts)
+
+
+def _scan_balanced_object(content: str) -> Optional[str]:
+    """Return the first top-level `{...}` substring, balancing braces.
+
+    Tolerates nested objects (e.g. when the model wraps the answer
+    inside another object) — the cheap `\\{[^{}]*\\}` regex would
+    have matched the innermost object and missed the right one.
+    """
+    depth = 0
+    start = -1
+    in_string = False
+    escape = False
+    for i, ch in enumerate(content):
+        if in_string:
+            if escape:
+                escape = False
+            elif ch == "\\":
+                escape = True
+            elif ch == '"':
+                in_string = False
+            continue
+        if ch == '"':
+            in_string = True
+            continue
+        if ch == "{":
+            if depth == 0:
+                start = i
+            depth += 1
+        elif ch == "}":
+            if depth == 0:
+                continue
+            depth -= 1
+            if depth == 0 and start >= 0:
+                return content[start : i + 1]
+    return None
+
+
+def parse_judge_response(content: str) -> dict:
+    """Pluck the JSON object out of the model's reply.
+
+    Tries three strategies in order:
+      1. The whole content as JSON (the prompt asks for this).
+      2. A ```json``` code fence (frontier models occasionally
+         wrap even when told not to).
+      3. The first top-level `{...}` substring with balanced
+         braces (handles nested objects and prose around the
+         payload).
+    """
+    stripped = content.strip()
+    if stripped:
+        try:
+            return json.loads(stripped)
+        except json.JSONDecodeError:
+            pass
+
+    fence = re.search(r"```(?:json)?\s*(\{.*?\})\s*```", content, re.DOTALL)
+    if fence:
+        return json.loads(fence.group(1))
+
+    balanced = _scan_balanced_object(content)
+    if balanced is not None:
+        return json.loads(balanced)
+
+    raise ValueError(f"no JSON object found in response: {content[:200]!r}")
+
+
+def is_frontier_judge_enabled() -> bool:
+    """Privacy gate. False unless the operator explicitly opts in."""
+    return os.environ.get(FRONTIER_GATE_ENV, "false").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+
+
+async def score_with_llm(
+    ctx: ReflectionContext,
+    *,
+    judge_model: Optional[str] = None,
+) -> RubricScore:
+    """Run the frontier judge. Refuses to run unless the gate env is set.
+
+    Imports `agent.llm.ModelClient` lazily so the eval module does
+    not pay for the client's startup cost when only the manual
+    mode is being used.
+    """
+    if not is_frontier_judge_enabled():
+        raise SystemExit(
+            f"LLM-judge mode requires {FRONTIER_GATE_ENV}=true. The "
+            "reflection text is sent to a non-local model — see "
+            "docs/reflection-eval-rubric.md §'LLM-judge mode'."
+        )
+    from agent.config import settings
+    from agent.llm import ModelClient
+
+    client = ModelClient(config=settings)
+    chosen_model = judge_model or settings.DEFAULT_FRONTIER_MODEL
+    user_prompt = render_judge_user_prompt(ctx)
+
+    result = await client.chat(
+        messages=[
+            {"role": "system", "content": _JUDGE_SYSTEM},
+            {"role": "user", "content": user_prompt},
+        ],
+        model=chosen_model,
+        # Reflections are structured-summary, not RAW_PERSONAL —
+        # SANITIZED is the right sensitivity per
+        # docs/reflection-eval-rubric.md §"LLM-judge mode".
+        data_sensitivity=DataSensitivity.SANITIZED,
+    )
+    raw = result.get("content") or ""
+    parsed = parse_judge_response(raw)
+
+    # Defensive: clamp out-of-range values to the closest valid
+    # score so a single noisy dimension does not invalidate the
+    # whole pass. Log when we clamp so calibration sees it.
+    def _clip(v) -> int:
+        try:
+            iv = int(v)
+        except (TypeError, ValueError):
+            return 0
+        if iv < 0:
+            return 0
+        if iv > 3:
+            return 3
+        return iv
+
+    return RubricScore(
+        reflection_id=ctx.reflection.reflection_id,
+        coherence=_clip(parsed.get("coherence")),
+        novelty=_clip(parsed.get("novelty")),
+        grounded_in_traces=_clip(parsed.get("grounded_in_traces")),
+        self_framing=_clip(parsed.get("self_framing")),
+        length_appropriateness=_clip(parsed.get("length_appropriateness")),
+        notes=str(parsed.get("notes") or ""),
+        mode="llm-judge",
+        judge_model=chosen_model,
+    )
+
+
+# ── CLI ─────────────────────────────────────────────────────────────────────
+
+
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        prog="agents.reflector.eval",
+        description=(
+            "Score a reflection against the rubric in "
+            "docs/reflection-eval-rubric.md."
+        ),
+    )
+    parser.add_argument(
+        "--mode",
+        required=True,
+        choices=("manual", "llm-judge"),
+    )
+    parser.add_argument("--reflection-id", required=True)
+    parser.add_argument(
+        "--judge-model",
+        default=None,
+        help="LLM-judge mode only. Defaults to DEFAULT_FRONTIER_MODEL.",
+    )
+    return parser.parse_args(argv)
+
+
+async def _main_async(args: argparse.Namespace) -> int:
+    config = load_runtime_config("reflector")
+    ctx = await load_context(
+        args.reflection_id, postgres_url=config.postgres_url
+    )
+    if args.mode == "manual":
+        sys.stdout.write(render_manual_prompt(ctx))
+        sys.stdout.write("\n")
+        return 0
+    score = await score_with_llm(ctx, judge_model=args.judge_model)
+    payload = asdict(score)
+    payload["scored_at"] = score.scored_at.isoformat()
+    payload["total"] = score.total
+    sys.stdout.write(json.dumps(payload, indent=2))
+    sys.stdout.write("\n")
+    return 0
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    args = _parse_args(sys.argv[1:] if argv is None else argv)
+    return asyncio.run(_main_async(args))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/reflection-eval-rubric.md
+++ b/docs/reflection-eval-rubric.md
@@ -1,0 +1,156 @@
+# Reflection eval rubric
+
+This document defines what "good reflection" means for the
+[`agents/reflector/`](../agents/reflector/) archetype. Without an
+explicit rubric we would soak for two weeks and have nothing to
+score against.
+
+The rubric applies to the daily reflection (#39) and to the weekly
+and monthly rollups (#40). Each dimension is scored 0–3; the total
+is the sum (max 15). The scoring tool that materialises this rubric
+lives at [`agents/reflector/eval.py`](../agents/reflector/eval.py).
+
+## Dimensions
+
+### 1. Coherence (0–3)
+
+Does the reflection read as a single voice with internal consistency
+— a paragraph from one mind, not a stitched-together set of one-line
+takes?
+
+- **0** — Incoherent. Sentences contradict each other, change voice,
+  or read as concatenated fragments with no thread.
+- **1** — Mostly fragmented. A single thread is present in places
+  but breaks at least once.
+- **2** — Coherent. One voice, one thread; minor stiffness allowed.
+- **3** — Coherent and supple. Reads like a journal entry: one
+  voice, one thread, language flows naturally.
+
+### 2. Novelty (0–3)
+
+Does the reflection surface something not already in yesterday's
+reflection (or, for rollups, in the previous tier-mate)?
+
+- **0** — Restates the previous reflection. The reader could read
+  yesterday's note and skip today's without losing anything.
+- **1** — Mostly restated, with one new observation.
+- **2** — Substantively different from yesterday. New observation,
+  new framing, or new connection.
+- **3** — Novel and earned. Surfaces something the previous
+  reflection could not have said.
+
+### 3. Grounded-in-traces (0–3)
+
+Can each non-trivial claim be traced back to specific `trace_id`s
+in the window? This is the **anti-platitude check**: a reflection
+that says "I felt productive today" without any trace evidence is
+not grounded.
+
+- **0** — Floating. The reflection contains claims that are not
+  recoverable from the day's traces. Could have been written
+  without reading any trace.
+- **1** — Mostly grounded but one or more claims are floating
+  generalities.
+- **2** — Grounded. Every non-trivial claim traces back to a turn
+  in the window.
+- **3** — Grounded and specific. The reflection cites concrete
+  observations only the day's traces could have produced.
+
+### 4. Self-framing (0–3)
+
+Is it written **to herself**, not to Jack? This is the voice check
+the system prompt enforces. A reflection with bullet lists,
+"action items:", "Jack should…", "TLDR:", "next steps:", or any
+other audience-shaped framing fails this dimension regardless of
+how grounded or coherent it is.
+
+`agents/reflector/main.py` records the rule labels that fired (in
+`metadata_.voice_violations`) so the scoring tool can read them
+directly without re-running the regex.
+
+- **0** — Audience-shaped throughout. Reads as a brief for Jack.
+- **1** — Mixed voice. Slips into audience framing once or twice.
+- **2** — First-person to herself with one minor slip (e.g. the
+  word "recommend" used self-directedly).
+- **3** — Pure first-person interior voice. No audience framing,
+  no slips.
+
+### 5. Length appropriateness (0–3)
+
+Did the reflection match the day's content? A quiet day should
+produce a short reflection (one sentence is fine); a busy day with
+many distinct turns should not collapse into one line.
+
+- **0** — Wildly inappropriate. A multi-page reflection on a quiet
+  day, or one sentence covering 50 trace turns.
+- **1** — Mismatched. Too long or too short for the window's
+  content; a reader can tell the model padded or truncated.
+- **2** — Roughly right. A few sentences for a normal day; one
+  short paragraph for a busy day.
+- **3** — Right-sized. Length earns each sentence; nothing is
+  padding, nothing is missing.
+
+## Scoring procedure
+
+There are two modes.
+
+### Manual mode
+
+`agents/reflector/eval.py --mode manual --reflection-id <uuid>`
+emits a prompt template that includes:
+
+- The reflection text being scored.
+- The trace window's input/output digests (so the reviewer can
+  verify groundedness).
+- The previous reflection (so the reviewer can verify novelty).
+- The recorded voice violations (already computed by the daily
+  reflector — feeds dimension 4).
+- A blank scoring sheet for the five dimensions plus a notes field.
+
+The reviewer copies the output, scores by hand, and pastes the
+result back into a notes file (the tool does not currently round-
+trip results back into the database — that is a follow-up once we
+have enough manual scores to know the data shape we want).
+
+### LLM-judge mode
+
+`agents/reflector/eval.py --mode llm-judge --reflection-id <uuid>`
+runs the same rubric through a frontier model (Sonnet by default).
+
+This mode is **off unless explicitly enabled** because the
+reflection text is sent to a non-local model:
+
+- The config flag `PEPPER_REFLECTION_EVAL_USE_FRONTIER` (env var
+  defaults to `false`) gates whether `--mode llm-judge` is allowed
+  to run. Setting it to `true` is an explicit operator opt-in.
+- The flag is documented at this single decision point: reflections
+  are a **structured-summary artefact**, not raw personal data
+  (raw trace text never appears verbatim in a reflection — the
+  daily prompt summarises). Sending the reflection text to a
+  frontier model is therefore inside the privacy invariant per
+  `docs/GUARDRAILS.md`. But it is still data that compresses raw
+  content, so it requires explicit opt-in.
+
+LLM-judge output is **advisory**. Manual scores override LLM-judge
+scores when both exist for the same reflection.
+
+## Calibration plan
+
+The 7-day soak + LLM-judge calibration is **deferred to operator
+follow-up**: this PR ships the rubric and the scoring tool, but the
+soak itself happens against real traces accumulating after merge,
+and the calibration result is recorded back into this document.
+
+Once #39 is soaking on real traces:
+
+1. Score each daily reflection in both modes for ~7 days.
+2. Compute Pearson correlation between manual and LLM-judge totals.
+3. If `r >= 0.7`, the LLM-judge is acceptable for ongoing
+   monitoring. Manual scoring drops to a weekly spot-check.
+4. If `r < 0.7`, reach back to the rubric: are the dimensions
+   under-specified? Is the LLM-judge prompt biased toward one
+   dimension? Iterate on the rubric or the prompt before asking
+   the model to do more work.
+
+Calibration result is documented in this file once it lands —
+look for a "Calibration: 2026-MM-DD" subsection at the bottom.


### PR DESCRIPTION
## Summary

- Authors `docs/reflection-eval-rubric.md` defining what "good reflection" means before the reflector starts producing outputs at scale.
- Ships `agents/reflector/eval.py` — the manual + LLM-judge scoring tool that materialises the rubric.
- Privacy posture: LLM-judge mode sends reflection text to a frontier model and is gated behind `PEPPER_REFLECTION_EVAL_USE_FRONTIER=true`. Default is OFF.

## Rubric (0–3 per dimension, 15 total)

1. **Coherence** — single voice, internal consistency.
2. **Novelty** — surfaces something not in the previous reflection.
3. **Grounded-in-traces** — anti-platitude check; each non-trivial claim traces back to specific `trace_id`s.
4. **Self-framing** — written to herself, no audience-shaped framing. The detector already records voice-violation labels (#39's `metadata_.voice_violations`); the rubric reads those directly so the judge doesn't re-run the regex.
5. **Length appropriateness** — matches the day's content; quiet day → short, busy day → richer.

## What's in `eval.py`

- `RubricScore` frozen dataclass with per-dimension validation (each in [0, 3]).
- `ReflectionContext` loader: pulls the reflection, the previous reflection (for novelty), the trace digests in the window, and the voice-violation labels already recorded by the daily reflector.
- `render_manual_prompt` — fills a scoring sheet the operator can paste into a notes file or a reviewer prompt.
- `render_judge_user_prompt` + `score_with_llm` — sends the reflection through a frontier model and parses back JSON.
- `parse_judge_response` tries whole-string JSON first, then a `\`\`\`json\`\`\`` fence, then a balanced-brace scan that **correctly skips JSON-string contents** — closes the medium-severity bug from review where the cheap `\{[^{}]*\}` regex would have matched the wrong object.
- `_clip` clamps each dimension to [0, 3] so a single noisy response cannot invalidate a whole pass.

## CLI

```bash
python -m agents.reflector.eval --mode manual --reflection-id <uuid>
python -m agents.reflector.eval --mode llm-judge --reflection-id <uuid>
```

LLM-judge mode raises `SystemExit` with the env var name in the message when the gate is off — fails loudly, never silently.

## Acceptance criteria from #42

- [x] `docs/reflection-eval-rubric.md` exists.
- [x] Scoring tool produces numeric scores per dimension.
- [ ] Soak window run with at least 7 daily reflections scored — **deferred** to operator follow-up against post-merge real traces. Documented in the rubric's "Calibration plan" section.
- [ ] Calibration result documented (LLM-judge accepted/rejected) — **deferred** until soak completes.

This PR ships the rubric and tooling. The 7-day soak runs against real traces accumulating after merge; the calibration result lands in the rubric doc when it's known.

## Test plan

- [x] **Rubric dataclass guards**: out-of-range dimensions rejected; unknown mode rejected; total computed correctly.
- [x] **Manual prompt rendering**: includes reflection text, every dimension, voice violations, previous reflection (or "(none)"), quiet-day acknowledgement.
- [x] **Judge response parsing**: bare JSON, fenced JSON, missing-JSON-raises, **nested-brace edge case** (notes containing literal `{...}` does NOT steal the match), whole-string round-trip.
- [x] **Frontier gate**: default off; truthy values (`1`, `true`, `yes`, `on`, ` true `) enable; falsy (`false`, `no`, `0`, `""`, `off`, `maybe`) disable.
- [x] **Privacy gate**: `score_with_llm` raises before any network call when the env var is unset.
- [x] **Score clamping**: out-of-range model output (`5`, `null`) clamps to `3` / `0`; whole-pass total stays in `[0, 15]`.
- [x] `pytest agent/tests/test_reflector_*.py agent/tests/test_agents_isolation.py` — **169 passing**.
- [x] `ruff check` — clean.

## Privacy summary

| Mode | Where reflection text goes | Gate |
| --- | --- | --- |
| Manual | Stays in the operator's terminal/notes | None — always allowed |
| LLM-judge | Sent to frontier model (default Sonnet) with `data_sensitivity=SANITIZED` | `PEPPER_REFLECTION_EVAL_USE_FRONTIER=true` required |

Reflections are a structured-summary artefact (raw trace text never appears verbatim — the daily prompt summarises). They are inside the privacy invariant per `docs/GUARDRAILS.md`, but they still compress raw content, so the explicit operator opt-in stays.

Closes #42. Closes Epic 04 (#36).