### PR TITLE
agent/strategies: data model for the Strategy Hub (#53)

### DIFF
--- a/agent/db.py
+++ b/agent/db.py
@@ -55,6 +55,9 @@ async def init_db(config=None) -> None:
         # `Base.metadata.create_all` runs — the model registers itself
         # with `Base.metadata` only at import time.
         import agent.traces.models  # noqa: F401  (side-effect import)
+        # Epic 06 (#53) — strategies table. Side-effect import for ORM
+        # registration on Base.metadata.
+        import agent.strategies.repository  # noqa: F401  (side-effect import)
 
         # 2. Create all tables defined via Base
         await conn.run_sync(Base.metadata.create_all)
@@ -187,6 +190,12 @@ async def init_db(config=None) -> None:
         from agent.traces.migration import apply_traces_migration
 
         await apply_traces_migration(conn)
+
+        # Epic 06 (#53) — strategies table: HNSW + GIN indexes that
+        # `create_all` cannot express.
+        from agent.strategies.migration import apply_strategies_migration
+
+        await apply_strategies_migration(conn)
 
 
 def get_engine():

--- a/agent/strategies/__init__.py
+++ b/agent/strategies/__init__.py
@@ -1,0 +1,38 @@
+"""Strategy Hub — interpretable decision strategies (PEARL-inspired).
+
+The third memory layer, distinct from facts (memory) and identity. Each
+strategy is a short natural-language sentence describing how Pepper
+chooses to act in a class of situations. Strategies are versioned,
+scored, and source-linked so that a future contributor (or the operator)
+can see *why* Pepper did what it did, and so the reflector can propose
+revisions through the propose-then-approve queue established in
+ADR-0008.
+
+This package ships the data layer. The query/update tools and UI
+inspector land in #54; this issue (#53) is the schema, repository, and
+bootstrap loader.
+
+Privacy posture: strategies are RAW_PERSONAL (they encode patterns about
+people in the operator's life) and live in the same Postgres database
+as traces and memory.
+"""
+
+from agent.strategies.bootstrap import (
+    BOOTSTRAP_STRATEGIES,
+    bootstrap_if_empty,
+)
+from agent.strategies.repository import (
+    Strategy,
+    StrategyCreatedBy,
+    StrategyRepository,
+    StrategyStatus,
+)
+
+__all__ = [
+    "BOOTSTRAP_STRATEGIES",
+    "Strategy",
+    "StrategyCreatedBy",
+    "StrategyRepository",
+    "StrategyStatus",
+    "bootstrap_if_empty",
+]

--- a/agent/strategies/bootstrap.py
+++ b/agent/strategies/bootstrap.py
@@ -1,0 +1,85 @@
+"""Bootstrap loader for the Strategy Hub.
+
+Per #53 acceptance criteria, the table ships with 5–10 hand-authored
+strategies extracted from existing `LIFE_CONTEXT.md`-style heuristics.
+These are the v0 baseline; the reflector adds more through #54's
+propose-update path once it lands.
+
+Each bootstrap strategy is `created_by=bootstrap`, version=1, with no
+source_trace_ids (they predate the trace store), and no embedding (a
+follow-up backfill populates the column once #54 wires the embed
+path).
+
+Re-runnable: `bootstrap_if_empty()` only inserts if no active strategy
+exists yet. Once the table has any active strategy, this function is
+a no-op — the operator owns the table from there on.
+"""
+from __future__ import annotations
+
+import structlog
+
+from agent.strategies.repository import (
+    Strategy,
+    StrategyCreatedBy,
+    StrategyRepository,
+)
+
+logger = structlog.get_logger(__name__)
+
+
+# Hand-authored. Each is one sentence, action-shaped, anchored in a
+# concrete pattern Pepper can detect from traces. Keep this list short
+# (5–10) — these are baselines, not a full operating manual. The
+# operator will iterate as real strategies emerge from reflection.
+BOOTSTRAP_STRATEGIES: tuple[str, ...] = (
+    # Communication / response shape
+    "When asked a factual question I am not certain about, say what I don't know "
+    "before what I do know.",
+    "When the conversation has produced enough information to act, stop summarising "
+    "and propose the next step.",
+    # Restraint
+    "When a scheduled brief is about to surface something Jack already addressed in "
+    "the last 24h, prefer wait over re-surfacing.",
+    "When Jack's affect signals tiredness or stress, deliver only what is time-"
+    "sensitive and hold non-urgent items for the next interaction.",
+    # Truthfulness
+    "If I notice I am about to fabricate a metric or a name, stop and ask Jack to "
+    "confirm rather than guessing.",
+    # Identity / voice
+    "Reflections are notes I write to myself, not briefs for Jack — first-person, "
+    "no audience-shaped framing.",
+    # Operational
+    "Before sending an outbound message on Jack's behalf, route it through the "
+    "pending-actions queue rather than executing directly.",
+    # People
+    "When a recurring person comes up across more than two days in a row, treat "
+    "the recurrence as a signal worth surfacing in the next reflection.",
+)
+
+
+async def bootstrap_if_empty(repo: StrategyRepository) -> int:
+    """Insert the bootstrap strategies iff the table is empty.
+
+    Returns the number of strategies inserted. A non-empty table
+    produces a no-op return of 0. This function is safe to call on
+    every Pepper startup.
+    """
+    existing = await repo.count_active()
+    if existing > 0:
+        logger.info(
+            "strategies_bootstrap_skipped_nonempty",
+            existing_count=existing,
+        )
+        return 0
+
+    inserted = 0
+    for text in BOOTSTRAP_STRATEGIES:
+        await repo.append(
+            Strategy(
+                text=text,
+                created_by=StrategyCreatedBy.BOOTSTRAP,
+            )
+        )
+        inserted += 1
+    logger.info("strategies_bootstrap_loaded", count=inserted)
+    return inserted

--- a/agent/strategies/migration.py
+++ b/agent/strategies/migration.py
@@ -1,0 +1,46 @@
+"""Idempotent post-`create_all` SQL for the `strategies` table.
+
+`create_all` produces the table and the simple b-tree indexes declared
+on `StrategyRow`. The HNSW index over the embedding column cannot be
+expressed in SQLAlchemy and lands here. Same shape as
+`agents/reflector/migration.py`.
+
+Called from `agent.db.init_db()` after `Base.metadata.create_all`.
+"""
+from __future__ import annotations
+
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncConnection
+
+
+async def apply_strategies_migration(conn: AsyncConnection) -> None:
+    """Apply post-create_all DDL for the `strategies` table.
+
+    Idempotent. Uses `IF NOT EXISTS` so re-running on every startup is
+    a no-op after the first successful boot.
+    """
+    # Partial HNSW index on the embedding column. Strategies may briefly
+    # land with NULL embedding (the bootstrap loader writes them text-
+    # only and a follow-up backfill populates the column), and pgvector
+    # rejects nulls inside an HNSW index. Same shape as the reflector's
+    # partial index.
+    await conn.execute(
+        text(
+            """
+            CREATE INDEX IF NOT EXISTS idx_strategies_embedding
+            ON strategies USING hnsw (embedding vector_cosine_ops)
+            WITH (m = 16, ef_construction = 64)
+            WHERE embedding IS NOT NULL
+            """
+        )
+    )
+    # GIN over source_trace_ids — the trace inspector ("which strategies
+    # cite this trace?") is a single GIN-indexed lookup.
+    await conn.execute(
+        text(
+            """
+            CREATE INDEX IF NOT EXISTS idx_strategies_source_trace_ids
+            ON strategies USING gin (source_trace_ids)
+            """
+        )
+    )

--- a/agent/strategies/repository.py
+++ b/agent/strategies/repository.py
@@ -1,0 +1,480 @@
+"""Persistence layer for the `strategies` table.
+
+Append-only at the app layer. A strategy is never edited in place; a
+new version is appended with `parent_strategy_id` pointing at the row
+it supersedes, and the old row's `status` is flipped to `superseded`.
+This mirrors the `reflections` and `traces` discipline.
+
+Schema (per #53):
+
+| Column                     | Type                | Notes                                                        |
+| -------------------------- | ------------------- | ------------------------------------------------------------ |
+| `strategy_id`              | uuid (pk)           | New uuid per row, including new versions                     |
+| `text`                     | text                | The strategy in natural language. Indexed via embedding      |
+| `version`                  | integer             | Monotonic per lineage; v1 for new lineages                   |
+| `parent_strategy_id`       | uuid (nullable)     | Points at the row this version supersedes                    |
+| `created_at`               | timestamptz         | Insertion time                                               |
+| `created_by`               | text (enum)         | `jack` | `reflector` | `bootstrap`                            |
+| `source_trace_ids`         | uuid[]              | Traces that informed the strategy; may be empty for bootstrap |
+| `confidence`               | real (0..1)         | Heuristic v0; revised once we see real strategies            |
+| `usage_count`              | integer             | Bumped by #54's query path                                    |
+| `last_confirmed_correct`   | timestamptz nullable | Bumped by #56's wait-feedback / explicit thumbs              |
+| `status`                   | text (enum)         | `active` | `superseded` | `flagged`                          |
+| `embedding`                | vector(1024)        | qwen3-embedding:0.6b — populated by #54's query path         |
+
+Confidence v0 (documented):
+    confidence = clamp01(0.5 + 0.05 * usage_count + recency_bonus)
+where recency_bonus is +0.2 if `last_confirmed_correct` is within 30 days,
++0.1 within 90 days, 0 otherwise.
+
+Conflict resolution:
+    On insert, the repository's `append_with_contradiction_check` helper
+    is offered a callback (`is_contradicting`) that the caller wires to
+    an LLM-judge in #54. If the callback flags an existing active
+    strategy as contradicted by the new one, the existing row's status
+    is flipped to `flagged` (NOT `superseded` — that requires explicit
+    operator approval). The new row is inserted with status=`active`.
+    A pending-actions notification is the surface; this module emits a
+    structured log line `strategy_contradiction_flagged` with both ids.
+"""
+from __future__ import annotations
+
+import uuid as _uuid
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from typing import Awaitable, Callable, Optional
+
+import structlog
+from pgvector.sqlalchemy import Vector
+from sqlalchemy import (
+    Boolean,
+    DateTime,
+    Float,
+    Index,
+    Integer,
+    String,
+    Text,
+    UniqueConstraint,
+    select,
+    update,
+)
+from sqlalchemy.dialects.postgresql import ARRAY, UUID
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import Mapped, deferred, mapped_column
+
+from agent.db import Base
+
+logger = structlog.get_logger(__name__)
+
+# Mirrors `agent.traces.schema.EMBEDDING_DIM` and reflector's storage.
+# Strategies are surfaced into the system prompt by #54 via similarity
+# search, so they need to share the embedding space with router/recall.
+STRATEGY_EMBEDDING_DIM: int = 1024
+STRATEGY_EMBEDDING_MODEL_DEFAULT: str = "qwen3-embedding:0.6b"
+
+
+class StrategyCreatedBy:
+    """Closed enum of valid `created_by` values.
+
+    Stored as text for forward-compat (no painful enum migration if a
+    new origin is added) but constrained at the Python layer.
+    """
+
+    JACK = "jack"
+    REFLECTOR = "reflector"
+    BOOTSTRAP = "bootstrap"
+
+    ALL: frozenset[str] = frozenset({JACK, REFLECTOR, BOOTSTRAP})
+
+
+class StrategyStatus:
+    """Closed enum of valid `status` values."""
+
+    ACTIVE = "active"
+    SUPERSEDED = "superseded"
+    FLAGGED = "flagged"
+
+    ALL: frozenset[str] = frozenset({ACTIVE, SUPERSEDED, FLAGGED})
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _new_strategy_id() -> _uuid.UUID:
+    return _uuid.uuid4()
+
+
+# ── Dataclass contract ───────────────────────────────────────────────────────
+
+
+@dataclass
+class Strategy:
+    """One persisted strategy.
+
+    Mutability of the dataclass mirrors the mutable column set the
+    repository exposes write paths for (`usage_count`,
+    `last_confirmed_correct`, `status`). The `text`, `version`,
+    `parent_strategy_id`, and `created_*` fields are write-once.
+    """
+
+    text: str
+    created_by: str = StrategyCreatedBy.JACK
+    version: int = 1
+    parent_strategy_id: Optional[_uuid.UUID] = None
+    source_trace_ids: list[_uuid.UUID] = field(default_factory=list)
+    confidence: float = 0.5
+    usage_count: int = 0
+    last_confirmed_correct: Optional[datetime] = None
+    status: str = StrategyStatus.ACTIVE
+    strategy_id: _uuid.UUID = field(default_factory=_new_strategy_id)
+    created_at: datetime = field(default_factory=_utcnow)
+    embedding: Optional[list[float]] = None
+
+    def __post_init__(self) -> None:
+        if not self.text or not self.text.strip():
+            raise ValueError("strategy text cannot be empty")
+        if self.created_by not in StrategyCreatedBy.ALL:
+            raise ValueError(
+                f"strategy created_by must be one of {sorted(StrategyCreatedBy.ALL)}, "
+                f"got {self.created_by!r}"
+            )
+        if self.status not in StrategyStatus.ALL:
+            raise ValueError(
+                f"strategy status must be one of {sorted(StrategyStatus.ALL)}, "
+                f"got {self.status!r}"
+            )
+        if self.version < 1:
+            raise ValueError("strategy version must be >= 1")
+        if not (0.0 <= self.confidence <= 1.0):
+            raise ValueError(
+                f"strategy confidence must be in [0.0, 1.0], got {self.confidence!r}"
+            )
+        if self.embedding is not None and len(self.embedding) != STRATEGY_EMBEDDING_DIM:
+            raise ValueError(
+                f"strategy embedding must have dim {STRATEGY_EMBEDDING_DIM}, "
+                f"got {len(self.embedding)}"
+            )
+
+
+# ── ORM mapping ──────────────────────────────────────────────────────────────
+
+
+class StrategyRow(Base):
+    """Storage projection for `Strategy`. Append-only at the app layer."""
+
+    __tablename__ = "strategies"
+
+    strategy_id: Mapped[_uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        default=_uuid.uuid4,
+    )
+    text: Mapped[str] = mapped_column(Text, nullable=False)
+    version: Mapped[int] = mapped_column(Integer, nullable=False, default=1)
+    parent_strategy_id: Mapped[Optional[_uuid.UUID]] = mapped_column(
+        UUID(as_uuid=True),
+        nullable=True,
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+    )
+    created_by: Mapped[str] = mapped_column(String(32), nullable=False)
+    source_trace_ids: Mapped[list[_uuid.UUID]] = mapped_column(
+        ARRAY(UUID(as_uuid=True)),
+        nullable=False,
+        default=list,
+    )
+    confidence: Mapped[float] = mapped_column(Float, nullable=False, default=0.5)
+    usage_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    last_confirmed_correct: Mapped[Optional[datetime]] = mapped_column(
+        DateTime(timezone=True),
+        nullable=True,
+    )
+    status: Mapped[str] = mapped_column(
+        String(16),
+        nullable=False,
+        default=StrategyStatus.ACTIVE,
+    )
+
+    embedding: Mapped[Optional[list[float]]] = deferred(
+        mapped_column(Vector(STRATEGY_EMBEDDING_DIM), nullable=True),
+    )
+
+    __table_args__ = (
+        Index("idx_strategies_status", "status"),
+        Index("idx_strategies_created_at", "created_at"),
+        Index("idx_strategies_parent", "parent_strategy_id"),
+    )
+
+
+# ── Repository ───────────────────────────────────────────────────────────────
+
+
+def _row_to_dataclass(row: StrategyRow) -> Strategy:
+    return Strategy(
+        text=row.text,
+        version=row.version,
+        parent_strategy_id=row.parent_strategy_id,
+        source_trace_ids=list(row.source_trace_ids or []),
+        confidence=row.confidence,
+        usage_count=row.usage_count,
+        last_confirmed_correct=row.last_confirmed_correct,
+        status=row.status,
+        strategy_id=row.strategy_id,
+        created_at=row.created_at,
+        created_by=row.created_by,
+        embedding=None,  # deferred — callers ask explicitly via `with_embeddings`
+    )
+
+
+def _coerce_uuid(value) -> _uuid.UUID:
+    if isinstance(value, _uuid.UUID):
+        return value
+    return _uuid.UUID(str(value))
+
+
+# Optional callback the caller wires to an LLM-judge (lands in #54). If
+# the callback returns True for `(existing_text, new_text)`, the
+# existing row is `flagged`. If None, no contradiction check is run.
+ContradictionJudge = Callable[[str, str], Awaitable[bool]]
+
+
+def compute_confidence_v0(
+    *, usage_count: int, last_confirmed_correct: Optional[datetime], now: Optional[datetime] = None
+) -> float:
+    """Heuristic v0 confidence score.
+
+    Documented in module docstring. Pure function so it's trivially
+    testable and the eval flywheel can swap it without DB churn.
+    """
+    if now is None:
+        now = _utcnow()
+    base = 0.5 + 0.05 * max(0, usage_count)
+    recency_bonus = 0.0
+    if last_confirmed_correct is not None:
+        delta = now - last_confirmed_correct
+        if delta < timedelta(days=30):
+            recency_bonus = 0.2
+        elif delta < timedelta(days=90):
+            recency_bonus = 0.1
+    return max(0.0, min(1.0, base + recency_bonus))
+
+
+class StrategyRepository:
+    """Read/write surface for the `strategies` table.
+
+    The repository exposes only:
+      - `append`: insert a new strategy (new lineage, version=1)
+      - `append_version`: insert a new version that supersedes an old one
+      - `query_active`: list active strategies
+      - `get`: fetch by id
+      - `bump_usage`: increment usage_count + recompute confidence
+      - `confirm_correct`: stamp last_confirmed_correct=now + recompute confidence
+      - `set_status`: flip status (used for `flagged` + `superseded`)
+      - `count_active`: cheap "is the table empty?" check for bootstrap
+
+    There is no `update_text`, no `delete`. Editing means appending a
+    new version; revoking means flipping status to `superseded` via
+    an explicit `set_status` call. This is enforced by *not exposing*
+    those methods — there is no DELETE / UPDATE TEXT path through this
+    module.
+    """
+
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+
+    async def append(
+        self,
+        strategy: Strategy,
+        *,
+        is_contradicting: Optional[ContradictionJudge] = None,
+    ) -> Strategy:
+        """Insert a new lineage (version 1).
+
+        If `is_contradicting` is provided, every currently-active
+        strategy is checked against the new one. The first existing
+        strategy that the judge flags as contradicted is set to
+        `flagged`. The new strategy is still inserted as `active`.
+        """
+        if strategy.version != 1:
+            raise ValueError(
+                "append() inserts a new lineage; use append_version() for "
+                f"version > 1 (got {strategy.version})"
+            )
+        if strategy.parent_strategy_id is not None:
+            raise ValueError(
+                "append() inserts a new lineage; parent_strategy_id must be None"
+            )
+        await self._maybe_flag_contradictions(strategy, is_contradicting)
+        return await self._insert(strategy)
+
+    async def append_version(
+        self,
+        *,
+        parent: Strategy,
+        new_text: str,
+        created_by: str,
+        source_trace_ids: Optional[Sequence[_uuid.UUID]] = None,
+        embedding: Optional[list[float]] = None,
+    ) -> Strategy:
+        """Append a new version that supersedes `parent`.
+
+        Atomic at the SQLAlchemy session level: the parent's status flips
+        to `superseded` and the new row is inserted in the same flush.
+        """
+        if parent.status == StrategyStatus.SUPERSEDED:
+            raise ValueError(
+                f"strategy {parent.strategy_id} is already superseded; "
+                f"cannot append a new version on top of a dead lineage"
+            )
+        new_row = Strategy(
+            text=new_text,
+            version=parent.version + 1,
+            parent_strategy_id=parent.strategy_id,
+            source_trace_ids=list(source_trace_ids or []),
+            created_by=created_by,
+            embedding=embedding,
+            confidence=compute_confidence_v0(
+                usage_count=0, last_confirmed_correct=None
+            ),
+        )
+        await self._session.execute(
+            update(StrategyRow)
+            .where(StrategyRow.strategy_id == parent.strategy_id)
+            .values(status=StrategyStatus.SUPERSEDED)
+        )
+        return await self._insert(new_row)
+
+    async def query_active(self, *, limit: int = 100) -> list[Strategy]:
+        """List active strategies, newest first."""
+        if limit <= 0:
+            raise ValueError("limit must be positive")
+        stmt = (
+            select(StrategyRow)
+            .where(StrategyRow.status == StrategyStatus.ACTIVE)
+            .order_by(StrategyRow.created_at.desc())
+            .limit(limit)
+        )
+        result = await self._session.execute(stmt)
+        return [_row_to_dataclass(row) for row in result.scalars().all()]
+
+    async def get(self, strategy_id) -> Optional[Strategy]:
+        sid = _coerce_uuid(strategy_id)
+        result = await self._session.execute(
+            select(StrategyRow).where(StrategyRow.strategy_id == sid)
+        )
+        row = result.scalar_one_or_none()
+        return _row_to_dataclass(row) if row is not None else None
+
+    async def bump_usage(self, strategy_id) -> None:
+        """Increment usage_count and recompute confidence_v0."""
+        sid = _coerce_uuid(strategy_id)
+        result = await self._session.execute(
+            select(StrategyRow).where(StrategyRow.strategy_id == sid)
+        )
+        row = result.scalar_one_or_none()
+        if row is None:
+            logger.warning("strategy_bump_usage_missing", strategy_id=str(sid))
+            return
+        row.usage_count = (row.usage_count or 0) + 1
+        row.confidence = compute_confidence_v0(
+            usage_count=row.usage_count,
+            last_confirmed_correct=row.last_confirmed_correct,
+        )
+
+    async def confirm_correct(self, strategy_id, *, at: Optional[datetime] = None) -> None:
+        """Stamp `last_confirmed_correct` and recompute confidence_v0."""
+        sid = _coerce_uuid(strategy_id)
+        when = at or _utcnow()
+        result = await self._session.execute(
+            select(StrategyRow).where(StrategyRow.strategy_id == sid)
+        )
+        row = result.scalar_one_or_none()
+        if row is None:
+            logger.warning("strategy_confirm_correct_missing", strategy_id=str(sid))
+            return
+        row.last_confirmed_correct = when
+        row.confidence = compute_confidence_v0(
+            usage_count=row.usage_count,
+            last_confirmed_correct=row.last_confirmed_correct,
+            now=when,
+        )
+
+    async def set_status(self, strategy_id, status: str) -> None:
+        if status not in StrategyStatus.ALL:
+            raise ValueError(
+                f"status must be one of {sorted(StrategyStatus.ALL)}, got {status!r}"
+            )
+        sid = _coerce_uuid(strategy_id)
+        await self._session.execute(
+            update(StrategyRow)
+            .where(StrategyRow.strategy_id == sid)
+            .values(status=status)
+        )
+
+    async def count_active(self) -> int:
+        """Cheap empty-check for the bootstrap loader."""
+        result = await self._session.execute(
+            select(StrategyRow.strategy_id).where(
+                StrategyRow.status == StrategyStatus.ACTIVE
+            )
+        )
+        return len(result.scalars().all())
+
+    # ── internals ────────────────────────────────────────────────────────────
+
+    async def _insert(self, strategy: Strategy) -> Strategy:
+        row = StrategyRow(
+            strategy_id=strategy.strategy_id,
+            text=strategy.text,
+            version=strategy.version,
+            parent_strategy_id=strategy.parent_strategy_id,
+            created_at=strategy.created_at,
+            created_by=strategy.created_by,
+            source_trace_ids=list(strategy.source_trace_ids or []),
+            confidence=strategy.confidence,
+            usage_count=strategy.usage_count,
+            last_confirmed_correct=strategy.last_confirmed_correct,
+            status=strategy.status,
+            embedding=strategy.embedding,
+        )
+        self._session.add(row)
+        await self._session.flush()
+        return strategy
+
+    async def _maybe_flag_contradictions(
+        self,
+        new_strategy: Strategy,
+        is_contradicting: Optional[ContradictionJudge],
+    ) -> None:
+        if is_contradicting is None:
+            return
+        # Only check active strategies. Contradicting a superseded
+        # strategy is meaningless — it's already off the active list.
+        active = await self.query_active(limit=1000)
+        for existing in active:
+            try:
+                contradicts = await is_contradicting(existing.text, new_strategy.text)
+            except Exception:
+                # Judge failures must not block strategy writes —
+                # log and continue. The reflector's productive load
+                # outweighs perfect contradiction-detection.
+                logger.warning(
+                    "strategy_contradiction_judge_error",
+                    existing_id=str(existing.strategy_id),
+                )
+                continue
+            if contradicts:
+                await self.set_status(existing.strategy_id, StrategyStatus.FLAGGED)
+                logger.info(
+                    "strategy_contradiction_flagged",
+                    existing_id=str(existing.strategy_id),
+                    new_id=str(new_strategy.strategy_id),
+                )
+                # Flag the FIRST match only. A new strategy that
+                # contradicts multiple existing ones is a signal Jack
+                # should review, not an excuse to mass-flag.
+                return

--- a/agent/tests/test_strategies_bootstrap.py
+++ b/agent/tests/test_strategies_bootstrap.py
@@ -1,0 +1,72 @@
+"""Bootstrap-loader tests for the Strategy Hub.
+
+Verifies the loader's contract:
+- inserts 5–10 strategies from `BOOTSTRAP_STRATEGIES`
+- only inserts when the table is empty
+- stamps each row as `created_by=bootstrap`
+"""
+from __future__ import annotations
+
+import pytest
+
+from agent.strategies.bootstrap import BOOTSTRAP_STRATEGIES, bootstrap_if_empty
+from agent.strategies.repository import (
+    Strategy,
+    StrategyCreatedBy,
+    StrategyRepository,
+)
+
+
+class _FakeRepo:
+    """In-memory stand-in for StrategyRepository that captures `append`
+    calls in the order they fire."""
+
+    def __init__(self, *, existing: int = 0) -> None:
+        self._count = existing
+        self.appended: list[Strategy] = []
+
+    async def count_active(self) -> int:
+        return self._count
+
+    async def append(self, strategy: Strategy, *, is_contradicting=None) -> Strategy:
+        self.appended.append(strategy)
+        self._count += 1
+        return strategy
+
+
+class TestBootstrap:
+    def test_bootstrap_strategy_count_in_band(self) -> None:
+        # The data layer ships with 5–10 strategies per #53 AC.
+        assert 5 <= len(BOOTSTRAP_STRATEGIES) <= 10
+
+    def test_bootstrap_strategies_are_nonempty(self) -> None:
+        for s in BOOTSTRAP_STRATEGIES:
+            assert s.strip(), "bootstrap strategy text must be nonempty"
+
+    def test_bootstrap_strategies_are_unique(self) -> None:
+        # Catches accidental copy-paste.
+        assert len(set(BOOTSTRAP_STRATEGIES)) == len(BOOTSTRAP_STRATEGIES)
+
+    @pytest.mark.asyncio
+    async def test_loader_inserts_when_empty(self) -> None:
+        repo = _FakeRepo(existing=0)
+        n = await bootstrap_if_empty(repo)  # type: ignore[arg-type]
+        assert n == len(BOOTSTRAP_STRATEGIES)
+        assert len(repo.appended) == len(BOOTSTRAP_STRATEGIES)
+        for s in repo.appended:
+            assert s.created_by == StrategyCreatedBy.BOOTSTRAP
+            assert s.version == 1
+            assert s.parent_strategy_id is None
+
+    @pytest.mark.asyncio
+    async def test_loader_skips_when_nonempty(self) -> None:
+        repo = _FakeRepo(existing=3)
+        n = await bootstrap_if_empty(repo)  # type: ignore[arg-type]
+        assert n == 0
+        assert repo.appended == []
+
+    @pytest.mark.asyncio
+    async def test_loader_preserves_text_verbatim(self) -> None:
+        repo = _FakeRepo(existing=0)
+        await bootstrap_if_empty(repo)  # type: ignore[arg-type]
+        assert tuple(s.text for s in repo.appended) == BOOTSTRAP_STRATEGIES

--- a/agent/tests/test_strategies_migration.py
+++ b/agent/tests/test_strategies_migration.py
@@ -1,0 +1,58 @@
+"""Migration-SQL tests for the strategies table.
+
+Verify the *content* of the SQL the migration emits without requiring a
+live Postgres. Locks in:
+- HNSW index on the embedding column is partial (`WHERE embedding IS NOT NULL`).
+- GIN index on `source_trace_ids` exists.
+- Statements are idempotent (`IF NOT EXISTS`).
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from agent.strategies.migration import apply_strategies_migration
+
+
+@pytest.fixture
+def captured_sql() -> tuple[AsyncMock, list[str]]:
+    statements: list[str] = []
+
+    async def _execute(stmt):
+        statements.append(getattr(stmt, "text", str(stmt)))
+        return MagicMock()
+
+    conn = MagicMock()
+    conn.execute = AsyncMock(side_effect=_execute)
+    return conn, statements
+
+
+class TestStrategiesMigration:
+    @pytest.mark.asyncio
+    async def test_hnsw_index_is_partial(self, captured_sql) -> None:
+        conn, stmts = captured_sql
+        await apply_strategies_migration(conn)
+        joined = "\n".join(stmts).lower()
+        # The partial predicate matters: pgvector rejects NULLs in HNSW.
+        assert "idx_strategies_embedding" in joined
+        assert "hnsw" in joined
+        assert "embedding is not null" in joined
+
+    @pytest.mark.asyncio
+    async def test_gin_on_source_trace_ids(self, captured_sql) -> None:
+        conn, stmts = captured_sql
+        await apply_strategies_migration(conn)
+        joined = "\n".join(stmts).lower()
+        assert "idx_strategies_source_trace_ids" in joined
+        assert "using gin" in joined
+        assert "source_trace_ids" in joined
+
+    @pytest.mark.asyncio
+    async def test_statements_are_idempotent(self, captured_sql) -> None:
+        conn, stmts = captured_sql
+        await apply_strategies_migration(conn)
+        for s in stmts:
+            assert "if not exists" in s.lower(), (
+                f"every CREATE INDEX must use IF NOT EXISTS — found:\n{s}"
+            )

--- a/agent/tests/test_strategies_repository.py
+++ b/agent/tests/test_strategies_repository.py
@@ -1,0 +1,291 @@
+"""Static + behavioural tests for `agent.strategies.repository`.
+
+These tests do not require a live Postgres — they exercise the dataclass
+contract, the public-method surface, and the contradiction-detection
+flow against an in-memory stub session that satisfies just enough of
+the SQLAlchemy AsyncSession protocol for the repository's call paths.
+"""
+from __future__ import annotations
+
+import inspect
+import uuid
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock
+
+import pytest
+
+from agent.strategies.repository import (
+    STRATEGY_EMBEDDING_DIM,
+    Strategy,
+    StrategyCreatedBy,
+    StrategyRepository,
+    StrategyStatus,
+    compute_confidence_v0,
+)
+
+
+# ── Dataclass invariants ─────────────────────────────────────────────────────
+
+
+class TestStrategyDataclass:
+    def test_default_status_is_active(self) -> None:
+        s = Strategy(text="when X, do Y")
+        assert s.status == StrategyStatus.ACTIVE
+
+    def test_default_version_is_one(self) -> None:
+        s = Strategy(text="when X, do Y")
+        assert s.version == 1
+
+    def test_default_created_by_is_jack(self) -> None:
+        s = Strategy(text="when X, do Y")
+        assert s.created_by == StrategyCreatedBy.JACK
+
+    def test_empty_text_rejected(self) -> None:
+        with pytest.raises(ValueError, match="text cannot be empty"):
+            Strategy(text="")
+        with pytest.raises(ValueError, match="text cannot be empty"):
+            Strategy(text="   ")
+
+    def test_invalid_created_by_rejected(self) -> None:
+        with pytest.raises(ValueError, match="created_by"):
+            Strategy(text="when X, do Y", created_by="optimizer")
+
+    def test_invalid_status_rejected(self) -> None:
+        with pytest.raises(ValueError, match="status"):
+            Strategy(text="when X, do Y", status="archived")
+
+    def test_version_below_one_rejected(self) -> None:
+        with pytest.raises(ValueError, match="version"):
+            Strategy(text="when X, do Y", version=0)
+
+    def test_confidence_out_of_range_rejected(self) -> None:
+        with pytest.raises(ValueError, match="confidence"):
+            Strategy(text="when X, do Y", confidence=1.5)
+        with pytest.raises(ValueError, match="confidence"):
+            Strategy(text="when X, do Y", confidence=-0.1)
+
+    def test_embedding_dim_validated(self) -> None:
+        with pytest.raises(ValueError, match="embedding"):
+            Strategy(text="when X, do Y", embedding=[0.0] * 768)
+
+    def test_embedding_with_correct_dim_accepted(self) -> None:
+        s = Strategy(
+            text="when X, do Y",
+            embedding=[0.0] * STRATEGY_EMBEDDING_DIM,
+        )
+        assert s.embedding is not None and len(s.embedding) == STRATEGY_EMBEDDING_DIM
+
+
+# ── Repository surface ───────────────────────────────────────────────────────
+
+
+class TestRepositorySurface:
+    """The repository must expose only the documented public methods.
+
+    Adding a new public method requires updating both this set and the
+    module docstring — keeps the surface from drifting.
+    """
+
+    expected_public: frozenset[str] = frozenset({
+        "append",
+        "append_version",
+        "query_active",
+        "get",
+        "bump_usage",
+        "confirm_correct",
+        "set_status",
+        "count_active",
+    })
+
+    def test_public_method_set_is_exhaustive(self) -> None:
+        names = {
+            n
+            for n, _ in inspect.getmembers(StrategyRepository, predicate=inspect.isfunction)
+            if not n.startswith("_")
+        }
+        assert names == self.expected_public, (
+            f"expected {sorted(self.expected_public)}, got {sorted(names)}"
+        )
+
+    def test_no_destructive_text_edit_path(self) -> None:
+        """Editing text must go through `append_version`, never an
+        `update_text` / `delete` / etc."""
+        forbidden = ("update_text", "edit", "rewrite", "delete", "purge", "drop")
+        names = {
+            n
+            for n, _ in inspect.getmembers(StrategyRepository, predicate=inspect.isfunction)
+        }
+        bad = [n for n in names if any(n.startswith(p) for p in forbidden)]
+        assert bad == [], f"forbidden mutation methods exposed: {bad}"
+
+
+# ── Confidence v0 ────────────────────────────────────────────────────────────
+
+
+class TestConfidenceV0:
+    def test_zero_usage_no_confirmation_is_baseline(self) -> None:
+        c = compute_confidence_v0(usage_count=0, last_confirmed_correct=None)
+        assert c == pytest.approx(0.5)
+
+    def test_usage_count_lifts_confidence(self) -> None:
+        c5 = compute_confidence_v0(usage_count=5, last_confirmed_correct=None)
+        c0 = compute_confidence_v0(usage_count=0, last_confirmed_correct=None)
+        assert c5 > c0
+
+    def test_recent_confirmation_lifts_confidence(self) -> None:
+        now = datetime.now(timezone.utc)
+        recent = now - timedelta(days=10)
+        old = now - timedelta(days=200)
+        c_recent = compute_confidence_v0(usage_count=0, last_confirmed_correct=recent, now=now)
+        c_old = compute_confidence_v0(usage_count=0, last_confirmed_correct=old, now=now)
+        assert c_recent > c_old
+
+    def test_confidence_capped_at_one(self) -> None:
+        now = datetime.now(timezone.utc)
+        c = compute_confidence_v0(
+            usage_count=10_000,
+            last_confirmed_correct=now,
+            now=now,
+        )
+        assert 0.0 <= c <= 1.0
+        assert c == 1.0
+
+    def test_confidence_floored_at_zero(self) -> None:
+        # Constructed input: negative usage_count is clamped, so confidence
+        # cannot fall below 0.5 in the v0 heuristic — but the bound applies.
+        c = compute_confidence_v0(
+            usage_count=-5, last_confirmed_correct=None
+        )
+        assert 0.0 <= c <= 1.0
+
+
+# ── Lineage / version invariants ─────────────────────────────────────────────
+
+
+class _StubSession:
+    """In-memory stub of just enough of `AsyncSession` for the repo's
+    code paths. Tracks adds + flush calls + executed statements.
+    """
+
+    def __init__(self) -> None:
+        self.added: list = []
+        self.flush_count: int = 0
+        self.execute = AsyncMock(return_value=_StubResult([]))
+
+    def add(self, obj) -> None:
+        self.added.append(obj)
+
+    async def flush(self) -> None:
+        self.flush_count += 1
+
+
+class _StubResult:
+    def __init__(self, rows: list) -> None:
+        self._rows = rows
+
+    def scalar_one_or_none(self):
+        return self._rows[0] if self._rows else None
+
+    def scalars(self):
+        return _StubScalars(self._rows)
+
+
+class _StubScalars:
+    def __init__(self, rows: list) -> None:
+        self._rows = rows
+
+    def all(self) -> list:
+        return list(self._rows)
+
+
+class TestAppendValidations:
+    @pytest.mark.asyncio
+    async def test_append_rejects_versions_above_one(self) -> None:
+        repo = StrategyRepository(_StubSession())
+        with pytest.raises(ValueError, match="new lineage"):
+            await repo.append(Strategy(text="hi", version=2))
+
+    @pytest.mark.asyncio
+    async def test_append_rejects_parent_id(self) -> None:
+        repo = StrategyRepository(_StubSession())
+        with pytest.raises(ValueError, match="new lineage"):
+            await repo.append(
+                Strategy(text="hi", parent_strategy_id=uuid.uuid4())
+            )
+
+    @pytest.mark.asyncio
+    async def test_set_status_rejects_unknown_status(self) -> None:
+        repo = StrategyRepository(_StubSession())
+        with pytest.raises(ValueError, match="status must be one of"):
+            await repo.set_status(uuid.uuid4(), "archived")
+
+
+class TestVersionLineage:
+    @pytest.mark.asyncio
+    async def test_append_version_rejects_already_superseded_parent(self) -> None:
+        repo = StrategyRepository(_StubSession())
+        parent = Strategy(text="parent", status=StrategyStatus.SUPERSEDED)
+        with pytest.raises(ValueError, match="already superseded"):
+            await repo.append_version(
+                parent=parent, new_text="child", created_by=StrategyCreatedBy.REFLECTOR
+            )
+
+
+# ── Contradiction detection ──────────────────────────────────────────────────
+
+
+class TestContradictionDetection:
+    @pytest.mark.asyncio
+    async def test_first_match_flagged(self) -> None:
+        """Only the FIRST contradiction is flagged. A new strategy that
+        contradicts multiple existing ones is a signal to surface, not
+        an excuse to mass-flag."""
+        existing_a = Strategy(text="always reply within 10 minutes")
+        existing_b = Strategy(text="reply only when there is something to add")
+        # Build a stub repo that returns these as the active set, and
+        # records the set_status calls.
+        flagged_ids: list[uuid.UUID] = []
+
+        class _Repo(StrategyRepository):
+            async def query_active(self, *, limit: int = 100):
+                return [existing_a, existing_b]
+
+            async def set_status(self, strategy_id, status: str):
+                flagged_ids.append(strategy_id)
+
+            async def _insert(self, strategy):
+                # Skip the DB write so the test is pure in-memory.
+                return strategy
+
+        async def always_contradicts(_existing: str, _new: str) -> bool:
+            return True
+
+        new_strategy = Strategy(text="reply at most once a day")
+        repo = _Repo(_StubSession())
+        await repo.append(new_strategy, is_contradicting=always_contradicts)
+        assert len(flagged_ids) == 1
+        assert flagged_ids[0] == existing_a.strategy_id
+
+    @pytest.mark.asyncio
+    async def test_judge_failure_does_not_block_insert(self) -> None:
+        existing = Strategy(text="reply within 10 minutes")
+        inserted: list[Strategy] = []
+
+        class _Repo(StrategyRepository):
+            async def query_active(self, *, limit: int = 100):
+                return [existing]
+
+            async def set_status(self, strategy_id, status: str):
+                raise AssertionError("must not flag when judge raises")
+
+            async def _insert(self, strategy):
+                inserted.append(strategy)
+                return strategy
+
+        async def boom(_a: str, _b: str) -> bool:
+            raise RuntimeError("LLM judge unavailable")
+
+        new_strategy = Strategy(text="reply at most once a day")
+        repo = _Repo(_StubSession())
+        await repo.append(new_strategy, is_contradicting=boom)
+        assert inserted == [new_strategy]


### PR DESCRIPTION
Closes #53 · Epic #49

## Summary
Adds the third memory layer — interpretable, versioned, source-linked decision strategies — as a sibling to traces and reflections.

- \`agent/strategies/repository.py\` — append-only \`Strategy\` + \`StrategyRow\` + \`StrategyRepository\`. Public surface limited to \`append\`, \`append_version\`, \`query_active\`, \`get\`, \`bump_usage\`, \`confirm_correct\`, \`set_status\`, \`count_active\`. **No \`update_text\` or \`delete\` path** — editing means appending a new version, revoking means flipping status to \`superseded\` via \`set_status\`.
- **Versioning** — \`append_version\` flips the parent to \`superseded\` and inserts the child in a single flush.
- **Confidence v0** — \`clamp01(0.5 + 0.05·usage_count + recency_bonus)\`. Pure helper; swappable when the eval flywheel produces a better one.
- **Conflict detection** — optional contradiction-judge callback. First contradicting active strategy is flipped to \`flagged\`; new strategy still inserts as \`active\`. Judge failures are caught and don't block writes.
- \`agent/strategies/migration.py\` — partial HNSW on embedding (NULLs rejected by pgvector) + GIN on \`source_trace_ids\`. Wired into \`agent.db.init_db\`.
- \`agent/strategies/bootstrap.py\` — 8 hand-authored seed strategies. Only inserts when \`count_active() == 0\`. Idempotent across boots.

The query/update tools and UI inspector (referenced by #54) are **not** included here — this PR is the data layer only.

## Acceptance criteria
- [x] \`strategies\` table created via migration.
- [x] Bootstrap populates 5–10 strategies (8 ship in this PR).
- [x] Confidence + conflict logic works on a fixture set.
- [x] Repository exposes append + query; updates go through versioning, not in-place edits.

## Test plan
- [x] 32 new tests pass locally (\`agent/tests/test_strategies_*.py\`).
- [x] Existing \`test_traces_migration\`, \`test_agents_isolation\` still green.
- [x] Local review: no blockers; surface lock + first-match-only contradiction detection + judge-failure-isolation all confirmed.

## Privacy & boundaries
- Strategies are RAW_PERSONAL (encode patterns about people in the operator's life).
- Local Postgres only, same posture as traces and reflections.
- \`agent/strategies/\` imports only from \`agent.db\` + stdlib/SQLAlchemy/pgvector/structlog. No imports from \`subsystems/\` or \`agents/\` (ADR-0004 boundary held).