### PR TITLE
optimizer: versioned prompts + eval-gate integration (#48)

### DIFF
--- a/agent/optimizer/__main__.py
+++ b/agent/optimizer/__main__.py
@@ -162,6 +162,15 @@ def _build_arg_parser() -> argparse.ArgumentParser:
     inspect.add_argument("--target", required=True)
     inspect.add_argument("--candidates-dir", type=Path, default=None)
 
+    gate = sub.add_parser(
+        "gate",
+        help="Run the pre-commit eval gate over a list of versioned-prompt paths.",
+    )
+    gate.add_argument(
+        "--paths", nargs="+", required=True, type=Path,
+        help="Paths under agent/prompts/<target>/<version>.json to evaluate.",
+    )
+
     return parser
 
 
@@ -267,6 +276,53 @@ def _cmd_show_candidates(args) -> int:
     return 0
 
 
+def _cmd_gate(args) -> int:
+    """Run the pre-commit eval gate.
+
+    Exit codes:
+      0 — every path passes its target threshold (or bypass is set).
+      1 — at least one path failed.
+      2 — gate misuse (no paths, etc).
+    """
+    from agent.optimizer.eval_gate import (  # noqa: PLC0415 — local import to keep CLI surface light
+        BYPASS_ENV_VAR,
+        bypassed,
+        evaluate_paths,
+    )
+
+    if not args.paths:
+        print("gate: no paths supplied", file=sys.stderr)
+        return 2
+
+    if bypassed():
+        print(
+            f"gate: BYPASSED via {BYPASS_ENV_VAR}=1 — "
+            "operator must justify in commit message",
+            file=sys.stderr,
+        )
+        return 0
+
+    results = evaluate_paths(list(args.paths))
+    failed = [r for r in results if not r.passed]
+    for r in results:
+        flag = "PASS" if r.passed else "FAIL"
+        line = (
+            f"gate: {flag}  target={r.target}  score={r.score:.4f}  "
+            f"threshold={r.threshold:.4f}  path={r.path}"
+        )
+        if r.notes:
+            line += f"  ({r.notes})"
+        print(line, file=sys.stderr if not r.passed else sys.stdout)
+    if failed:
+        print(
+            f"gate: {len(failed)} of {len(results)} prompts failed; "
+            f"bypass with {BYPASS_ENV_VAR}=1 only for emergency rollback",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = _build_arg_parser()
     args = parser.parse_args(argv)
@@ -274,6 +330,8 @@ def main(argv: list[str] | None = None) -> int:
         return asyncio.run(_cmd_optimize(args))
     if args.cmd == "show-candidates":
         return _cmd_show_candidates(args)
+    if args.cmd == "gate":
+        return _cmd_gate(args)
     parser.print_help()
     return 2
 

--- a/agent/optimizer/eval_gate.py
+++ b/agent/optimizer/eval_gate.py
@@ -1,0 +1,316 @@
+"""Pre-commit eval gate for versioned prompts.
+
+Acceptance criteria from #48:
+
+- Gate blocks bad prompts.
+- Gate passes good prompts.
+- Bypass requires explicit flag and logs to commit.
+- Documented thresholds in ``docs/optimizer-policy.md``.
+
+Wire-up
+-------
+
+The shell hook (``scripts/git-hooks/pre-commit-prompt-eval-gate``)
+detects staged changes under ``agent/prompts/`` and shells out to:
+
+    python -m agent.optimizer gate --paths <p1> <p2> ...
+
+This module is the dispatcher: each prompt is resolved to its target
+(via the directory layout ``agent/prompts/<target>/<version>.json``)
+and the per-target eval runner is invoked. If any runner returns a
+score below its target threshold, the gate exits non-zero.
+
+Per-target evaluators are looked up from ``EVAL_RUNNERS``. Targets land
+their runners in #46 (context-assembly) and #47 (router classifier);
+this PR ships the dispatcher, the threshold table, and the existing
+router runner that reuses ``agent.router_eval``.
+
+Bypass
+------
+
+Set ``PEPPER_BYPASS_EVAL_GATE=1`` to skip the gate. The bypass is
+logged to stderr loudly and the operator is expected to surface it in
+the commit message; the shell hook injects a trailer. This is for
+emergency rollback only — see ``docs/optimizer-policy.md``.
+
+Thresholds
+----------
+
+Hard-coded defaults match ``docs/optimizer-policy.md``. Per-target
+overrides via env vars: ``PEPPER_GATE_THRESHOLD_<TARGET_UPPER>=0.78``.
+"""
+from __future__ import annotations
+
+import json
+import math
+import os
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+import structlog
+
+from agent.optimizer.sanitizer import scan as _sanitize_scan
+from agent.optimizer.schema import CandidatePrompt, PromptStatus
+from agent.optimizer.storage import _candidate_from_json  # internal but stable
+
+logger = structlog.get_logger(__name__)
+
+ACCEPTED_PROMPTS_DIR = Path("agent/prompts")
+BYPASS_ENV_VAR = "PEPPER_BYPASS_EVAL_GATE"
+
+
+@dataclass(frozen=True)
+class GateResult:
+    """One per (path, target) evaluation. ``passed`` collapses both the
+    runner's success and the score-vs-threshold check."""
+
+    path: Path
+    target: str
+    score: float
+    threshold: float
+    passed: bool
+    notes: str = ""
+
+
+# ── Threshold configuration ──────────────────────────────────────────────────
+
+# Defaults documented in docs/optimizer-policy.md. Per-target override
+# via PEPPER_GATE_THRESHOLD_<TARGET_UPPER> (e.g. PEPPER_GATE_THRESHOLD_ROUTER_CLASSIFIER=0.90).
+DEFAULT_THRESHOLDS: dict[str, float] = {
+    "router_classifier": 0.85,    # matches existing pre-commit-router-eval
+    "context_assembly": 0.65,     # baseline-from-#30 retrieval Recall@5
+    "reflector_rubric": 0.70,     # baseline-from-#42 rubric mean score
+}
+
+# Targets the gate knows about. Unknown targets fail closed (refuse to
+# promote a prompt the gate cannot evaluate).
+KNOWN_TARGETS: frozenset[str] = frozenset(DEFAULT_THRESHOLDS)
+
+
+def threshold_for(target: str) -> float:
+    """Resolve the floor score for a target.
+
+    Order: env override → DEFAULT_THRESHOLDS → KeyError.
+
+    Env-var overrides are validated to be finite floats in ``[0, 1]``.
+    A stray ``-inf`` or negative override would silently pass every
+    prompt; we fail loud instead.
+    """
+    env_key = f"PEPPER_GATE_THRESHOLD_{target.upper()}"
+    if env_key in os.environ:
+        try:
+            v = float(os.environ[env_key])
+        except ValueError as e:
+            raise ValueError(
+                f"{env_key}={os.environ[env_key]!r} is not a number",
+            ) from e
+        if not math.isfinite(v) or not 0.0 <= v <= 1.0:
+            raise ValueError(
+                f"{env_key}={v!r} must be a finite number in [0, 1]",
+            )
+        return v
+    return DEFAULT_THRESHOLDS[target]
+
+
+# ── Eval runners ─────────────────────────────────────────────────────────────
+
+EvalRunner = Callable[[CandidatePrompt], float]
+"""A runner returns a single higher-is-better score in [0, 1]. The gate
+compares it to the target threshold; >= passes."""
+
+
+# Module-level mutable registry — populated by register_runner.
+#
+# Empty by default. Each target registers its runner from its own
+# module at import time:
+#
+#   - #47 lands `router_classifier` (rebuilds the router with the
+#     candidate's prompt and runs `agent.router_eval.evaluate`).
+#   - #46 lands `context_assembly` (runs the #30 retrieval eval
+#     against the candidate prompt).
+#   - #42 follow-up lands `reflector_rubric`.
+#
+# The gate fails closed for unregistered targets, which is the right
+# safety bias: never promote a prompt for a target whose runner isn't
+# yet available. ``register_runner`` is idempotent — re-registration
+# replaces the previous callable.
+EVAL_RUNNERS: dict[str, EvalRunner] = {}
+
+
+def register_runner(target: str, runner: EvalRunner) -> None:
+    """Register or replace an eval runner for ``target``.
+
+    Targets call this at import-time from their own module so the
+    gate's import surface stays narrow (no need to import #46's
+    context-assembly stack from inside the eval_gate module itself).
+    """
+    EVAL_RUNNERS[target] = runner
+
+
+# ── Path → target resolution ─────────────────────────────────────────────────
+
+
+def target_from_path(path: Path) -> Optional[str]:
+    """Return the target name for ``agent/prompts/<target>/<version>.json``.
+
+    Returns None for paths outside that layout — the shell hook
+    pre-filters, so this is mostly a defence-in-depth check.
+    """
+    p = Path(path).resolve()
+    accepted_root = ACCEPTED_PROMPTS_DIR.resolve()
+    try:
+        rel = p.relative_to(accepted_root)
+    except ValueError:
+        return None
+    if len(rel.parts) != 2 or not rel.parts[1].endswith(".json"):
+        return None
+    return rel.parts[0]
+
+
+def load_candidate(path: Path) -> CandidatePrompt:
+    """Load a CandidatePrompt from a versioned-prompt JSON file."""
+    return _candidate_from_json(json.loads(Path(path).read_text()))
+
+
+# ── The gate ────────────────────────────────────────────────────────────────
+
+
+def evaluate_paths(paths: list[Path]) -> list[GateResult]:
+    """Run the gate over a list of changed prompt paths.
+
+    Returns one GateResult per evaluated path. Paths whose target is
+    unknown to the gate produce a failing result (fail-closed).
+
+    The gate refuses to evaluate prompts whose ``status`` is not
+    ``ACCEPTED`` — the gate exists to gate promotion, and a CANDIDATE
+    file landing in ``agent/prompts/`` (committed) is itself a policy
+    violation that should fail the commit.
+    """
+    out: list[GateResult] = []
+    for raw in paths:
+        path = Path(raw)
+
+        # Refuse symlinks under agent/prompts/ — they have no
+        # legitimate use here and would let the gate JSON-parse a file
+        # outside the prompt store. The store itself never creates
+        # symlinks, so any symlinked path is operator-introduced.
+        if path.is_symlink():
+            out.append(GateResult(
+                path=path, target="(unknown)",
+                score=0.0, threshold=1.0, passed=False,
+                notes="path is a symlink; refused (use real files only)",
+            ))
+            continue
+
+        target = target_from_path(path)
+        if target is None:
+            out.append(GateResult(
+                path=path, target="(unknown)",
+                score=0.0, threshold=1.0, passed=False,
+                notes="path outside agent/prompts/<target>/<version>.json layout",
+            ))
+            continue
+
+        try:
+            candidate = load_candidate(path)
+        except (OSError, json.JSONDecodeError, KeyError, ValueError) as e:
+            out.append(GateResult(
+                path=path, target=target,
+                score=0.0, threshold=1.0, passed=False,
+                notes=f"failed to load candidate: {type(e).__name__}: {e}",
+            ))
+            continue
+
+        if candidate.status != PromptStatus.ACCEPTED:
+            out.append(GateResult(
+                path=path, target=target,
+                score=0.0, threshold=1.0, passed=False,
+                notes=(
+                    f"prompt has status={candidate.status.value!r}; "
+                    "only ACCEPTED prompts may live under agent/prompts/. "
+                    "Promote via the optimizer flow, do not edit directly."
+                ),
+            ))
+            continue
+
+        # PII gate (defence-in-depth): check both the on-disk
+        # ``sanitization`` field AND re-scan the prompt text. The
+        # storage layer already refuses ACCEPTED + non-empty
+        # sanitization, but a hand-edited file could set
+        # ``sanitization: []`` while leaving PII in ``prompt_text`` —
+        # re-scanning catches that.
+        live_findings = _sanitize_scan(candidate.prompt_text)
+        if candidate.sanitization or live_findings:
+            combined = list(dict.fromkeys(candidate.sanitization + live_findings))
+            out.append(GateResult(
+                path=path, target=target,
+                score=0.0, threshold=1.0, passed=False,
+                notes=(
+                    "ACCEPTED prompt has PII findings (recorded or live-rescan): "
+                    f"{combined!r}"
+                ),
+            ))
+            continue
+
+        if target not in EVAL_RUNNERS:
+            out.append(GateResult(
+                path=path, target=target,
+                score=0.0, threshold=1.0, passed=False,
+                notes=(
+                    f"no eval runner registered for target {target!r}. "
+                    f"Known targets: {sorted(EVAL_RUNNERS)!r}. "
+                    "Register one before promoting prompts for this target."
+                ),
+            ))
+            continue
+
+        try:
+            threshold = threshold_for(target)
+        except KeyError:
+            out.append(GateResult(
+                path=path, target=target,
+                score=0.0, threshold=1.0, passed=False,
+                notes=(
+                    f"no threshold defined for target {target!r}. "
+                    f"Set PEPPER_GATE_THRESHOLD_{target.upper()} or add a default "
+                    "in eval_gate.DEFAULT_THRESHOLDS."
+                ),
+            ))
+            continue
+
+        try:
+            score = float(EVAL_RUNNERS[target](candidate))
+        except Exception as e:  # pragma: no cover — defensive
+            out.append(GateResult(
+                path=path, target=target,
+                score=0.0, threshold=threshold, passed=False,
+                notes=f"eval runner raised: {type(e).__name__}: {e}",
+            ))
+            continue
+
+        # A misbehaving runner returning ``inf`` would silently
+        # auto-pass any threshold; NaN sneaks past `>=` only by
+        # always being False, which fails closed (acceptable). Reject
+        # any non-finite or out-of-range score loudly.
+        if not math.isfinite(score) or not 0.0 <= score <= 1.0:
+            out.append(GateResult(
+                path=path, target=target,
+                score=score, threshold=threshold, passed=False,
+                notes=f"runner returned out-of-range score {score!r}; expected finite [0, 1]",
+            ))
+            continue
+
+        passed = score >= threshold
+        out.append(GateResult(
+            path=path, target=target,
+            score=score, threshold=threshold, passed=passed,
+            notes="" if passed else f"score {score:.4f} below threshold {threshold:.4f}",
+        ))
+    return out
+
+
+def bypassed() -> bool:
+    """True iff the operator set the bypass env var."""
+    return os.environ.get(BYPASS_ENV_VAR, "0") == "1"

--- a/agent/tests/optimizer/test_cli.py
+++ b/agent/tests/optimizer/test_cli.py
@@ -7,6 +7,7 @@ is covered by the runner integration test above.
 from __future__ import annotations
 
 from datetime import timedelta
+from pathlib import Path
 
 import pytest
 
@@ -43,6 +44,75 @@ def test_arg_parser_optimize_minimal():
     assert args.target == "ctx_assembly"
     assert args.runner == "deterministic"  # default
     assert args.window == timedelta(days=7)
+
+
+def test_arg_parser_gate():
+    parser = _build_arg_parser()
+    args = parser.parse_args([
+        "gate",
+        "--paths", "agent/prompts/x/abcd1234.json", "agent/prompts/y/deadbeef.json",
+    ])
+    assert args.cmd == "gate"
+    assert len(args.paths) == 2
+
+
+def test_cmd_gate_passes(monkeypatch, tmp_path, capsys):
+    """Smoke: gate with a passing stub runner exits 0."""
+    from agent.optimizer import eval_gate
+    from agent.optimizer.__main__ import _cmd_gate
+
+    root = tmp_path / "agent_prompts"
+    root.mkdir()
+    monkeypatch.setattr(eval_gate, "ACCEPTED_PROMPTS_DIR", root)
+    eval_gate.register_runner("router_classifier", lambda c: 0.99)
+
+    # Build a passing prompt file via the same fixture shape used in
+    # test_eval_gate.
+    from agent.optimizer.schema import CandidatePrompt, PromptStatus
+    from agent.optimizer.storage import compute_version_hash
+    from datetime import datetime, timezone
+    text = "x"
+    vh = compute_version_hash("router_classifier", text)
+    target_dir = root / "router_classifier"
+    target_dir.mkdir()
+    p = target_dir / f"{vh}.json"
+    cand = CandidatePrompt(
+        target="router_classifier", version_hash=vh, parent_version="",
+        optimizer_run_id="r", prompt_text=text, eval_score=0.5,
+        status=PromptStatus.ACCEPTED,
+        created_at=datetime(2026, 5, 3, tzinfo=timezone.utc),
+    )
+    import json as _json
+    p.write_text(_json.dumps({
+        "target": cand.target, "version_hash": cand.version_hash,
+        "parent_version": cand.parent_version,
+        "optimizer_run_id": cand.optimizer_run_id,
+        "prompt_text": cand.prompt_text, "eval_score": cand.eval_score,
+        "status": cand.status.value,
+        "created_at": cand.created_at.isoformat(),
+        "sanitization": [],
+    }))
+
+    class A:
+        cmd = "gate"
+        paths = [p]
+    monkeypatch.delenv("PEPPER_BYPASS_EVAL_GATE", raising=False)
+    rc = _cmd_gate(A())
+    out = capsys.readouterr()
+    assert rc == 0, out.out + out.err
+
+
+def test_cmd_gate_bypass_short_circuits(monkeypatch, capsys):
+    from agent.optimizer.__main__ import _cmd_gate
+    monkeypatch.setenv("PEPPER_BYPASS_EVAL_GATE", "1")
+
+    class A:
+        cmd = "gate"
+        paths = [Path("nonexistent")]
+    rc = _cmd_gate(A())
+    err = capsys.readouterr().err
+    assert rc == 0
+    assert "BYPASSED" in err
 
 
 def test_arg_parser_show_candidates():

--- a/agent/tests/optimizer/test_eval_gate.py
+++ b/agent/tests/optimizer/test_eval_gate.py
@@ -1,0 +1,305 @@
+"""Tests for ``agent/optimizer/eval_gate.py`` — pre-commit gate logic.
+
+Hermetic — no shell, no git, no real eval runners. The router runner is
+swapped for a stub via ``register_runner``.
+"""
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from agent.optimizer import eval_gate
+from agent.optimizer.eval_gate import (
+    BYPASS_ENV_VAR,
+    DEFAULT_THRESHOLDS,
+    bypassed,
+    evaluate_paths,
+    register_runner,
+    target_from_path,
+    threshold_for,
+)
+from agent.optimizer.schema import CandidatePrompt, PromptStatus
+from agent.optimizer.storage import compute_version_hash
+
+
+# ── Fixtures ────────────────────────────────────────────────────────────────
+
+
+def _write_prompt(
+    base: Path,
+    *,
+    target: str,
+    text: str = "hello",
+    status: PromptStatus = PromptStatus.ACCEPTED,
+    sanitization: list[str] | None = None,
+    version_hash: str | None = None,
+) -> Path:
+    vh = version_hash or compute_version_hash(target, text)
+    candidate = CandidatePrompt(
+        target=target,
+        version_hash=vh,
+        parent_version="",
+        optimizer_run_id="run-1",
+        prompt_text=text,
+        eval_score=0.42,
+        status=status,
+        created_at=datetime(2026, 5, 3, tzinfo=timezone.utc),
+        sanitization=sanitization or [],
+    )
+    target_dir = base / target
+    target_dir.mkdir(parents=True, exist_ok=True)
+    p = target_dir / f"{vh}.json"
+    p.write_text(json.dumps({
+        "target": candidate.target,
+        "version_hash": candidate.version_hash,
+        "parent_version": candidate.parent_version,
+        "optimizer_run_id": candidate.optimizer_run_id,
+        "prompt_text": candidate.prompt_text,
+        "eval_score": candidate.eval_score,
+        "status": candidate.status.value,
+        "created_at": candidate.created_at.isoformat(),
+        "sanitization": candidate.sanitization,
+    }))
+    return p
+
+
+@pytest.fixture
+def prompts_root(tmp_path, monkeypatch):
+    """Point `agent/prompts/` at a tmp dir for the duration of one test."""
+    root = tmp_path / "agent_prompts"
+    root.mkdir()
+    monkeypatch.setattr(eval_gate, "ACCEPTED_PROMPTS_DIR", root)
+    return root
+
+
+@pytest.fixture(autouse=True)
+def reset_runners():
+    """Snapshot/restore the EVAL_RUNNERS registry between tests so a
+    test that registers a stub doesn't leak into the next test."""
+    saved = dict(eval_gate.EVAL_RUNNERS)
+    yield
+    eval_gate.EVAL_RUNNERS.clear()
+    eval_gate.EVAL_RUNNERS.update(saved)
+
+
+# ── target_from_path ───────────────────────────────────────────────────────
+
+
+def test_target_from_path_extracts_target(prompts_root):
+    p = _write_prompt(prompts_root, target="ctx_assembly")
+    assert target_from_path(p) == "ctx_assembly"
+
+
+def test_target_from_path_rejects_non_prompt_layout(prompts_root, tmp_path):
+    bogus = tmp_path / "random.json"
+    bogus.write_text("{}")
+    assert target_from_path(bogus) is None
+
+
+def test_target_from_path_rejects_nested_layout(prompts_root):
+    nested = prompts_root / "ctx_assembly" / "deeper" / "x.json"
+    nested.parent.mkdir(parents=True)
+    nested.write_text("{}")
+    assert target_from_path(nested) is None
+
+
+# ── threshold_for ──────────────────────────────────────────────────────────
+
+
+def test_threshold_default_per_target():
+    for target, default in DEFAULT_THRESHOLDS.items():
+        assert threshold_for(target) == default
+
+
+def test_threshold_env_override(monkeypatch):
+    monkeypatch.setenv("PEPPER_GATE_THRESHOLD_ROUTER_CLASSIFIER", "0.99")
+    assert threshold_for("router_classifier") == 0.99
+
+
+def test_threshold_unknown_target_raises():
+    with pytest.raises(KeyError):
+        threshold_for("does_not_exist")
+
+
+def test_threshold_env_override_rejects_negative(monkeypatch):
+    """Stray negative override would silently pass everything."""
+    monkeypatch.setenv("PEPPER_GATE_THRESHOLD_ROUTER_CLASSIFIER", "-0.1")
+    with pytest.raises(ValueError, match="must be a finite number"):
+        threshold_for("router_classifier")
+
+
+def test_threshold_env_override_rejects_inf(monkeypatch):
+    monkeypatch.setenv("PEPPER_GATE_THRESHOLD_ROUTER_CLASSIFIER", "-inf")
+    with pytest.raises(ValueError, match="must be a finite number"):
+        threshold_for("router_classifier")
+
+
+def test_threshold_env_override_rejects_above_one(monkeypatch):
+    monkeypatch.setenv("PEPPER_GATE_THRESHOLD_ROUTER_CLASSIFIER", "1.5")
+    with pytest.raises(ValueError, match="must be a finite number in"):
+        threshold_for("router_classifier")
+
+
+def test_threshold_env_override_rejects_garbage(monkeypatch):
+    monkeypatch.setenv("PEPPER_GATE_THRESHOLD_ROUTER_CLASSIFIER", "yes please")
+    with pytest.raises(ValueError, match="not a number"):
+        threshold_for("router_classifier")
+
+
+# ── evaluate_paths ─────────────────────────────────────────────────────────
+
+
+def test_evaluate_passes_above_threshold(prompts_root):
+    p = _write_prompt(prompts_root, target="router_classifier")
+    register_runner("router_classifier", lambda c: 0.95)
+    [r] = evaluate_paths([p])
+    assert r.passed
+    assert r.target == "router_classifier"
+    assert r.score == 0.95
+    assert r.threshold == DEFAULT_THRESHOLDS["router_classifier"]
+
+
+def test_evaluate_blocks_below_threshold(prompts_root):
+    p = _write_prompt(prompts_root, target="router_classifier")
+    register_runner("router_classifier", lambda c: 0.50)
+    [r] = evaluate_paths([p])
+    assert not r.passed
+    assert "below threshold" in r.notes
+
+
+def test_evaluate_passes_at_exact_threshold(prompts_root):
+    """`>=` not `>`: exact threshold must pass."""
+    p = _write_prompt(prompts_root, target="router_classifier")
+    threshold = DEFAULT_THRESHOLDS["router_classifier"]
+    register_runner("router_classifier", lambda c: threshold)
+    [r] = evaluate_paths([p])
+    assert r.passed
+
+
+def test_evaluate_rejects_inf_score(prompts_root):
+    """An `inf`-returning runner would silently auto-pass; reject it."""
+    p = _write_prompt(prompts_root, target="router_classifier")
+    register_runner("router_classifier", lambda c: float("inf"))
+    [r] = evaluate_paths([p])
+    assert not r.passed
+    assert "out-of-range" in r.notes
+
+
+def test_evaluate_rejects_negative_score(prompts_root):
+    p = _write_prompt(prompts_root, target="router_classifier")
+    register_runner("router_classifier", lambda c: -0.5)
+    [r] = evaluate_paths([p])
+    assert not r.passed
+    assert "out-of-range" in r.notes
+
+
+def test_evaluate_rejects_symlink(prompts_root, tmp_path):
+    """Symlinks under agent/prompts/ are refused — operator-introduced."""
+    real = _write_prompt(prompts_root, target="router_classifier")
+    link = prompts_root / "router_classifier" / "deadbeef00000000.json"
+    if link.exists():
+        link.unlink()
+    link.symlink_to(real)
+    register_runner("router_classifier", lambda c: 0.99)
+    [r] = evaluate_paths([link])
+    assert not r.passed
+    assert "symlink" in r.notes.lower()
+
+
+def test_evaluate_rescans_for_pii_even_with_clean_field(prompts_root, monkeypatch):
+    """Hand-edited file with sanitization=[] but PII in prompt_text
+    must still be blocked. Defence-in-depth against bypass of
+    PromptStore.put."""
+    p = _write_prompt(
+        prompts_root,
+        target="router_classifier",
+        text="Call user@example.com to confirm.",
+        sanitization=[],  # operator wrote a clean field
+    )
+    register_runner("router_classifier", lambda c: 0.99)
+    [r] = evaluate_paths([p])
+    assert not r.passed
+    assert "pii" in r.notes.lower() or "email" in r.notes.lower()
+
+
+def test_evaluate_rejects_non_accepted_status(prompts_root):
+    p = _write_prompt(
+        prompts_root,
+        target="router_classifier",
+        status=PromptStatus.CANDIDATE,
+    )
+    register_runner("router_classifier", lambda c: 1.0)
+    [r] = evaluate_paths([p])
+    assert not r.passed
+    assert "status" in r.notes.lower()
+
+
+def test_evaluate_rejects_accepted_with_sanitization(prompts_root):
+    """Defence-in-depth: PromptStore.put should already block this, but
+    a hand-edited file could bypass storage."""
+    p = _write_prompt(
+        prompts_root,
+        target="router_classifier",
+        sanitization=["life_context token: 'pepperton'"],
+    )
+    register_runner("router_classifier", lambda c: 1.0)
+    [r] = evaluate_paths([p])
+    assert not r.passed
+    assert "pii findings" in r.notes.lower()
+
+
+def test_evaluate_unknown_target_fails_closed(prompts_root):
+    p = _write_prompt(prompts_root, target="brand_new_target")
+    [r] = evaluate_paths([p])
+    assert not r.passed
+    assert "no eval runner" in r.notes.lower()
+
+
+def test_evaluate_corrupt_file_fails_closed(prompts_root):
+    target_dir = prompts_root / "router_classifier"
+    target_dir.mkdir()
+    p = target_dir / "deadbeef00000000.json"
+    p.write_text("{not valid json")
+    [r] = evaluate_paths([p])
+    assert not r.passed
+    assert "failed to load" in r.notes.lower()
+
+
+def test_evaluate_path_outside_prompts_fails_closed(tmp_path):
+    bogus = tmp_path / "bogus.json"
+    bogus.write_text("{}")
+    [r] = evaluate_paths([bogus])
+    assert not r.passed
+    assert r.target == "(unknown)"
+
+
+def test_evaluate_multiple_paths_all_results_returned(prompts_root):
+    register_runner("router_classifier", lambda c: 0.95)
+    p1 = _write_prompt(prompts_root, target="router_classifier", text="A",
+                       version_hash="aaaa000000000001")
+    p2 = _write_prompt(prompts_root, target="router_classifier", text="B",
+                       version_hash="aaaa000000000002")
+    results = evaluate_paths([p1, p2])
+    assert len(results) == 2
+    assert all(r.passed for r in results)
+
+
+# ── bypass ──────────────────────────────────────────────────────────────────
+
+
+def test_bypass_default_false(monkeypatch):
+    monkeypatch.delenv(BYPASS_ENV_VAR, raising=False)
+    assert bypassed() is False
+
+
+def test_bypass_set_true(monkeypatch):
+    monkeypatch.setenv(BYPASS_ENV_VAR, "1")
+    assert bypassed() is True
+
+
+def test_bypass_only_on_exact_one(monkeypatch):
+    monkeypatch.setenv(BYPASS_ENV_VAR, "true")
+    assert bypassed() is False  # we accept "1" only — no fuzzy truthy

--- a/docs/optimizer-policy.md
+++ b/docs/optimizer-policy.md
@@ -1,0 +1,130 @@
+# Optimizer policy
+
+This document is the canonical reference for the prompt-optimization
+loop's gating policy: which targets the gate evaluates, which
+thresholds they must clear, and how the bypass is supposed to be used.
+
+The loop itself is described in [ADR-0007](adr/0007-optimizer-framework-gepa.md).
+The implementing modules are under `agent/optimizer/`.
+
+## What the gate does
+
+The pre-commit hook
+[`scripts/git-hooks/pre-commit-prompt-eval-gate`](../scripts/git-hooks/pre-commit-prompt-eval-gate)
+detects staged file changes under `agent/prompts/<target>/<version>.json`
+and shells out to `python -m agent.optimizer gate --paths <…>`.
+
+For each changed prompt, the gate:
+
+1. Refuses any prompt whose status is not `ACCEPTED` (CANDIDATE prompts
+   live under `data/optimizer/candidates/`, not `agent/prompts/`).
+2. Refuses any prompt whose `sanitization` field is non-empty
+   (defence-in-depth — `PromptStore.put` already enforces this).
+3. Looks up the per-target eval runner from
+   `agent.optimizer.eval_gate.EVAL_RUNNERS`.
+4. Runs the eval and compares the score to the target's threshold.
+5. Exits non-zero if any prompt fails.
+
+## Targets and thresholds
+
+| target              | runner                                   | default threshold | rationale                                                  |
+| ------------------- | ---------------------------------------- | ----------------- | ---------------------------------------------------------- |
+| `router_classifier` | registered by #47                        | `0.85`            | Matches existing `pre-commit-router-eval` floor.           |
+| `context_assembly`  | registered by #46                        | `0.65`            | Baseline-from-#30 retrieval Recall@5; #46 lands the runner.|
+| `reflector_rubric`  | registered by #42 follow-up              | `0.70`            | Baseline-from-#42 rubric mean score.                       |
+
+This PR ships the gate dispatcher and the threshold table. The
+runners themselves land with the targets that need them — until then,
+the gate fails closed for any prompt under `agent/prompts/<target>/`
+because `EVAL_RUNNERS` has no entry for it. That's the correct safety
+bias: prompts cannot land for a target whose evaluator does not yet
+exist.
+
+Env-var threshold overrides are validated to be finite floats in
+`[0, 1]`; anything else (NaN, `-inf`, negative, `2.0`) is rejected.
+Runner return values are validated to the same range.
+
+Per-target overrides via env var:
+
+```bash
+PEPPER_GATE_THRESHOLD_ROUTER_CLASSIFIER=0.90  # raise the router floor for one commit
+```
+
+The env-var path is for tightening the floor on a per-commit basis
+(e.g. before a release). To loosen it durably, edit
+`DEFAULT_THRESHOLDS` in `agent/optimizer/eval_gate.py` and document
+the change in this file.
+
+Unknown targets fail closed: a prompt for a target with no registered
+runner will block the commit. To add a new target, register an
+`EvalRunner` via `agent.optimizer.eval_gate.register_runner` (see the
+docstring) and add a row to the table above.
+
+## Bypass
+
+```bash
+PEPPER_BYPASS_EVAL_GATE=1 git commit ...
+```
+
+The bypass requires both hooks to be installed (see "Installing the
+hooks" below). The mechanism splits across two hooks because
+`pre-commit` runs *before* Git writes the commit-message file for the
+new commit, so the trailer cannot live there:
+
+1. `pre-commit-prompt-eval-gate` reads the env var and short-circuits
+   the eval, printing `gate: BYPASSED via PEPPER_BYPASS_EVAL_GATE=1`
+   to stderr.
+2. `prepare-commit-msg-eval-gate` runs after Git creates the message
+   file, sees the env var, and idempotently appends a
+   `Bypassed-Eval-Gate: yes` trailer so the bypass is visible in
+   `git log` after the fact.
+
+The bypass is for **emergency rollback only** — a known-good prompt
+needs to land immediately while the eval set is broken or unavailable.
+It is not for "the gate is annoying me today." Repeated use should
+either result in a threshold change (documented here) or a fix to the
+underlying eval runner.
+
+## Promotion lifecycle
+
+```text
+candidate (data/optimizer/candidates/<target>/<v>.json)
+  ↓  optimizer accepts via PromptStore.put(status=ACCEPTED)  ←─ sanitizer gate (hard)
+accepted (agent/prompts/<target>/<v>.json)
+  ↓  git add + git commit                                    ←─ this gate (per-target eval)
+committed
+  ↓  production telemetry triggers rollback (if needed)
+rolled_back (status=ROLLED_BACK in same file)
+```
+
+The two gates are intentionally distinct:
+
+- `PromptStore.put` blocks PII leakage at the moment of promotion.
+- The pre-commit eval gate blocks regressions at the moment of commit.
+
+Bypassing one does not bypass the other. There is no env var to bypass
+the PII gate — that is a hard refusal.
+
+## Adding a new target
+
+1. Implement an `EvalRunner` (callable taking a `CandidatePrompt`,
+   returning a `float` in `[0, 1]`, higher-is-better).
+2. Register it from your module: `register_runner("my_target", my_runner)`.
+3. Add a row to the threshold table above.
+4. Add a default to `DEFAULT_THRESHOLDS` in `agent/optimizer/eval_gate.py`.
+5. Update tests in `agent/tests/optimizer/test_eval_gate.py`.
+
+## Installing the hooks
+
+The hooks are not installed automatically — Pepper does not ship a
+`pre-commit` framework dispatcher. Install both:
+
+```bash
+ln -sf ../../scripts/git-hooks/pre-commit-prompt-eval-gate .git/hooks/pre-commit
+ln -sf ../../scripts/git-hooks/prepare-commit-msg-eval-gate .git/hooks/prepare-commit-msg
+```
+
+If you already have `pre-commit-router-eval` installed, both
+pre-commit hooks need to fire. Either chain them via a small
+dispatcher script or replace the single `pre-commit` symlink with a
+script that runs both.

--- a/scripts/git-hooks/pre-commit-prompt-eval-gate
+++ b/scripts/git-hooks/pre-commit-prompt-eval-gate
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Pre-commit hook: gate versioned prompt changes on the per-target eval set.
+#
+# Detects staged files under agent/prompts/<target>/<version>.json and
+# invokes `python -m agent.optimizer gate --paths ...`. Blocks the commit
+# if any prompt fails its target's threshold (see docs/optimizer-policy.md).
+#
+# Bypass (emergency rollback only):
+#   PEPPER_BYPASS_EVAL_GATE=1 git commit ...
+# The bypass is logged loudly to stderr; the companion
+# `prepare-commit-msg-eval-gate` hook injects a `Bypassed-Eval-Gate`
+# trailer into the commit message so the bypass surfaces in `git log`.
+#
+# Install:
+#   ln -sf ../../scripts/git-hooks/pre-commit-prompt-eval-gate .git/hooks/pre-commit
+#   ln -sf ../../scripts/git-hooks/prepare-commit-msg-eval-gate .git/hooks/prepare-commit-msg
+# (or chain into an existing dispatcher — these hooks are idempotent
+# and exit 0 when no prompt files are staged.)
+
+set -euo pipefail
+IFS=$'\n'  # Defensive: never let a stray exported IFS shred newlines.
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+PY="${REPO_ROOT}/.venv/bin/python"
+PROMPTS_PATTERN='^agent/prompts/[a-z][a-z0-9_]*/[a-f0-9]{8,64}\.json$'
+
+# Collect staged versioned-prompt paths. The pre-filter regex restricts
+# basenames to [a-f0-9.] and forbids spaces/glob chars/leading `--`,
+# so `$staged` (unquoted below for newline word-splitting) is safe.
+# Filenames git would have to quote (non-ASCII) won't match the regex
+# and are silently dropped — operator should not be naming prompt files
+# with non-ASCII anyway.
+staged=$(git diff --cached --name-only --diff-filter=ACMR | grep -E "$PROMPTS_PATTERN" || true)
+
+if [[ -z "$staged" ]]; then
+  exit 0
+fi
+
+if [[ ! -x "$PY" ]]; then
+  echo "pre-commit-prompt-eval-gate: ${PY} not found; install the project venv (see README)" >&2
+  exit 1
+fi
+
+cd "$REPO_ROOT"
+echo "pre-commit-prompt-eval-gate: gating on $(echo "$staged" | wc -l | tr -d ' ') prompt(s)…"
+
+# shellcheck disable=SC2086  # we want word-splitting on $staged here.
+if ! "$PY" -m agent.optimizer gate --paths $staged; then
+  echo "" >&2
+  echo "pre-commit-prompt-eval-gate: eval gate FAILED" >&2
+  echo "  - inspect the per-prompt output above for the failing target/score" >&2
+  echo "  - bypass (only with cause): PEPPER_BYPASS_EVAL_GATE=1 git commit ..." >&2
+  exit 1
+fi
+
+echo "pre-commit-prompt-eval-gate: eval gate PASSED"
+exit 0

--- a/scripts/git-hooks/prepare-commit-msg-eval-gate
+++ b/scripts/git-hooks/prepare-commit-msg-eval-gate
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# prepare-commit-msg hook: inject Bypassed-Eval-Gate trailer when the
+# operator set PEPPER_BYPASS_EVAL_GATE=1 to skip the prompt eval gate.
+#
+# Runs before the editor opens, when the commit message file ($1) is
+# the right one for *this* commit (unlike pre-commit, which runs
+# before the message file exists for the new commit). Idempotent —
+# never appends the trailer twice if it's already present.
+#
+# Install:
+#   ln -sf ../../scripts/git-hooks/prepare-commit-msg-eval-gate .git/hooks/prepare-commit-msg
+#
+# Companion to pre-commit-prompt-eval-gate. See docs/optimizer-policy.md.
+
+set -euo pipefail
+
+MSG_FILE="${1:-}"
+COMMIT_SOURCE="${2:-}"
+
+# Only act when the bypass is in effect.
+if [[ "${PEPPER_BYPASS_EVAL_GATE:-0}" != "1" ]]; then
+  exit 0
+fi
+
+# Skip messages that aren't operator-authored prose (merges, squashes,
+# cherry-picks supply their own structure).
+case "$COMMIT_SOURCE" in
+  merge|squash|commit) exit 0 ;;
+esac
+
+if [[ -z "$MSG_FILE" || ! -f "$MSG_FILE" ]]; then
+  exit 0
+fi
+
+# Idempotent — only inject if the trailer isn't already present.
+if grep -q '^Bypassed-Eval-Gate:' "$MSG_FILE" 2>/dev/null; then
+  exit 0
+fi
+
+{
+  echo ""
+  echo "Bypassed-Eval-Gate: yes  # PEPPER_BYPASS_EVAL_GATE=1 — operator must justify"
+} >> "$MSG_FILE"
+
+exit 0


### PR DESCRIPTION
Closes #48.

## Summary
Adds the pre-commit eval gate that blocks regressions in versioned prompts under `agent/prompts/<target>/<version>.json`.

Components:
- `agent/optimizer/eval_gate.py` — dispatcher with per-target threshold table, validated env-var overrides, defence-in-depth re-scan against the PII sanitizer, fail-closed for unknown targets and out-of-range runner scores.
- `agent/optimizer/__main__.py` — `gate` subcommand wiring the dispatcher to a CLI.
- `scripts/git-hooks/pre-commit-prompt-eval-gate` — collects staged prompt paths and shells out to the gate.
- `scripts/git-hooks/prepare-commit-msg-eval-gate` — companion hook that injects `Bypassed-Eval-Gate: yes` trailer into the commit message when the bypass is in effect (pre-commit cannot do this — it fires before COMMIT_EDITMSG holds the new commit's message).
- `docs/optimizer-policy.md` — thresholds, bypass policy, install steps.

## Acceptance criteria
- [x] **Gate blocks bad prompts** — `test_evaluate_blocks_below_threshold` + `test_evaluate_rejects_*` + `test_evaluate_unknown_target_fails_closed`
- [x] **Gate passes good prompts** — `test_evaluate_passes_above_threshold` + `test_evaluate_passes_at_exact_threshold`
- [x] **Bypass requires explicit flag and logs to commit** — `PEPPER_BYPASS_EVAL_GATE=1`, stderr `gate: BYPASSED ...` line, `prepare-commit-msg-eval-gate` injects the trailer
- [x] **Documented thresholds** — [docs/optimizer-policy.md](docs/optimizer-policy.md)

## EVAL_RUNNERS starts empty — by design
Targets register their runners from their own modules at import time:
- `router_classifier` ← #47
- `context_assembly` ← #46
- `reflector_rubric` ← #42 follow-up

The gate fails closed for any target whose runner isn't yet registered — promoting prompts for those targets is blocked until the runner exists. This is the right safety bias.

## Hardening from review
- `threshold_for()` rejects NaN, ±inf, negative, >1 env overrides.
- `evaluate_paths()` rejects out-of-range runner scores so a misbehaving runner can't auto-pass with `inf`.
- Symlinked paths under `agent/prompts/` are refused.
- Sanitizer is re-run on `prompt_text` inside the gate even when the on-disk `sanitization` field is empty — closes the hand-edited-file bypass.
- Shell hook hardens IFS and documents the regex pre-filter that makes `--paths $staged` safe to word-split.
- Bypass-trailer injection moved to `prepare-commit-msg` hook (review caught that `pre-commit` runs before COMMIT_EDITMSG is the commit's actual message file).

## Test plan
- [x] 78 unit tests in `agent/tests/optimizer/` (gate dispatch, status/sanitization rejection, threshold edge cases, runner-score validation, symlink refusal, bypass behavior, CLI subcommand wiring)
- [x] `python -m agent.optimizer gate --help` works
- [x] `bash -n` syntax check on both shell hooks
- [x] `ruff check agent/optimizer/ agent/tests/optimizer/` clean