### PR TITLE
optimizer: apply optimization to context-assembly prompts (#46)

### DIFF
--- a/agent/memory.py
+++ b/agent/memory.py
@@ -1,14 +1,11 @@
 from __future__ import annotations
 
 import re
-import json
 import structlog
 from collections import deque
 from datetime import datetime, timedelta
 from typing import Optional
 from sqlalchemy import select, delete, and_, text, func, literal
-from sqlalchemy.ext.asyncio import AsyncSession
-from pgvector.sqlalchemy import Vector
 from agent.models import MemoryEvent, AuditLog
 
 logger = structlog.get_logger()
@@ -572,7 +569,18 @@ class MemoryManager:
         if not all_results:
             return "", []
 
-        lines = ["[Relevant memories from your history]"]
+        # Render the memory-block envelope via the optimizer's
+        # template loader (#46). The active template is whichever
+        # ACCEPTED candidate the operator most recently promoted; it
+        # falls back to DEFAULT_TEMPLATE (the pre-#46 inline format)
+        # when no candidate has landed.
+        from agent.optimizer.adapters.context_assembly import (  # noqa: PLC0415 — local import keeps memory.py importable when optimizer module is absent
+            DEFAULT_TEMPLATE,
+            render_template,
+        )
+        from agent.optimizer.templates import load_active_template  # noqa: PLC0415
+
+        memory_lines: list[str] = []
         for r in all_results:
             age = ""
             try:
@@ -582,10 +590,11 @@ class MemoryManager:
                     age = f" ({delta.days}d ago)"
             except Exception:
                 pass
-            lines.append(f"• {r['content']}{age}")
-        lines.append("[End memories]")
+            memory_lines.append(f"• {r['content']}{age}")
 
-        return "\n".join(lines), all_results
+        template = load_active_template("context_assembly", DEFAULT_TEMPLATE)
+        rendered = render_template(template, "\n".join(memory_lines))
+        return rendered, all_results
 
     # ─── Admin ────────────────────────────────────────────────────────────────
 

--- a/agent/optimizer/__main__.py
+++ b/agent/optimizer/__main__.py
@@ -171,6 +171,22 @@ def _build_arg_parser() -> argparse.ArgumentParser:
         help="Paths under agent/prompts/<target>/<version>.json to evaluate.",
     )
 
+    rollback = sub.add_parser(
+        "rollback",
+        help="Mark an ACCEPTED prompt as ROLLED_BACK so the loader skips it.",
+    )
+    rollback.add_argument("--target", required=True)
+    rollback.add_argument(
+        "--version", required=True,
+        help="version_hash to roll back (look up via show-accepted).",
+    )
+
+    show_accepted = sub.add_parser(
+        "show-accepted",
+        help="List ACCEPTED prompts for a target, newest first.",
+    )
+    show_accepted.add_argument("--target", required=True)
+
     return parser
 
 
@@ -202,16 +218,23 @@ async def _cmd_optimize(args, *, adapter_factory=None) -> int:
     window_until = datetime.now(timezone.utc)
     window_since: Optional[datetime] = window_until - args.window
 
-    # Adapter resolution — see _NullAdapter docstring.
+    # Adapter resolution: tests inject ``adapter_factory``; production
+    # looks up the per-target factory in the adapter registry (#46).
+    # Falls back to ``_NullAdapter`` only when the operator passes a
+    # target with no registered adapter — that's a smoke path.
     if adapter_factory is not None:
         adapter: OptimizerAdapter = adapter_factory(args.target)
     else:
-        print(
-            f"warn: no target adapter registered for {args.target!r}; "
-            "using _NullAdapter (smoke path only — not a real metric)",
-            file=sys.stderr,
-        )
-        adapter = _NullAdapter(args.target)
+        from agent.optimizer.adapters import get_adapter  # noqa: PLC0415
+        try:
+            adapter = get_adapter(args.target)
+        except KeyError:
+            print(
+                f"warn: no target adapter registered for {args.target!r}; "
+                "using _NullAdapter (smoke path only — not a real metric)",
+                file=sys.stderr,
+            )
+            adapter = _NullAdapter(args.target)
 
     # Local import so the CLI module is importable even without the DB layer
     # (e.g. running --help in a stripped environment).
@@ -284,6 +307,12 @@ def _cmd_gate(args) -> int:
       1 — at least one path failed.
       2 — gate misuse (no paths, etc).
     """
+    # Import the adapters package for its side-effect of registering
+    # every shipped target's eval runner into ``eval_gate.EVAL_RUNNERS``.
+    # Without this, the gate would fail closed for every target — even
+    # ones whose runner is supposed to be in-tree (#46 ships
+    # context_assembly).
+    import agent.optimizer.adapters  # noqa: F401, PLC0415
     from agent.optimizer.eval_gate import (  # noqa: PLC0415 — local import to keep CLI surface light
         BYPASS_ENV_VAR,
         bypassed,
@@ -323,6 +352,79 @@ def _cmd_gate(args) -> int:
     return 0
 
 
+def _cmd_rollback(args) -> int:
+    """Roll back an ACCEPTED prompt.
+
+    Reads the candidate from agent/prompts/<target>/<version>.json,
+    flips its status to ROLLED_BACK, and writes it back. The loader
+    (``load_active_template``) then skips it on next call, falling
+    through to the next-most-recent ACCEPTED candidate (or the
+    DEFAULT_TEMPLATE if none remain).
+
+    Exit codes:
+      0 — rollback applied.
+      1 — prompt not found, not ACCEPTED, or rollback rejected.
+    """
+    from agent.optimizer.schema import PromptStatus  # noqa: PLC0415
+    from agent.optimizer.storage import (  # noqa: PLC0415
+        DEFAULT_ACCEPTED_DIR,
+        PromptStore,
+    )
+    store = PromptStore(DEFAULT_ACCEPTED_DIR)
+    cand = store.get(args.target, args.version)
+    if cand is None:
+        print(
+            f"rollback: no prompt found for target={args.target!r} "
+            f"version={args.version!r}",
+            file=sys.stderr,
+        )
+        return 1
+    if cand.status != PromptStatus.ACCEPTED:
+        print(
+            f"rollback: prompt {args.version!r} has status="
+            f"{cand.status.value!r}; only ACCEPTED prompts can be rolled back",
+            file=sys.stderr,
+        )
+        return 1
+    rolled = type(cand)(
+        target=cand.target,
+        version_hash=cand.version_hash,
+        parent_version=cand.parent_version,
+        optimizer_run_id=cand.optimizer_run_id,
+        prompt_text=cand.prompt_text,
+        eval_score=cand.eval_score,
+        status=PromptStatus.ROLLED_BACK,
+        created_at=cand.created_at,
+        sanitization=cand.sanitization,
+    )
+    store.put(rolled)
+    print(
+        f"rollback: target={args.target!r} version={args.version!r} "
+        "marked ROLLED_BACK",
+    )
+    return 0
+
+
+def _cmd_show_accepted(args) -> int:
+    from agent.optimizer.schema import PromptStatus  # noqa: PLC0415
+    from agent.optimizer.storage import (  # noqa: PLC0415
+        DEFAULT_ACCEPTED_DIR,
+        PromptStore,
+    )
+    store = PromptStore(DEFAULT_ACCEPTED_DIR)
+    accepted = store.list(args.target, status=PromptStatus.ACCEPTED)
+    if not accepted:
+        print(f"(no ACCEPTED prompts for target {args.target!r})")
+        return 0
+    for c in accepted:
+        print(
+            f"{c.version_hash}  score={c.eval_score:.4f}  "
+            f"parent={c.parent_version or '(seed)'}  "
+            f"created_at={c.created_at.isoformat()}",
+        )
+    return 0
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = _build_arg_parser()
     args = parser.parse_args(argv)
@@ -332,6 +434,10 @@ def main(argv: list[str] | None = None) -> int:
         return _cmd_show_candidates(args)
     if args.cmd == "gate":
         return _cmd_gate(args)
+    if args.cmd == "rollback":
+        return _cmd_rollback(args)
+    if args.cmd == "show-accepted":
+        return _cmd_show_accepted(args)
     parser.print_help()
     return 2
 

--- a/agent/optimizer/adapters/__init__.py
+++ b/agent/optimizer/adapters/__init__.py
@@ -1,0 +1,63 @@
+"""Per-target optimizer-adapter registry.
+
+Targets register their adapter factory + eval runner from their own
+module at import time. The CLI looks up `--target` here to construct
+the adapter for an `optimize` run; the eval gate looks up the runner
+via ``agent.optimizer.eval_gate.EVAL_RUNNERS`` (which the adapter
+modules also populate).
+
+Two-step API:
+
+- ``register_adapter(target, factory)`` — for the optimization side.
+- ``eval_gate.register_runner(target, runner)`` — for the gate.
+
+Both are called from each adapter module's import.
+
+To make sure the registries are populated before the CLI consults
+them, import this package's ``__init__`` triggers a side-effect
+import of every shipped adapter module (currently just
+``context_assembly``). New target modules need a corresponding line
+below.
+"""
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from agent.optimizer.runners import OptimizerAdapter
+
+AdapterFactory = Callable[[], OptimizerAdapter]
+"""A zero-arg callable returning a fresh adapter instance."""
+
+ADAPTERS: dict[str, AdapterFactory] = {}
+
+
+def register_adapter(target: str, factory: AdapterFactory) -> None:
+    """Register or replace an adapter factory for ``target``.
+
+    Idempotent — re-registration replaces the previous factory.
+    """
+    ADAPTERS[target] = factory
+
+
+def get_adapter(target: str) -> OptimizerAdapter:
+    """Resolve the adapter for ``target``.
+
+    Raises KeyError if no factory is registered. Callers handle the
+    error and surface a clear message so the operator knows which
+    target needs an adapter module.
+    """
+    if target not in ADAPTERS:
+        raise KeyError(
+            f"no adapter registered for target {target!r}. "
+            f"Known targets: {sorted(ADAPTERS)!r}. "
+            "Targets register from their own module's import-time call to "
+            "agent.optimizer.adapters.register_adapter().",
+        )
+    return ADAPTERS[target]()
+
+
+# ── Side-effect imports ──────────────────────────────────────────────────────
+# Each adapter module registers itself at import time. Adding a new target
+# adds one line here.
+
+from agent.optimizer.adapters import context_assembly  # noqa: E402, F401 — registers on import

--- a/agent/optimizer/adapters/context_assembly.py
+++ b/agent/optimizer/adapters/context_assembly.py
@@ -1,0 +1,190 @@
+"""Context-assembly adapter — Epic 05 (#46).
+
+Optimizes the **memory-block envelope** that wraps retrieved memory
+items before they are handed to the LLM. The default template lives
+in this module (``DEFAULT_TEMPLATE``); the production loader at
+``agent.optimizer.templates.load_active_template`` reads the
+most-recent ``ACCEPTED`` candidate and falls back to ``DEFAULT_TEMPLATE``
+when none has been promoted.
+
+Why this is a real target
+-------------------------
+
+The memory-block envelope is the smallest piece of "context-assembly
+prompt" in the codebase that is genuinely model-facing. The retrieval
+ranking itself is embedding-driven (no LLM in the loop, so no prompt
+to optimize there). The memory-block envelope, by contrast, is text
+the LLM reads on every turn — restructuring it (e.g. switching to a
+JSON list, adding usage instructions) plausibly moves comprehension.
+
+What this PR ships
+------------------
+
+- The template extraction and the loader (so candidates can replace
+  the envelope at runtime once promoted).
+- The structural scorer below — verifies a candidate template renders,
+  contains the required ``{memory_lines}`` placeholder, and stays
+  within a sensible byte budget. It is **not** a comprehension delta
+  metric.
+- The mutation set used by ``DeterministicRunner``.
+
+What this PR does NOT ship
+--------------------------
+
+- A real comprehension-delta scorer that runs an LLM against the #30
+  retrieval eval. That requires a model client and a populated
+  ``retrieval_eval_set.jsonl`` (gitignored, owner-only). The hooks
+  exist (``score`` is a method on the adapter), so the operator can
+  swap in a real scorer by subclassing ``ContextAssemblyAdapter`` and
+  re-registering. The acceptance criterion "Eval delta ≥5pp Recall@5"
+  is operator-gated on a real run, not on this PR.
+
+Promotion lifecycle
+-------------------
+
+The same pipeline as every target:
+
+    candidate (data/optimizer/candidates/context_assembly/<v>.json)
+      → eval gate (#48) (re-runs sanitizer, runs this module's runner)
+      → ACCEPTED (agent/prompts/context_assembly/<v>.json) — committed
+
+Rollback to a prior accepted version is a single CLI command:
+
+    python -m agent.optimizer rollback --target context_assembly --version <hash>
+"""
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import TYPE_CHECKING
+
+from agent.optimizer.adapters import register_adapter
+from agent.optimizer.eval_gate import register_runner
+
+if TYPE_CHECKING:  # pragma: no cover — type-only
+    from agent.optimizer.schema import CandidatePrompt, TraceExample
+
+
+TARGET_NAME: str = "context_assembly"
+
+# The baseline envelope. Identical to what `agent/memory.py` has used
+# inline for the last year — extracted here so the optimizer has
+# something to mutate. Kept as a Python constant (rather than a JSON
+# file) so importing this module never depends on the filesystem.
+DEFAULT_TEMPLATE: str = (
+    "[Relevant memories from your history]\n"
+    "{memory_lines}\n"
+    "[End memories]"
+)
+
+# Sanity bounds for a candidate template. Real memory-block envelopes
+# are well under 1KB; anything bigger is either a bug or a
+# pathological optimizer mutation.
+_MAX_TEMPLATE_BYTES: int = 2048
+_REQUIRED_PLACEHOLDER: str = "{memory_lines}"
+
+
+def render_template(template_text: str, memory_lines: str) -> str:
+    """Render the memory block.
+
+    Production callers (``agent/memory.py``) use this. Always uses
+    ``str.replace`` rather than ``.format`` so a candidate template
+    that happens to contain stray ``{`` / ``}`` characters does not
+    raise — the optimizer mutation surface is text, not Python format
+    grammar.
+    """
+    return template_text.replace(_REQUIRED_PLACEHOLDER, memory_lines)
+
+
+def _structural_score(template_text: str) -> float:
+    """Score in [0, 1].
+
+    Today this is a structural sanity check — does the candidate
+    render correctly and stay within a reasonable byte budget. The
+    follow-up (operator-driven) replaces this with an LLM-driven
+    comprehension delta against the #30 retrieval eval.
+    """
+    if _REQUIRED_PLACEHOLDER not in template_text:
+        return 0.0
+    if len(template_text.encode("utf-8", errors="replace")) > _MAX_TEMPLATE_BYTES:
+        return 0.0
+    rendered = render_template(template_text, "• example memory item")
+    if not rendered.strip():
+        return 0.0
+    # Heuristic spread: shorter is better (cheaper context), but a
+    # template that's *too* short usually drops useful guidance.
+    # Map [50, 500] bytes → [1.0, 0.7]; outside drops further.
+    n = len(template_text)
+    if n < 30:
+        return 0.5
+    if n <= 500:
+        # Linear interpolation, anchored at the bounds above.
+        return 1.0 - 0.3 * (max(n - 50, 0) / 450.0)
+    # Above 500B keep penalising linearly down to the byte-budget cap.
+    return max(0.4 - 0.3 * (n - 500) / (_MAX_TEMPLATE_BYTES - 500), 0.05)
+
+
+class ContextAssemblyAdapter:
+    """Adapter for the memory-block envelope.
+
+    Implements the ``OptimizerAdapter`` protocol. ``score`` and
+    ``mutate`` are deterministic for a given ``seed``, so the
+    optimizer's reproducibility test holds.
+    """
+
+    target = TARGET_NAME
+
+    def score(self, prompt_text: str, example: "TraceExample") -> float:
+        # The example is unused by the structural scorer; it exists
+        # in the signature so a richer scorer (LLM-driven) can drop
+        # in without changing the call site.
+        del example
+        return _structural_score(prompt_text)
+
+    def mutate(
+        self,
+        prompt_text: str,
+        examples: "Sequence[TraceExample]",
+        seed: int,
+    ) -> list[str]:
+        """Deterministic mutations of the envelope.
+
+        Same ``seed`` → same outputs. The set is intentionally small
+        and structural; richer mutations land via GEPA's reflection
+        step in production runs.
+        """
+        del examples
+        # Each mutation must keep ``{memory_lines}`` to render.
+        return [
+            # 1. JSON-list rewrite, terser.
+            'Memories (most relevant first):\n{memory_lines}',
+            # 2. Add a brief instruction to the LLM about how to use them.
+            (
+                "[Relevant memories from your history]\n"
+                "Use these to ground your answer; cite them when applicable.\n"
+                "{memory_lines}\n"
+                "[End memories]"
+            ),
+            # 3. Trim the closing tag.
+            "[Relevant memories from your history]\n{memory_lines}",
+            # 4. No-op spaces (must NOT be returned because == baseline-after-strip).
+            #    Skipped intentionally — the runner's `if mutated == baseline_prompt`
+            #    filter would catch it but adding it teaches no signal.
+        ]
+
+
+def _eval_runner(candidate: "CandidatePrompt") -> float:
+    """Eval-gate runner for ``context_assembly``.
+
+    Runs the same structural scorer as the adapter. The eval gate's
+    job is to refuse promotion of broken templates; the structural
+    scorer catches the obvious cases (missing placeholder, oversize,
+    empty). When the operator swaps in an LLM-driven adapter the
+    runner can be replaced via ``register_runner`` to match.
+    """
+    return _structural_score(candidate.prompt_text)
+
+
+# ── Registrations (run at import time) ──────────────────────────────────────
+
+register_adapter(TARGET_NAME, ContextAssemblyAdapter)
+register_runner(TARGET_NAME, _eval_runner)

--- a/agent/optimizer/templates.py
+++ b/agent/optimizer/templates.py
@@ -1,0 +1,82 @@
+"""Active-template loader for versioned prompts.
+
+Production code that wants the *current* prompt for an optimizer
+target calls ``load_active_template(target, default)``. The loader
+checks the prompt store for an ``ACCEPTED`` candidate and returns its
+text, falling back to ``default`` if no accepted prompt exists.
+
+Promotion semantics
+-------------------
+
+The optimizer writes ``CANDIDATE`` records to
+``data/optimizer/candidates/<target>/`` (gitignored). Operator
+promotion via the eval gate (#48) writes ``ACCEPTED`` records to
+``agent/prompts/<target>/`` (committed). This loader reads only the
+committed accepted set — never the local candidate set — so production
+code can never accidentally consume an unvetted prompt.
+
+Multiple ``ACCEPTED`` records can coexist for one target (e.g. during
+A/B comparison). The loader picks the most recent by ``created_at``;
+older accepted prompts remain on disk for rollback via the
+``rollback`` CLI subcommand (#46).
+
+Caching
+-------
+
+Templates are read every call by default — the file system access is
+cheap (≤ 100 small files per target) and the loader's callers are not
+on the hot path. Tests can monkeypatch
+``ACCEPTED_PROMPTS_DIR`` to swap the read root.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import structlog
+
+from agent.optimizer.schema import PromptStatus
+from agent.optimizer.storage import DEFAULT_ACCEPTED_DIR, PromptStore
+
+logger = structlog.get_logger(__name__)
+
+# Re-exported so tests can monkeypatch a single name.
+ACCEPTED_PROMPTS_DIR: Path = DEFAULT_ACCEPTED_DIR
+
+
+def load_active_template(target: str, default: str) -> str:
+    """Return the text of the most-recent ACCEPTED prompt for ``target``.
+
+    Returns ``default`` if:
+      - the accepted-prompts directory does not exist,
+      - the target subdirectory does not exist,
+      - no ACCEPTED candidate exists for the target.
+
+    Logs a single ``optimizer.template.loaded`` event with the
+    version_hash so the trace ledger can correlate which prompt was
+    active at the moment a turn ran.
+    """
+    if not ACCEPTED_PROMPTS_DIR.exists():
+        return default
+    store = PromptStore(ACCEPTED_PROMPTS_DIR)
+    accepted = store.list(target, status=PromptStatus.ACCEPTED)
+    if not accepted:
+        return default
+    chosen = accepted[0]  # store.list is sorted newest-first
+    logger.debug(
+        "optimizer.template.loaded",
+        target=target,
+        version_hash=chosen.version_hash,
+    )
+    return chosen.prompt_text
+
+
+def list_accepted_versions(target: str) -> list[str]:
+    """Return version_hashes of ACCEPTED prompts, newest first.
+
+    Used by the ``rollback`` CLI subcommand and by operators inspecting
+    promotion history.
+    """
+    if not ACCEPTED_PROMPTS_DIR.exists():
+        return []
+    store = PromptStore(ACCEPTED_PROMPTS_DIR)
+    return [c.version_hash for c in store.list(target, status=PromptStatus.ACCEPTED)]

--- a/agent/prompts/context_assembly/fdf5eb1653a78988.json
+++ b/agent/prompts/context_assembly/fdf5eb1653a78988.json
@@ -1,0 +1,11 @@
+{
+  "target": "context_assembly",
+  "version_hash": "fdf5eb1653a78988",
+  "parent_version": "",
+  "optimizer_run_id": "baseline-extraction-46",
+  "prompt_text": "[Relevant memories from your history]\n{memory_lines}\n[End memories]",
+  "eval_score": 0.9886666666666667,
+  "status": "accepted",
+  "created_at": "2026-05-03T00:00:00+00:00",
+  "sanitization": []
+}

--- a/agent/tests/optimizer/test_cli.py
+++ b/agent/tests/optimizer/test_cli.py
@@ -102,6 +102,47 @@ def test_cmd_gate_passes(monkeypatch, tmp_path, capsys):
     assert rc == 0, out.out + out.err
 
 
+def test_cmd_gate_passes_committed_baseline(monkeypatch, tmp_path, capsys):
+    """End-to-end (regression): _cmd_gate must pass the committed
+    baseline file for context_assembly.
+
+    The bug this guards: the side-effect import of
+    ``agent.optimizer.adapters`` must run before ``EVAL_RUNNERS`` is
+    consulted. If it doesn't, the gate fails closed on the very
+    baseline this PR commits.
+    """
+    import json as _json
+
+    import agent.optimizer.eval_gate as eval_gate
+    from agent.optimizer.__main__ import _cmd_gate
+    from agent.optimizer.adapters.context_assembly import DEFAULT_TEMPLATE
+    from agent.optimizer.storage import compute_version_hash
+
+    root = tmp_path / "agent_prompts"
+    target_dir = root / "context_assembly"
+    target_dir.mkdir(parents=True)
+    monkeypatch.setattr(eval_gate, "ACCEPTED_PROMPTS_DIR", root)
+
+    vh = compute_version_hash("context_assembly", DEFAULT_TEMPLATE)
+    p = target_dir / f"{vh}.json"
+    p.write_text(_json.dumps({
+        "target": "context_assembly", "version_hash": vh,
+        "parent_version": "", "optimizer_run_id": "baseline",
+        "prompt_text": DEFAULT_TEMPLATE, "eval_score": 0.99,
+        "status": "accepted",
+        "created_at": "2026-05-03T00:00:00+00:00",
+        "sanitization": [],
+    }))
+
+    class A:
+        cmd = "gate"
+        paths = [p]
+    monkeypatch.delenv("PEPPER_BYPASS_EVAL_GATE", raising=False)
+    rc = _cmd_gate(A())
+    out = capsys.readouterr()
+    assert rc == 0, f"gate failed unexpectedly: stdout={out.out!r} stderr={out.err!r}"
+
+
 def test_cmd_gate_bypass_short_circuits(monkeypatch, capsys):
     from agent.optimizer.__main__ import _cmd_gate
     monkeypatch.setenv("PEPPER_BYPASS_EVAL_GATE", "1")

--- a/agent/tests/optimizer/test_context_assembly_adapter.py
+++ b/agent/tests/optimizer/test_context_assembly_adapter.py
@@ -1,0 +1,126 @@
+"""Tests for ``agent/optimizer/adapters/context_assembly.py``."""
+from __future__ import annotations
+
+
+from agent.optimizer.adapters.context_assembly import (
+    DEFAULT_TEMPLATE,
+    TARGET_NAME,
+    ContextAssemblyAdapter,
+    _eval_runner,
+    _structural_score,
+    render_template,
+)
+from agent.optimizer.schema import (
+    CandidatePrompt,
+    PromptStatus,
+    TraceExample,
+)
+from agent.optimizer.storage import compute_version_hash
+
+
+def _ex() -> TraceExample:
+    return TraceExample(
+        trace_id="t1", archetype="orchestrator", prompt_version="v3",
+        input="q", output="a",
+    )
+
+
+def _candidate(text: str) -> CandidatePrompt:
+    return CandidatePrompt(
+        target=TARGET_NAME,
+        version_hash=compute_version_hash(TARGET_NAME, text),
+        parent_version="",
+        optimizer_run_id="r",
+        prompt_text=text,
+        eval_score=0.0,
+        status=PromptStatus.CANDIDATE,
+    )
+
+
+def test_default_template_has_required_placeholder():
+    assert "{memory_lines}" in DEFAULT_TEMPLATE
+
+
+def test_default_template_renders():
+    rendered = render_template(DEFAULT_TEMPLATE, "• A\n• B")
+    assert "[Relevant memories" in rendered
+    assert "• A" in rendered
+
+
+def test_render_template_handles_braces_in_candidate():
+    """Candidate templates may contain stray { or } characters from
+    optimizer mutations. ``render_template`` must not raise — it
+    uses ``str.replace``, not ``str.format``."""
+    weird = "Here are memories: {memory_lines} (note: dict-like {x: 1} examples)"
+    rendered = render_template(weird, "• Z")
+    assert "• Z" in rendered
+    assert "{x: 1}" in rendered
+
+
+def test_structural_score_default_template_is_high():
+    assert _structural_score(DEFAULT_TEMPLATE) > 0.85
+
+
+def test_structural_score_missing_placeholder_is_zero():
+    assert _structural_score("[Relevant memories]\n[End]") == 0.0
+
+
+def test_structural_score_oversized_is_zero():
+    huge = "x" * 5000 + "{memory_lines}"
+    assert _structural_score(huge) == 0.0
+
+
+def test_structural_score_too_short_is_low():
+    score = _structural_score("{memory_lines}")
+    # Short but valid — placeholder present, < 30 bytes → 0.5
+    assert 0.4 <= score <= 0.6
+
+
+def test_adapter_target_name():
+    assert ContextAssemblyAdapter.target == "context_assembly"
+    assert ContextAssemblyAdapter().target == TARGET_NAME
+
+
+def test_adapter_score_uses_structural():
+    a = ContextAssemblyAdapter()
+    assert a.score(DEFAULT_TEMPLATE, _ex()) == _structural_score(DEFAULT_TEMPLATE)
+
+
+def test_adapter_mutate_is_deterministic():
+    a = ContextAssemblyAdapter()
+    m1 = a.mutate(DEFAULT_TEMPLATE, [], 0)
+    m2 = a.mutate(DEFAULT_TEMPLATE, [], 0)
+    assert m1 == m2
+    # All mutations must keep the placeholder, otherwise structural
+    # score is zero and the runner filters them out.
+    for m in m1:
+        assert "{memory_lines}" in m
+
+
+def test_eval_runner_matches_structural_score():
+    cand = _candidate(DEFAULT_TEMPLATE)
+    assert _eval_runner(cand) == _structural_score(DEFAULT_TEMPLATE)
+
+
+def test_adapter_registered_via_registry():
+    """Importing the adapters package triggers the side-effect import
+    of context_assembly, which calls register_adapter and
+    register_runner. Both registries must contain context_assembly."""
+    from agent.optimizer.adapters import ADAPTERS, get_adapter
+    from agent.optimizer.eval_gate import EVAL_RUNNERS
+
+    assert "context_assembly" in ADAPTERS
+    assert "context_assembly" in EVAL_RUNNERS
+    a = get_adapter("context_assembly")
+    assert a.target == "context_assembly"
+
+
+def test_runner_above_threshold(monkeypatch):
+    """Default template scores above the documented 0.65 threshold."""
+    from agent.optimizer.eval_gate import (
+        DEFAULT_THRESHOLDS,
+        EVAL_RUNNERS,
+    )
+    cand = _candidate(DEFAULT_TEMPLATE)
+    score = EVAL_RUNNERS["context_assembly"](cand)
+    assert score >= DEFAULT_THRESHOLDS["context_assembly"]

--- a/agent/tests/optimizer/test_templates.py
+++ b/agent/tests/optimizer/test_templates.py
@@ -1,0 +1,137 @@
+"""Tests for ``agent/optimizer/templates.py`` — active-template loader."""
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from agent.optimizer import templates
+from agent.optimizer.schema import CandidatePrompt, PromptStatus
+from agent.optimizer.storage import compute_version_hash
+
+
+def _write_accepted(
+    base: Path, *, target: str, text: str, when: datetime,
+    status: PromptStatus = PromptStatus.ACCEPTED,
+) -> Path:
+    vh = compute_version_hash(target, text)
+    cand = CandidatePrompt(
+        target=target, version_hash=vh, parent_version="",
+        optimizer_run_id="r", prompt_text=text, eval_score=1.0,
+        status=status, created_at=when, sanitization=[],
+    )
+    target_dir = base / target
+    target_dir.mkdir(parents=True, exist_ok=True)
+    p = target_dir / f"{vh}.json"
+    p.write_text(json.dumps({
+        "target": cand.target, "version_hash": cand.version_hash,
+        "parent_version": cand.parent_version,
+        "optimizer_run_id": cand.optimizer_run_id,
+        "prompt_text": cand.prompt_text, "eval_score": cand.eval_score,
+        "status": cand.status.value,
+        "created_at": cand.created_at.isoformat(),
+        "sanitization": cand.sanitization,
+    }))
+    return p
+
+
+@pytest.fixture
+def prompts_root(tmp_path, monkeypatch):
+    root = tmp_path / "prompts"
+    root.mkdir()
+    monkeypatch.setattr(templates, "ACCEPTED_PROMPTS_DIR", root)
+    return root
+
+
+def test_falls_back_when_no_accepted(prompts_root):
+    assert templates.load_active_template("ctx", "DEFAULT") == "DEFAULT"
+
+
+def test_falls_back_when_root_missing(tmp_path, monkeypatch):
+    monkeypatch.setattr(templates, "ACCEPTED_PROMPTS_DIR", tmp_path / "missing")
+    assert templates.load_active_template("ctx", "DEFAULT") == "DEFAULT"
+
+
+def test_loads_accepted_template(prompts_root):
+    _write_accepted(
+        prompts_root, target="ctx", text="HELLO {memory_lines}",
+        when=datetime(2026, 5, 1, tzinfo=timezone.utc),
+    )
+    assert templates.load_active_template("ctx", "DEFAULT") == "HELLO {memory_lines}"
+
+
+def test_picks_newest_accepted(prompts_root):
+    _write_accepted(
+        prompts_root, target="ctx", text="OLD",
+        when=datetime(2026, 1, 1, tzinfo=timezone.utc),
+    )
+    _write_accepted(
+        prompts_root, target="ctx", text="NEW",
+        when=datetime(2026, 5, 1, tzinfo=timezone.utc),
+    )
+    assert templates.load_active_template("ctx", "DEFAULT") == "NEW"
+
+
+def test_skips_rolled_back(prompts_root):
+    _write_accepted(
+        prompts_root, target="ctx", text="GOOD",
+        when=datetime(2026, 1, 1, tzinfo=timezone.utc),
+    )
+    _write_accepted(
+        prompts_root, target="ctx", text="BAD",
+        when=datetime(2026, 5, 1, tzinfo=timezone.utc),
+        status=PromptStatus.ROLLED_BACK,
+    )
+    # Newer ROLLED_BACK is skipped; older ACCEPTED wins.
+    assert templates.load_active_template("ctx", "DEFAULT") == "GOOD"
+
+
+def test_promote_then_rollback_falls_back_to_previous(prompts_root, monkeypatch):
+    """End-to-end (#46 acceptance): promote a new template, then run
+    the rollback CLI; the loader must return the previous active
+    template.
+    """
+    from agent.optimizer.__main__ import _cmd_rollback
+    from agent.optimizer import storage as storage_mod
+
+    # Point the rollback CLI's PromptStore at the test directory.
+    monkeypatch.setattr(storage_mod, "DEFAULT_ACCEPTED_DIR", prompts_root)
+
+    # Two ACCEPTED templates: an older "OLD" and a newer "NEW".
+    _write_accepted(
+        prompts_root, target="ctx", text="OLD",
+        when=datetime(2026, 1, 1, tzinfo=timezone.utc),
+    )
+    _write_accepted(
+        prompts_root, target="ctx", text="NEW",
+        when=datetime(2026, 5, 1, tzinfo=timezone.utc),
+    )
+    # Loader picks NEW.
+    assert templates.load_active_template("ctx", "DEFAULT") == "NEW"
+
+    # Roll back the NEW one via the CLI.
+    class _Args:
+        target = "ctx"
+        version = compute_version_hash("ctx", "NEW")
+    rc = _cmd_rollback(_Args())
+    assert rc == 0
+
+    # Loader now picks OLD.
+    assert templates.load_active_template("ctx", "DEFAULT") == "OLD"
+
+
+def test_list_accepted_versions(prompts_root):
+    _write_accepted(
+        prompts_root, target="ctx", text="A",
+        when=datetime(2026, 1, 1, tzinfo=timezone.utc),
+    )
+    _write_accepted(
+        prompts_root, target="ctx", text="B",
+        when=datetime(2026, 5, 1, tzinfo=timezone.utc),
+    )
+    versions = templates.list_accepted_versions("ctx")
+    assert len(versions) == 2
+    # Newest first.
+    assert versions[0] == compute_version_hash("ctx", "B")


### PR DESCRIPTION
Closes #46.

## Summary
Wires the `context_assembly` target end-to-end through the optimization loop landed in #45 + #48.

- Extracts the memory-block envelope from `agent/memory.py` into a versioned prompt under [`agent/prompts/context_assembly/fdf5eb1653a78988.json`](agent/prompts/context_assembly/fdf5eb1653a78988.json), with a loader (`agent/optimizer/templates.py`) that reads the most-recent ACCEPTED candidate and falls back to `DEFAULT_TEMPLATE`.
- Adds the per-target adapter registry (`agent/optimizer/adapters/`) and the `ContextAssemblyAdapter`, which scores candidates via a structural sanity check (placeholder present, byte budget).
- Registers the eval-gate runner via the adapter module's import-time `register_runner` call. **Side-effect import in `_cmd_gate` ensures `EVAL_RUNNERS` is populated before the gate runs** — caught in code review, fixed before push.
- Ships the rollback CLI: `python -m agent.optimizer rollback --target context_assembly --version <hash>` flips the candidate to ROLLED_BACK so the loader falls back to the previous active.
- Ships `show-accepted` for inspecting the promotion history.

## Memory.py rewire safety
`build_context_with_provenance` now renders via the loader. Output is byte-identical to the pre-#46 inline format when `DEFAULT_TEMPLATE` is active — the only path the existing memory tests exercise. All 32 pre-existing memory tests still pass.

## Honest deferral on acceptance criteria
- **≥5pp Recall@5 vs baseline**: requires a real LLM-driven scorer running against a populated `retrieval_eval_set.jsonl` (gitignored, owner-only). The hooks exist (subclass `ContextAssemblyAdapter`, swap the scorer, re-register), but the actual delta number is operator-gated. This PR ships the structure, not a number on the scoreboard.
- **Optimized prompt passes #48 eval gate**: the committed baseline does pass — verified in [`test_cmd_gate_passes_committed_baseline`](agent/tests/optimizer/test_cli.py).
- **Rollback path tested**: end-to-end via [`test_promote_then_rollback_falls_back_to_previous`](agent/tests/optimizer/test_templates.py).

## Test plan
- [x] 99 optimizer tests pass (was 78 before this PR; +21)
- [x] 32 memory tests pass (no regression)
- [x] CLI smoke: `python -m agent.optimizer gate --paths agent/prompts/context_assembly/fdf5eb1653a78988.json` → `gate: PASS  target=context_assembly  score=0.9887  threshold=0.6500`
- [x] CLI smoke: `python -m agent.optimizer show-accepted --target context_assembly` lists the baseline
- [x] `ruff check agent/optimizer/ agent/tests/optimizer/ agent/memory.py` clean

## What's left in Epic 05
Only #47 — apply optimization to intent classification (router_classifier target).