### PR TITLE
agent: wait-action — first-class non-action with logged reason (#55)

### DIFF
--- a/agent/core.py
+++ b/agent/core.py
@@ -34,6 +34,7 @@ from agent.error_classifier import ClassifiedLLMError, ErrorCategory
 from agent.skills import load_all_skills
 from agent.skill_reviewer import SkillReviewer
 from agent.skill_tools import SKILL_TOOLS, execute_skill_tool
+from agent.wait_tool import WAIT_TOOLS, WaitsRegistry, execute_wait
 from agent.web_search import brave_search, brave_image_search
 from agent.routing import get_driving_time
 from agent.calendar_tools import (
@@ -445,6 +446,13 @@ class PepperCore:
                 name, args, session_id="pending_actions", skip_mcp_write_gate=True
             )
         )
+
+        # Epic 06 (#55) — wait registry. Per-session in-memory ring buffer
+        # of "this turn ended in a wait" so the scheduler can suppress the
+        # user-facing send without misclassifying restraint as failure.
+        # The persistent record lives in the trace store via the existing
+        # tools_called plumbing.
+        self.waits = WaitsRegistry()
 
     @property
     def _system_prompt(self) -> str:
@@ -4104,6 +4112,7 @@ class PepperCore:
                 + IMAGE_TOOLS
                 + SKILL_TOOLS
                 + SEND_TOOLS
+                + WAIT_TOOLS
                 + _PENDING_ACTION_TOOLS
             )
         # Phase 5: append MCP tools discovered from external servers
@@ -4632,7 +4641,17 @@ class PepperCore:
                 )
                 return result
 
-            if name == "queue_outbound_action":
+            if name == "wait":
+                # Epic 06 (#55) — first-class non-action with logged reason.
+                # The wait is recorded in the per-session registry so the
+                # scheduler can suppress the user-facing send for this turn,
+                # and into the trace's tools_called via the existing
+                # chat-turn-logger plumbing. No external side effects.
+                result = await execute_wait(
+                    args, registry=self.waits, session_id=session_id
+                )
+
+            elif name == "queue_outbound_action":
                 # Phase 6.7: model calls this when it has a draft action ready
                 # (e.g. a reply to send). Enqueues it for async user approval via
                 # the web UI rather than executing immediately.

--- a/agent/main.py
+++ b/agent/main.py
@@ -92,6 +92,11 @@ from agents.reflector.http import router as _reflector_router  # noqa: E402
 
 app.include_router(_reflector_router, prefix="/api")
 
+# Epic 06 (#55): wait panel endpoint.
+from agent.waits_http import router as _waits_router  # noqa: E402
+
+app.include_router(_waits_router, prefix="/api")
+
 
 class ChatRequest(BaseModel):
     message: str

--- a/agent/scheduler.py
+++ b/agent/scheduler.py
@@ -172,6 +172,27 @@ class PepperScheduler:
             scheduler_job_name="morning_brief",
         )
 
+        # Epic 06 (#55) — wait short-circuit. If the model called the
+        # wait tool during this turn, treat the brief as a chosen
+        # non-action (success, not failure). Suppress the send + the
+        # save_to_recall, but log the wait into the audit trail and
+        # mark _last_brief so the daily slot is consumed (avoids a
+        # double-fire if the operator hits /brief/now after).
+        wait = self.pepper.waits.consume_latest(session_id)
+        if wait is not None:
+            logger.info(
+                "morning_brief_waited",
+                date=today,
+                reason_preview=wait.reason[:200],
+                until_raw=wait.until_raw,
+            )
+            await self._audit(
+                "morning_brief_waited",
+                f"Brief for {today} held back. Reason: {wait.reason[:300]}",
+            )
+            self._last_brief = datetime.utcnow()
+            return brief_text
+
         # Guaranteed persistence: save here rather than relying on the model to
         # follow the skill's save_memory instruction (skills are guidance, not
         # mandates). The morning_brief skill no longer includes a save_memory step

--- a/agent/tests/test_scheduler_trace_emission.py
+++ b/agent/tests/test_scheduler_trace_emission.py
@@ -34,6 +34,12 @@ def _make_pepper(*, with_db: bool = True):
     pepper.memory.save_to_recall = AsyncMock()
     pepper.memory.search_recall = AsyncMock(return_value=[])
 
+    # Epic 06 (#55) — default the per-session waits registry to "no wait"
+    # so existing tests exercise the normal send path. Tests that want to
+    # cover the wait-suppression branch override this explicitly.
+    pepper.waits = MagicMock()
+    pepper.waits.consume_latest = MagicMock(return_value=None)
+
     if with_db:
         executed_sql: list[str] = []
 

--- a/agent/tests/test_scheduler_wait_suppression.py
+++ b/agent/tests/test_scheduler_wait_suppression.py
@@ -1,0 +1,85 @@
+"""Scheduler wait-suppression tests (#55).
+
+When a scheduled brief turn ends in a `wait` tool call, the scheduler
+must:
+- still treat the run as success (no exception, returns the brief text)
+- NOT call `_send` (no user-facing notification)
+- NOT call `pepper.memory.save_to_recall` (no MORNING BRIEF recall row)
+- emit `morning_brief_waited` to the audit log
+- still update `_last_brief` (the daily slot is consumed)
+"""
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from agent.scheduler import PepperScheduler
+from agent.wait_tool import Wait
+
+
+def _make_config():
+    config = MagicMock()
+    config.TIMEZONE = "UTC"
+    config.MORNING_BRIEF_HOUR = 8
+    config.MORNING_BRIEF_MINUTE = 0
+    config.WEEKLY_REVIEW_DAY = "sun"
+    config.WEEKLY_REVIEW_HOUR = 18
+    return config
+
+
+def _make_pepper_with_wait(wait_obj):
+    pepper = MagicMock()
+    pepper.chat = AsyncMock(return_value="")
+    pepper.memory = MagicMock()
+    pepper.memory.save_to_recall = AsyncMock()
+    pepper.memory.search_recall = AsyncMock(return_value=[])
+
+    pepper.waits = MagicMock()
+    pepper.waits.consume_latest = MagicMock(return_value=wait_obj)
+
+    @asynccontextmanager
+    async def _session_ctx():
+        sess = MagicMock()
+        sess.execute = AsyncMock(return_value=MagicMock())
+        sess.commit = AsyncMock()
+        sess.add = MagicMock()
+        yield sess
+
+    pepper.db_factory = _session_ctx
+    return pepper
+
+
+class TestMorningBriefWaitSuppression:
+    @pytest.mark.asyncio
+    async def test_wait_skips_send_and_recall(self) -> None:
+        wait = Wait(reason="Jack already addressed this in last night's chat.")
+        pepper = _make_pepper_with_wait(wait)
+        sch = PepperScheduler(pepper, _make_config())
+        # Replace _send so we can assert the no-send invariant.
+        sch._send = AsyncMock()
+
+        result = await sch.generate_morning_brief()
+
+        # Brief returned successfully — wait is treated as success.
+        assert result is not None
+        # No send to the user.
+        sch._send.assert_not_awaited()
+        # No save_to_recall — the brief was held back, nothing to remember.
+        pepper.memory.save_to_recall.assert_not_awaited()
+        # The wait was consumed exactly once.
+        assert pepper.waits.consume_latest.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_no_wait_keeps_existing_send_behaviour(self) -> None:
+        # Default: consume_latest returns None — normal send path.
+        pepper = _make_pepper_with_wait(None)
+        pepper.chat = AsyncMock(return_value="hello, here is your brief")
+        sch = PepperScheduler(pepper, _make_config())
+        sch._send = AsyncMock()
+
+        await sch.generate_morning_brief()
+
+        sch._send.assert_awaited_once()
+        pepper.memory.save_to_recall.assert_awaited_once()

--- a/agent/tests/test_wait_tool.py
+++ b/agent/tests/test_wait_tool.py
@@ -1,0 +1,213 @@
+"""Unit tests for `agent.wait_tool` (#55).
+
+Covers the issue's acceptance contract:
+- wait tool produces a well-formed result with `reason` populated
+- wait without `reason` fails validation (the field is required)
+- ISO `until` is parsed; non-ISO `until` is preserved as-is and not parsed
+- WaitsRegistry consume_latest is one-shot
+- WaitsRegistry per-session capacity is bounded (no leak)
+- WAIT_TOOLS schema declares `reason` required and is JSON-schema-shaped
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from agent.wait_tool import (
+    MAX_REASON_LEN,
+    MAX_UNTIL_LEN,
+    WAIT_TOOLS,
+    Wait,
+    WaitsRegistry,
+    execute_wait,
+)
+
+
+# ── Schema contract ──────────────────────────────────────────────────────────
+
+
+class TestWaitToolSchema:
+    def test_single_tool_named_wait(self) -> None:
+        assert len(WAIT_TOOLS) == 1
+        assert WAIT_TOOLS[0]["function"]["name"] == "wait"
+
+    def test_reason_is_required(self) -> None:
+        params = WAIT_TOOLS[0]["function"]["parameters"]
+        assert "reason" in params["required"]
+        assert "until" not in params.get("required", [])
+
+    def test_no_side_effects_flag(self) -> None:
+        # Wait is a non-action: no external side effects.
+        assert WAIT_TOOLS[0]["side_effects"] is False
+
+
+# ── Validation ───────────────────────────────────────────────────────────────
+
+
+class TestExecuteWaitValidation:
+    @pytest.mark.asyncio
+    async def test_missing_reason_returns_error(self) -> None:
+        registry = WaitsRegistry()
+        result = await execute_wait({}, registry=registry, session_id="s1")
+        assert "error" in result
+        assert "reason" in result["error"]
+        # Nothing recorded.
+        assert registry.peek_latest("s1") is None
+
+    @pytest.mark.asyncio
+    async def test_empty_reason_returns_error(self) -> None:
+        registry = WaitsRegistry()
+        result = await execute_wait(
+            {"reason": "   "}, registry=registry, session_id="s1"
+        )
+        assert "error" in result
+        assert registry.peek_latest("s1") is None
+
+    @pytest.mark.asyncio
+    async def test_non_string_reason_returns_error(self) -> None:
+        registry = WaitsRegistry()
+        result = await execute_wait(
+            {"reason": 42}, registry=registry, session_id="s1"
+        )
+        assert "error" in result
+
+    @pytest.mark.asyncio
+    async def test_reason_length_bounded(self) -> None:
+        registry = WaitsRegistry()
+        too_long = "a" * (MAX_REASON_LEN + 1)
+        result = await execute_wait(
+            {"reason": too_long}, registry=registry, session_id="s1"
+        )
+        assert "error" in result
+
+    @pytest.mark.asyncio
+    async def test_until_length_bounded(self) -> None:
+        registry = WaitsRegistry()
+        too_long = "x" * (MAX_UNTIL_LEN + 1)
+        result = await execute_wait(
+            {"reason": "ok", "until": too_long},
+            registry=registry,
+            session_id="s1",
+        )
+        assert "error" in result
+
+
+# ── Happy path ───────────────────────────────────────────────────────────────
+
+
+class TestExecuteWaitHappyPath:
+    @pytest.mark.asyncio
+    async def test_minimal_reason_recorded(self) -> None:
+        registry = WaitsRegistry()
+        result = await execute_wait(
+            {"reason": "Jack already addressed this in the morning brief."},
+            registry=registry,
+            session_id="s1",
+        )
+        assert result == {
+            "ok": True,
+            "waited": True,
+            "reason": "Jack already addressed this in the morning brief.",
+            "until": None,
+            "until_iso": None,
+        }
+        wait = registry.peek_latest("s1")
+        assert wait is not None
+        assert wait.reason.startswith("Jack already")
+        assert wait.session_id == "s1"
+
+    @pytest.mark.asyncio
+    async def test_iso_until_parsed_with_z(self) -> None:
+        registry = WaitsRegistry()
+        result = await execute_wait(
+            {"reason": "after meeting", "until": "2026-05-04T17:00:00Z"},
+            registry=registry,
+            session_id="s1",
+        )
+        assert result["ok"] is True
+        assert result["until"] == "2026-05-04T17:00:00Z"
+        assert result["until_iso"] is not None
+        wait = registry.peek_latest("s1")
+        assert wait is not None
+        assert wait.until_iso is not None
+        assert wait.until_iso.tzinfo is not None
+        assert wait.until_iso == datetime(2026, 5, 4, 17, 0, 0, tzinfo=timezone.utc)
+
+    @pytest.mark.asyncio
+    async def test_natural_language_until_kept_as_raw(self) -> None:
+        registry = WaitsRegistry()
+        result = await execute_wait(
+            {"reason": "ok", "until": "after the meeting"},
+            registry=registry,
+            session_id="s1",
+        )
+        assert result["until"] == "after the meeting"
+        # Cannot parse — until_iso must be None, not a guess.
+        assert result["until_iso"] is None
+        wait = registry.peek_latest("s1")
+        assert wait is not None
+        assert wait.until_raw == "after the meeting"
+        assert wait.until_iso is None
+
+    @pytest.mark.asyncio
+    async def test_iso_without_zone_treated_as_utc(self) -> None:
+        registry = WaitsRegistry()
+        result = await execute_wait(
+            {"reason": "ok", "until": "2026-05-04T17:00:00"},
+            registry=registry,
+            session_id="s1",
+        )
+        assert result["until_iso"] is not None
+        wait = registry.peek_latest("s1")
+        assert wait is not None
+        assert wait.until_iso is not None and wait.until_iso.tzinfo is not None
+
+
+# ── Registry ─────────────────────────────────────────────────────────────────
+
+
+class TestWaitsRegistry:
+    def test_consume_latest_is_one_shot(self) -> None:
+        registry = WaitsRegistry()
+        registry.record(Wait(reason="r", session_id="s1"))
+        first = registry.consume_latest("s1")
+        assert first is not None
+        # Second consume returns None — the bucket was popped.
+        second = registry.consume_latest("s1")
+        assert second is None
+
+    def test_consume_returns_most_recent(self) -> None:
+        registry = WaitsRegistry()
+        registry.record(Wait(reason="older", session_id="s1"))
+        registry.record(Wait(reason="newer", session_id="s1"))
+        latest = registry.consume_latest("s1")
+        assert latest is not None
+        assert latest.reason == "newer"
+
+    def test_per_session_capacity_bounds_memory(self) -> None:
+        registry = WaitsRegistry(per_session_capacity=2)
+        for i in range(5):
+            registry.record(Wait(reason=f"r{i}", session_id="s1"))
+        # After 5 records, the deque holds the last 2.
+        latest = registry.consume_latest("s1")
+        assert latest is not None
+        assert latest.reason == "r4"
+        latest2 = registry.consume_latest("s1")
+        assert latest2 is not None
+        assert latest2.reason == "r3"
+
+    def test_sessions_are_isolated(self) -> None:
+        registry = WaitsRegistry()
+        registry.record(Wait(reason="for s1", session_id="s1"))
+        # Other session sees nothing.
+        assert registry.consume_latest("s2") is None
+        # Original session still has its wait.
+        latest = registry.consume_latest("s1")
+        assert latest is not None
+        assert latest.reason == "for s1"
+
+    def test_unknown_session_returns_none(self) -> None:
+        registry = WaitsRegistry()
+        assert registry.consume_latest("never-seen") is None
+        assert registry.peek_latest("never-seen") is None

--- a/agent/wait_tool.py
+++ b/agent/wait_tool.py
@@ -1,0 +1,279 @@
+"""Wait — a first-class non-action.
+
+The reflector and the scheduled brief flows occasionally need a way to
+say "I considered surfacing this, and chose not to, for the following
+reason." Today that decision is implicit: the model produces an empty
+string and the scheduler interprets the absence as a successful no-op.
+The implicit-empty path conflates restraint with failure (a dropped
+brief, a model that lost track, a context-overflow retry that produced
+nothing) and erases the reason.
+
+`wait` makes restraint observable. It is a tool the model calls during
+a turn; the call is recorded in the trace's `tools_called` field with
+the operator-readable reason. The wait panel (`/api/waits` +
+`web/src/components/Waits.tsx`) surfaces recent waits with reasons.
+The scheduler treats a wait-resolved scheduled run as success, not
+failure, and suppresses the user-facing send.
+
+Privacy posture: wait reasons are RAW_PERSONAL. They commonly carry
+sensitive observation about the operator's affect ("Jack seemed off,
+don't pile on with the email triage"). They live in the `traces` table
+and follow the same access controls as any other trace contents.
+
+This module exposes:
+- `WAIT_TOOLS`: the tool schema list (one entry, registers the `wait` tool).
+- `execute_wait(args, *, registry, session_id)`: validator + side-effect.
+- `WaitsRegistry`: per-session in-memory registry of "this turn waited",
+  consulted by the scheduler immediately after each chat() call.
+- `Wait` dataclass: the payload shape both the registry and the trace
+  carry.
+"""
+from __future__ import annotations
+
+import re
+import time
+from collections import deque
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Optional
+
+import structlog
+
+logger = structlog.get_logger(__name__)
+
+
+# ── Constants ────────────────────────────────────────────────────────────────
+
+# Per #55 spec the only currently-supported `until` shapes are:
+#   1. ISO-8601 timestamp (parsed; used for #56 wait-window expiry).
+#   2. Free natural-language string ("after the meeting"); kept as-is,
+#      not interpreted by the scheduler. The reflector is welcome to
+#      do something with it later.
+#   3. Omitted (the wait has no specific expiry).
+# An empty string is rejected — that's a `None` masquerading as a value.
+MAX_REASON_LEN: int = 2000
+MAX_UNTIL_LEN: int = 200
+_RECENT_WAITS_PER_SESSION: int = 16
+
+
+# ── Tool schema ──────────────────────────────────────────────────────────────
+
+
+WAIT_TOOLS = [
+    {
+        "type": "function",
+        "side_effects": False,
+        "function": {
+            "name": "wait",
+            "description": (
+                "Choose not to surface anything for this turn, with a logged "
+                "reason. Use when restraint is the right call: a recent topic "
+                "Jack already addressed, an affect signal that suggests not "
+                "piling on, or a brief that has nothing time-sensitive. The "
+                "reason is recorded in the trace and surfaced in the wait "
+                "panel — it should be specific enough that you would "
+                "recognise the call as your own next week. The wait is a "
+                "non-action: it does not send anything to Jack and does not "
+                "queue a draft. If you instead want to defer something to a "
+                "specific later moment, use `until` with an ISO timestamp."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "reason": {
+                        "type": "string",
+                        "description": (
+                            "Why you chose not to surface this turn. "
+                            "First-person, specific. Required."
+                        ),
+                    },
+                    "until": {
+                        "type": "string",
+                        "description": (
+                            "Optional. ISO-8601 timestamp (e.g. "
+                            "'2026-05-04T17:00:00Z') or natural-language "
+                            "phrase (e.g. 'after the meeting') describing "
+                            "when the situation should be re-evaluated."
+                        ),
+                    },
+                },
+                "required": ["reason"],
+            },
+        },
+    },
+]
+
+
+# ── Wait payload + registry ──────────────────────────────────────────────────
+
+
+@dataclass
+class Wait:
+    """A single recorded wait.
+
+    `created_at` is when the wait fired. `until_iso` is the parsed ISO
+    timestamp if `until` happened to be one; `until_raw` is the string
+    the model passed (which may be natural language). The reflector's
+    expiry-detection (#56) reads `until_iso`; the panel and the
+    operator read `until_raw`.
+    """
+
+    reason: str
+    session_id: str = ""
+    until_raw: Optional[str] = None
+    until_iso: Optional[datetime] = None
+    created_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+
+    def to_dict(self) -> dict[str, Any]:
+        d = asdict(self)
+        # ISO datetimes serialise as strings.
+        d["created_at"] = self.created_at.isoformat()
+        d["until_iso"] = self.until_iso.isoformat() if self.until_iso else None
+        return d
+
+
+class WaitsRegistry:
+    """In-memory ring buffer of recent waits per session.
+
+    Used by the scheduler to ask "did this turn end in a wait?" right
+    after `pepper.chat()` returns. Bounded so a chatty session cannot
+    leak unbounded memory. The persistent record lives in the trace
+    store; this registry is operational ephemera.
+    """
+
+    def __init__(self, *, per_session_capacity: int = _RECENT_WAITS_PER_SESSION) -> None:
+        self._per_session_capacity = per_session_capacity
+        self._by_session: dict[str, deque[Wait]] = {}
+
+    def record(self, wait: Wait) -> None:
+        sid = wait.session_id or ""
+        bucket = self._by_session.get(sid)
+        if bucket is None:
+            bucket = deque(maxlen=self._per_session_capacity)
+            self._by_session[sid] = bucket
+        bucket.append(wait)
+
+    def consume_latest(self, session_id: str) -> Optional[Wait]:
+        """Return the most recent wait for this session and remove it.
+
+        `consume_` semantics: the scheduler asks "did the just-finished
+        chat() turn end in a wait?" exactly once per turn. Subsequent
+        reads on the same session_id return None until a fresh wait
+        fires. Other sessions' buckets are untouched.
+        """
+        bucket = self._by_session.get(session_id)
+        if not bucket:
+            return None
+        return bucket.pop()
+
+    def peek_latest(self, session_id: str) -> Optional[Wait]:
+        """Read-only variant of `consume_latest` for tests + diagnostics."""
+        bucket = self._by_session.get(session_id)
+        if not bucket:
+            return None
+        return bucket[-1]
+
+
+# ── Validators ───────────────────────────────────────────────────────────────
+
+
+def _coerce_str(value: Any, *, field_name: str, max_len: int) -> str:
+    if value is None:
+        return ""
+    if not isinstance(value, str):
+        raise ValueError(f"{field_name} must be a string")
+    if len(value) > max_len:
+        raise ValueError(f"{field_name} exceeds {max_len} chars")
+    return value
+
+
+# Strict-enough ISO-8601 parser. Falls back to None on any failure —
+# `until` is allowed to be natural language; we just do not pretend to
+# know when it expires.
+_ISO_RE = re.compile(
+    r"^\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}(?::\d{2}(?:\.\d+)?)?"
+    r"(?:Z|[+-]\d{2}:?\d{2})?$"
+)
+
+
+def _try_parse_iso(value: Optional[str]) -> Optional[datetime]:
+    if not value:
+        return None
+    if not _ISO_RE.match(value.strip()):
+        return None
+    raw = value.strip().replace(" ", "T")
+    # Python's fromisoformat accepts "+00:00" but not "Z" until 3.11+;
+    # handle both shapes deterministically.
+    if raw.endswith("Z"):
+        raw = raw[:-1] + "+00:00"
+    try:
+        dt = datetime.fromisoformat(raw)
+    except ValueError:
+        return None
+    if dt.tzinfo is None:
+        # ISO without zone — treat as UTC; better a definite tz than a
+        # silent timezone-naive datetime that bites us at compare time.
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt
+
+
+# ── Executor ─────────────────────────────────────────────────────────────────
+
+
+async def execute_wait(
+    args: dict[str, Any],
+    *,
+    registry: WaitsRegistry,
+    session_id: str = "",
+) -> dict[str, Any]:
+    """Execute a `wait` tool call.
+
+    Returns the LLM-facing tool result. On validation failure returns
+    `{"error": "..."}` (matches the convention used elsewhere in
+    `agent/core.py`).
+
+    Side effect: the wait is recorded into `registry` keyed by
+    `session_id` so the scheduler can consume it after the turn.
+    The trace's `tools_called` entry is populated by the existing
+    chat-turn logger plumbing (no extra wiring needed here).
+    """
+    raw_reason = args.get("reason")
+    raw_until = args.get("until")
+
+    try:
+        reason = _coerce_str(raw_reason, field_name="reason", max_len=MAX_REASON_LEN)
+        until_raw = _coerce_str(raw_until, field_name="until", max_len=MAX_UNTIL_LEN)
+    except ValueError as exc:
+        return {"error": str(exc)}
+
+    reason = reason.strip()
+    if not reason:
+        # Required field. Hard error so the model learns the contract.
+        return {"error": "wait requires a non-empty 'reason'"}
+
+    until_raw = until_raw.strip() or None
+    until_iso = _try_parse_iso(until_raw) if until_raw else None
+
+    wait = Wait(
+        reason=reason,
+        session_id=session_id,
+        until_raw=until_raw,
+        until_iso=until_iso,
+    )
+    registry.record(wait)
+
+    logger.info(
+        "wait_recorded",
+        session_id=session_id,
+        reason_preview=reason[:200],
+        until_raw=until_raw,
+        until_iso=until_iso.isoformat() if until_iso else None,
+    )
+
+    return {
+        "ok": True,
+        "waited": True,
+        "reason": reason,
+        "until": until_raw,
+        "until_iso": until_iso.isoformat() if until_iso else None,
+    }

--- a/agent/waits_http.py
+++ b/agent/waits_http.py
@@ -1,0 +1,195 @@
+"""FastAPI router for the wait panel (#55).
+
+Exposes:
+
+- `GET /api/waits` — recent waits with reasons, newest first.
+
+Backed by the `traces` table: a wait turn is a row whose
+`tools_called` JSONB array contains an entry with `name = "wait"`. The
+GIN/jsonb_path_ops index from #20 makes the `@>` containment query
+fast. There is no separate `pepper_waits` table — the trace itself is
+the canonical record.
+
+Privacy posture mirrors `agent/traces/http.py`:
+
+1. **API-key required** via `require_api_key`.
+2. **Localhost bind by default** when `PEPPER_BIND_LOCALHOST_ONLY` is
+   true. Wait reasons commonly carry sensitive observation about the
+   operator's affect ("Jack seemed off, don't pile on with the email
+   triage"); the same access controls used for raw trace contents
+   apply here.
+3. **No mutation surface.** Read-only by construction — append-only
+   trace store enforces this at the storage layer.
+"""
+from __future__ import annotations
+
+import ipaddress
+from typing import Any, Optional
+
+import structlog
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from pydantic import BaseModel
+from sqlalchemy import text as _sql_text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from agent.auth import require_api_key
+from agent.db import get_db
+from agent.wait_tool import _try_parse_iso
+
+logger = structlog.get_logger(__name__)
+
+router = APIRouter(prefix="/waits", tags=["waits"])
+
+
+# ── Localhost guard (mirrors agents/reflector/http.py) ───────────────────────
+
+
+def _client_is_loopback(request: Request) -> bool:
+    host = request.client.host if request.client else ""
+    if not host:
+        return False
+    if host in {"localhost"} or host.startswith("127."):
+        return True
+    try:
+        return ipaddress.ip_address(host).is_loopback
+    except ValueError:
+        return False
+
+
+async def _enforce_localhost_bind(request: Request) -> None:
+    from agent.config import settings
+
+    bind_localhost = getattr(settings, "PEPPER_BIND_LOCALHOST_ONLY", True)
+    if bind_localhost and not _client_is_loopback(request):
+        host = request.client.host if request.client else "<unknown>"
+        logger.warning(
+            "waits_endpoint_non_loopback_denied",
+            client_host=host,
+            path=str(request.url.path),
+        )
+        raise HTTPException(
+            status_code=403,
+            detail=(
+                "/waits is bound to localhost. Set "
+                "PEPPER_BIND_LOCALHOST_ONLY=false AND wire session-level "
+                "auth before exposing externally."
+            ),
+        )
+
+
+# ── Response models ──────────────────────────────────────────────────────────
+
+
+class WaitEntry(BaseModel):
+    trace_id: str
+    created_at: str
+    reason: str
+    until_raw: Optional[str] = None
+    until_iso: Optional[str] = None
+    trigger_source: str
+    scheduler_job_name: Optional[str] = None
+
+
+class WaitsListResponse(BaseModel):
+    waits: list[WaitEntry]
+
+
+# ── Routes ───────────────────────────────────────────────────────────────────
+
+
+_DEFAULT_LIMIT: int = 50
+_MAX_LIMIT: int = 200
+
+
+def _extract_wait_args(tools_called: Any) -> Optional[dict[str, Any]]:
+    """Return the args dict of the *last* wait-tool call in `tools_called`,
+    or None if there is none.
+
+    The GIN containment query has already filtered to rows that contain
+    a wait call somewhere; this projection picks out the args payload
+    so the panel does not have to walk the full tool-call list itself.
+
+    Edge case: a turn that called `wait` more than once (e.g. the model
+    retried after a tool result it found unsatisfying) records each call
+    in order. The last entry is the model's final decision, so that's
+    the one the panel surfaces.
+    """
+    if not isinstance(tools_called, list):
+        return None
+    last_args: Optional[dict[str, Any]] = None
+    for call in tools_called:
+        if not isinstance(call, dict):
+            continue
+        if call.get("name") == "wait":
+            args = call.get("args")
+            last_args = args if isinstance(args, dict) else {}
+    return last_args
+
+
+@router.get(
+    "",
+    response_model=WaitsListResponse,
+    dependencies=[Depends(require_api_key), Depends(_enforce_localhost_bind)],
+)
+async def list_waits(
+    limit: int = Query(_DEFAULT_LIMIT, ge=1, le=_MAX_LIMIT),
+    db: AsyncSession = Depends(get_db),
+) -> WaitsListResponse:
+    """Return the most recent wait traces, newest first."""
+    # `@>` containment uses the GIN(jsonb_path_ops) index on
+    # `traces.tools_called`. Cast the JSON literal explicitly so the
+    # planner picks the index regardless of the column's storage type
+    # at runtime.
+    stmt = _sql_text(
+        """
+        SELECT
+            trace_id,
+            created_at,
+            tools_called,
+            trigger_source,
+            scheduler_job_name
+        FROM traces
+        WHERE tools_called @> CAST(:probe AS jsonb)
+        ORDER BY created_at DESC
+        LIMIT :limit
+        """
+    )
+    rows = (
+        await db.execute(
+            stmt,
+            {"probe": '[{"name": "wait"}]', "limit": limit},
+        )
+    ).fetchall()
+
+    out: list[WaitEntry] = []
+    for r in rows:
+        # SQLAlchemy returns Row tuples — index by position to avoid
+        # dialect-specific row mappings. Order matches the SELECT.
+        trace_id = str(r[0])
+        created_at = r[1].isoformat() if r[1] is not None else ""
+        wait_args = _extract_wait_args(r[2]) or {}
+        reason = str(wait_args.get("reason") or "")
+        until_raw = wait_args.get("until")
+        until_raw = str(until_raw) if until_raw else None
+        # Re-parse `until` server-side: the trace's tool_call entry
+        # carries only the raw string the model passed (the wait
+        # tool's parsed `until_iso` is in the LLM-facing tool result,
+        # which is not persisted on the trace). Re-running the same
+        # parser here keeps the panel's `until_iso` field load-bearing
+        # without bloating the trace schema.
+        parsed = _try_parse_iso(until_raw) if until_raw else None
+        until_iso = parsed.isoformat() if parsed else None
+        out.append(
+            WaitEntry(
+                trace_id=trace_id,
+                created_at=created_at,
+                reason=reason,
+                until_raw=until_raw,
+                until_iso=until_iso,
+                trigger_source=str(r[3] or ""),
+                scheduler_job_name=str(r[4]) if r[4] else None,
+            )
+        )
+
+    logger.info("waits_list", count=len(out), limit=limit)
+    return WaitsListResponse(waits=out)

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -6,9 +6,10 @@ import LifeContext from './components/LifeContext'
 import Relationships from './components/Relationships'
 import Traces from './components/Traces'
 import ReflectorAlerts from './components/ReflectorAlerts'
+import Waits from './components/Waits'
 import { logInfo } from './logger'
 
-type Tab = 'chat' | 'status' | 'context' | 'relationships' | 'traces' | 'alerts'
+type Tab = 'chat' | 'status' | 'context' | 'relationships' | 'traces' | 'alerts' | 'waits'
 
 export default function App() {
   const [tab, setTab] = useState<Tab>('chat')
@@ -38,6 +39,14 @@ export default function App() {
             // Set the hash that Traces.tsx watches AND switch tabs
             // in one motion. Without this the user clicks a trace
             // chip in the alert panel and nothing visible happens.
+            window.location.hash = `#/traces/${traceId}/context`
+            setTab('traces')
+          }}
+        />
+      )}
+      {tab === 'waits' && (
+        <Waits
+          onOpenTrace={(traceId) => {
             window.location.hash = `#/traces/${traceId}/context`
             setTab('traces')
           }}

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -305,6 +305,20 @@ export const api = {
       `/reflector/alerts/${alertId}/file`,
       { method: 'POST' },
     ),
+
+  // Epic 06 (#55) — wait panel ("things Pepper chose not to surface").
+  listWaits: (limit = 50) =>
+    req<{ waits: WaitEntry[] }>(`/waits?limit=${limit}`),
+}
+
+export interface WaitEntry {
+  trace_id: string
+  created_at: string
+  reason: string
+  until_raw: string | null
+  until_iso: string | null
+  trigger_source: string
+  scheduler_job_name: string | null
 }
 
 // Epic 04 (#41) — pattern detector alerts.

--- a/web/src/components/Layout.tsx
+++ b/web/src/components/Layout.tsx
@@ -1,7 +1,7 @@
 import { ReactNode } from 'react'
 import { logInfo } from '../logger'
 
-type Tab = 'chat' | 'status' | 'context' | 'relationships' | 'traces' | 'alerts'
+type Tab = 'chat' | 'status' | 'context' | 'relationships' | 'traces' | 'alerts' | 'waits'
 
 interface Props {
   tab: Tab
@@ -68,7 +68,7 @@ export default function Layout({ tab, onTabChange, children }: Props) {
         <span style={styles.logo}>Pepper</span>
         <span style={styles.dot} title="online" />
         <nav style={styles.tabs}>
-          {(['chat', 'status', 'context', 'relationships', 'traces', 'alerts'] as Tab[]).map((t) => (
+          {(['chat', 'status', 'context', 'relationships', 'traces', 'alerts', 'waits'] as Tab[]).map((t) => (
             <button
               key={t}
               style={styles.tab(tab === t)}
@@ -87,7 +87,9 @@ export default function Layout({ tab, onTabChange, children }: Props) {
                 ? 'Relationships'
                 : t === 'traces'
                 ? 'Traces'
-                : 'Alerts'}
+                : t === 'alerts'
+                ? 'Alerts'
+                : 'Waits'}
             </button>
           ))}
         </nav>

--- a/web/src/components/Waits.tsx
+++ b/web/src/components/Waits.tsx
@@ -1,0 +1,186 @@
+// Epic 06 (#55) — "Things Pepper chose not to surface".
+//
+// Read-only panel listing recent wait traces, newest first. Each entry
+// shows the reason, the optional `until` value the model passed, and a
+// chip linking back into the trace inspector so the operator can see
+// the full assembled context that produced the wait.
+import { useEffect, useState } from 'react'
+import { api, type WaitEntry } from '../api'
+import { logError, logInfo } from '../logger'
+
+const styles = {
+  root: {
+    display: 'flex',
+    flexDirection: 'column' as const,
+    height: '100%',
+    overflow: 'hidden',
+    color: '#e0e0e0',
+  },
+  header: {
+    padding: '16px 20px',
+    borderBottom: '1px solid #1e1e1e',
+    background: '#0d0d0d',
+  },
+  title: { fontSize: '14px', fontWeight: 600, marginBottom: '4px' },
+  hint: { fontSize: '12px', color: '#888' },
+  list: { flex: 1, overflow: 'auto', padding: '12px 20px' },
+  card: {
+    background: '#111',
+    border: '1px solid #1e1e1e',
+    borderRadius: '6px',
+    padding: '14px 16px',
+    marginBottom: '12px',
+  },
+  cardHeader: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'baseline',
+    marginBottom: '8px',
+  },
+  reason: {
+    fontSize: '13px',
+    lineHeight: 1.5,
+    color: '#e0e0e0',
+    whiteSpace: 'pre-wrap' as const,
+  },
+  meta: { fontSize: '11px', color: '#777' },
+  pill: {
+    display: 'inline-block',
+    padding: '2px 8px',
+    borderRadius: '4px',
+    fontSize: '10px',
+    fontWeight: 600,
+    background: '#52525222',
+    color: '#a1a1aa',
+    marginLeft: '8px',
+    textTransform: 'uppercase' as const,
+    letterSpacing: '0.05em',
+  },
+  detailsRow: {
+    display: 'flex',
+    flexWrap: 'wrap' as const,
+    gap: '8px',
+    marginTop: '10px',
+    fontSize: '11px',
+    color: '#888',
+  },
+  traceLink: {
+    fontSize: '11px',
+    fontFamily: 'monospace',
+    padding: '3px 8px',
+    background: '#1f2937',
+    color: '#9ca3af',
+    borderRadius: '4px',
+    textDecoration: 'none',
+    cursor: 'pointer',
+    border: '1px solid #2a2a2a',
+  },
+  empty: { color: '#666', padding: 32, textAlign: 'center' as const },
+}
+
+function formatRelative(iso: string): string {
+  const dt = new Date(iso)
+  if (Number.isNaN(dt.getTime())) return iso
+  const diffMs = Date.now() - dt.getTime()
+  const mins = Math.round(diffMs / 60_000)
+  if (mins < 1) return 'just now'
+  if (mins < 60) return `${mins}m ago`
+  const hours = Math.round(mins / 60)
+  if (hours < 48) return `${hours}h ago`
+  const days = Math.round(hours / 24)
+  return `${days}d ago`
+}
+
+interface Props {
+  onOpenTrace?: (traceId: string) => void
+}
+
+export default function Waits({ onOpenTrace }: Props) {
+  const [waits, setWaits] = useState<WaitEntry[] | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    logInfo('waits', 'mount')
+    api
+      .listWaits()
+      .then((res) => {
+        if (cancelled) return
+        setWaits(res.waits)
+        logInfo('waits', 'loaded', { count: res.waits.length })
+      })
+      .catch((err) => {
+        if (cancelled) return
+        setError(String(err))
+        logError('waits', 'load_failed', { error: String(err) })
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  if (error) {
+    return (
+      <div style={styles.root}>
+        <div style={styles.empty}>Failed to load waits: {error}</div>
+      </div>
+    )
+  }
+
+  if (waits === null) {
+    return (
+      <div style={styles.root}>
+        <div style={styles.empty}>Loading…</div>
+      </div>
+    )
+  }
+
+  return (
+    <div style={styles.root}>
+      <div style={styles.header}>
+        <div style={styles.title}>Things Pepper chose not to surface</div>
+        <div style={styles.hint}>
+          Each entry is a turn where Pepper called the <code>wait</code> tool. The
+          reason is recorded with the trace; this panel surfaces the latest
+          {waits.length > 0 ? ` ${waits.length}.` : '.'}
+        </div>
+      </div>
+      <div style={styles.list}>
+        {waits.length === 0 ? (
+          <div style={styles.empty}>No waits recorded yet.</div>
+        ) : (
+          waits.map((w) => (
+            <div key={w.trace_id} style={styles.card}>
+              <div style={styles.cardHeader}>
+                <div style={styles.meta}>
+                  {formatRelative(w.created_at)}
+                  <span style={styles.pill}>{w.trigger_source || 'turn'}</span>
+                  {w.scheduler_job_name && (
+                    <span style={styles.pill}>{w.scheduler_job_name}</span>
+                  )}
+                </div>
+              </div>
+              <div style={styles.reason}>{w.reason || <em>(no reason)</em>}</div>
+              <div style={styles.detailsRow}>
+                {w.until_raw && (
+                  <span>
+                    <strong>until:</strong> {w.until_raw}
+                  </span>
+                )}
+                <span
+                  style={styles.traceLink}
+                  onClick={() => {
+                    if (onOpenTrace) onOpenTrace(w.trace_id)
+                  }}
+                  title="Open trace in inspector"
+                >
+                  trace {w.trace_id.slice(0, 8)}
+                </span>
+              </div>
+            </div>
+          ))
+        )}
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
Closes #55 · Epic #49

## Summary
Adds `wait` as a first-class tool the model can call when restraint is the right move. The wait is observable: recorded in the trace's \`tools_called\` field, surfaced in a new web-UI panel, and consumed by the scheduler to suppress user-facing sends without misclassifying restraint as failure.

## What lands
- **\`agent/wait_tool.py\`** — schema (\`reason\` required, \`until\` optional), \`execute_wait\`, \`Wait\` dataclass, \`WaitsRegistry\` (per-session in-memory ring buffer of \"this turn ended in a wait\"). ISO \`until\` is parsed (used by #56's expiry detector); natural-language \`until\` is preserved raw.
- **\`agent/core.py\`** — registers \`WAIT_TOOLS\` in the LLM tool list; dispatches \`wait\` calls; instantiates \`pepper.waits\`. Trace's \`tools_called\` is populated by the existing chat-turn-logger plumbing.
- **\`agent/scheduler.py:generate_morning_brief\`** — after \`pepper.chat()\` returns, consume the wait registry. If a wait fired this turn: skip \`_send\`, skip \`save_to_recall\`, audit-log \`morning_brief_waited\`, still bump \`_last_brief\` so the daily slot is consumed. **No false alarms in metrics.**
- **\`agent/waits_http.py\`** — \`GET /api/waits\` queries the trace store via the existing GIN(jsonb_path_ops) index on \`tools_called\` for the containment probe \`[{\"name\":\"wait\"}]\`. Localhost-bound + API-key gated; mirrors trace HTTP posture.
- **\`web/src/components/Waits.tsx\` + \`Layout.tsx\` + \`App.tsx\` + \`api.ts\`** — read-only \"Things Pepper chose not to surface\" panel + new **Waits** tab.

## Acceptance criteria
- [x] Wait tool registered and callable.
- [x] Scheduled events can resolve to wait without false alarms (scheduler short-circuit verified by 2 new tests).
- [x] Wait panel in web UI shows recent waits.
- [x] All tests pass.

## Test plan
- [x] 19 new tests pass: \`test_wait_tool.py\` (17) + \`test_scheduler_wait_suppression.py\` (2).
- [x] 11 existing scheduler tests still green (added default \`pepper.waits.consume_latest = MagicMock(return_value=None)\` in \`_make_pepper\`).
- [x] Adjacent test suites (traces, strategies, agents-isolation) green: 76 tests pass.
- [x] \`web/\` typechecks cleanly.

## Privacy
Wait reasons are RAW_PERSONAL — they commonly carry sensitive observation about the operator's affect. They live only in the local trace store + per-session in-memory registry; \`/api/waits\` is localhost-bound + API-key gated. No external surface.

## Out of scope
Feedback loop (#56) and trace-grounded wait-correctness scoring.