### PR TITLE
inner-life: PEPPER_IDENTITY.md seed + identity selector + propose-then-approve diff flow (#52)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,9 +15,11 @@ build/
 *.log
 logs/*
 
-# User-mutable state — life_context.md and any future per-user files.
-# Personal data lives under data/, never under docs/. The .gitkeep
-# survives clones so the mount target exists; everything else is local.
+# User-mutable state — life_context.md, pepper_identity.md, and any future
+# per-user files. Personal data lives under data/, never under docs/. The
+# .gitkeep survives clones so the mount target exists; everything else is local.
+# Identity governance: pepper_identity.md is covered by data/* below.
+# See ADR-0008 and issue #52 for governance model.
 data/*
 !data/.gitkeep
 

--- a/agent/context/assembler.py
+++ b/agent/context/assembler.py
@@ -28,6 +28,7 @@ from zoneinfo import ZoneInfo
 
 from agent.context.selectors import (
     CapabilityBlockSelector,
+    IdentitySelector,
     LastNTurnsSelector,
     LifeContextSelector,
     RetrievedMemorySelector,
@@ -59,6 +60,7 @@ class ContextAssembler:
             capability_registry=capability_registry,
         )
         self._retrieved_memory = RetrievedMemorySelector()
+        self._identity = IdentitySelector()
         self._skill_match = SkillMatchSelector(skills_provider=skills_provider)
         self._last_n_turns = LastNTurnsSelector(memory_manager=memory_manager)
 
@@ -106,7 +108,16 @@ class ContextAssembler:
         if turn.channel:
             system = f"[Interface: You are responding via {turn.channel}.]\n\n" + system
 
-        # 4. Retrieved memory (already fetched by caller via gather()).
+        # 4. Identity — Pepper's self-model (values, voice, open questions).
+        #    Placed after the base system prompt so it sits "close" to the
+        #    life-context facts but is clearly a distinct block. Empty when
+        #    data/pepper_identity.md is absent (graceful degradation).
+        id_record = self._identity.select()
+        records[id_record.name] = id_record
+        if id_record.content:
+            system += f"\n\n{id_record.content}"
+
+        # 5. Retrieved memory (already fetched by caller via gather()).
         # ``memory_records`` is optional — when present, the selector emits
         # ``memory_ids`` for #33 provenance. Backward-compat: callers that
         # don't thread structured rows still get a populated context block.
@@ -118,7 +129,7 @@ class ContextAssembler:
         if rm_record.content:
             system += f"\n\n{rm_record.content}"
 
-        # 5. Other proactive contexts. These are NOT named selectors per the
+        # 6. Other proactive contexts. These are NOT named selectors per the
         #    issue but they DO contribute to the prompt — preserved here as
         #    a flat ordered append to keep byte-identical output. The Turn
         #    dataclass exposes them as plain strings.
@@ -146,13 +157,13 @@ class ContextAssembler:
         if turn.extra_system_suffix:
             system += turn.extra_system_suffix
 
-        # 6. Skills index — lazy progressive disclosure.
+        # 7. Skills index — lazy progressive disclosure.
         sk_record = self._skill_match.select(include=turn.include_skills_index)
         records[sk_record.name] = sk_record
         if sk_record.content:
             system = system + "\n\n" + sk_record.content
 
-        # 7. History.
+        # 8. History.
         ln_record = self._last_n_turns.select(
             limit=turn.history_limit,
             isolated=turn.isolated,

--- a/agent/context/selectors/__init__.py
+++ b/agent/context/selectors/__init__.py
@@ -7,6 +7,7 @@ that governs the rest of the codebase applies here.
 """
 
 from agent.context.selectors.capability_block import CapabilityBlockSelector
+from agent.context.selectors.identity import IdentitySelector
 from agent.context.selectors.last_n_turns import LastNTurnsSelector
 from agent.context.selectors.life_context import LifeContextSelector
 from agent.context.selectors.retrieved_memory import RetrievedMemorySelector
@@ -14,6 +15,7 @@ from agent.context.selectors.skill_match import SkillMatchSelector
 
 __all__ = [
     "CapabilityBlockSelector",
+    "IdentitySelector",
     "LastNTurnsSelector",
     "LifeContextSelector",
     "RetrievedMemorySelector",

--- a/agent/context/selectors/identity.py
+++ b/agent/context/selectors/identity.py
@@ -1,0 +1,67 @@
+"""IdentitySelector — injects Pepper's self-model into the system prompt.
+
+Reads from data/pepper_identity.md via :mod:`agent.identity`. Two sections
+are surfaced:
+
+  ## Identity — the committed self-model (values, voice, how Pepper handles
+    being wrong). Approval-gated via propose_identity_diff (ADR-0008).
+
+  ## Questions Pepper is asking about herself — observational, reflector-
+    writable. Framed in the prompt as "things you are still working out about
+    yourself" so the model treats it as exploratory rather than settled.
+
+Graceful degradation: if the identity file is missing the selector returns
+empty content — Pepper boots and operates normally without one. Callers MUST
+NOT treat an empty identity block as an error.
+
+NOTE: The optimizer (agent/optimizer/) is explicitly forbidden from optimizing
+or tuning either section produced by this selector. Identity is a sacred
+artifact, not a tunable prompt. See ADR-0008 §Decision and issue #52.
+Enforcement is in agent/optimizer/runners.py — the identity target name is
+included in EXCLUDED_TARGETS.
+"""
+from __future__ import annotations
+
+from agent.context.types import SelectorRecord
+from agent.identity import get_identity_block, get_questions_block, identity_version
+
+
+class IdentitySelector:
+    """Inject Pepper's identity blocks into the assembled system prompt.
+
+    The selector is stateless across turns — it calls the module-level cache
+    in agent.identity on every turn rather than holding its own. The identity
+    cache is invalidated by apply_identity_diff / update_identity_questions,
+    so changes become visible on the next turn after the write.
+    """
+
+    name = "identity"
+
+    def select(self) -> SelectorRecord:
+        identity_block = get_identity_block()
+        questions_block = get_questions_block()
+        ver = identity_version()
+
+        parts: list[str] = []
+        if identity_block:
+            parts.append("## Pepper's Identity\n\n" + identity_block)
+        if questions_block:
+            parts.append(
+                "## Things Pepper is still working out about herself\n\n"
+                + questions_block
+            )
+
+        content = "\n\n".join(parts) if parts else ""
+
+        provenance: dict = {
+            "selector": self.name,
+            "identity_present": bool(identity_block),
+            "questions_present": bool(questions_block),
+            "identity_version": ver,
+            "content_chars": len(content),
+        }
+        return SelectorRecord(
+            name=self.name,
+            content=content,
+            provenance=provenance,
+        )

--- a/agent/core.py
+++ b/agent/core.py
@@ -101,6 +101,11 @@ from agent.local_filesystem_tools import (
     extract_path_from_text,
     inspect_local_path_sync,
 )
+from agent.identity import (
+    apply_identity_diff,
+    propose_identity_diff,
+    update_identity_questions,
+)
 
 logger = structlog.get_logger()
 
@@ -323,6 +328,68 @@ _PENDING_ACTION_TOOLS = [
             },
         },
     }
+]
+
+# Issue #52 — identity governance tools (propose-then-approve + reflector write).
+# These are internal tools: propose_identity_diff is reflector-facing;
+# apply_identity_diff is executor-facing (never exposed to the LLM directly);
+# update_identity_questions is reflector-facing (no approval gate).
+_IDENTITY_TOOLS = [
+    {
+        "type": "function",
+        "function": {
+            "name": "propose_identity_diff",
+            "description": (
+                "Propose a change to Pepper's committed identity (## Identity section of "
+                "data/pepper_identity.md). The diff is queued for Jack's review in the "
+                "Pepper status panel — it does NOT take effect until approved. "
+                "Call this when accumulated trace evidence suggests the self-model "
+                "should be updated. Never use this for speculative or ungrounded changes."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "identity_section_text": {
+                        "type": "string",
+                        "description": (
+                            "The full proposed replacement body of the ## Identity section "
+                            "(not including the '## Identity' heading line)."
+                        ),
+                    },
+                    "description": {
+                        "type": "string",
+                        "description": "Short rationale for the proposed change (shown as advisory).",
+                    },
+                },
+                "required": ["identity_section_text"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "update_identity_questions",
+            "description": (
+                "Replace the '## Questions Pepper is asking about herself' section in "
+                "data/pepper_identity.md. No approval gate — this is the low-stakes "
+                "reflector self-observation path (ADR-0008). Use this to update "
+                "Pepper's active open questions based on accumulated traces."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "new_questions": {
+                        "type": "string",
+                        "description": (
+                            "The full replacement body of the Questions section "
+                            "(not including the heading line)."
+                        ),
+                    },
+                },
+                "required": ["new_questions"],
+            },
+        },
+    },
 ]
 
 IMAGE_TOOLS = [
@@ -4704,6 +4771,29 @@ class PepperCore:
                 # rebuilt prompt so subsequent turns see the new context.
                 self.assembler.refresh_life_context()
                 result = {"ok": True, "message": f"Updated section: {args['section']}"}
+
+            elif name == "propose_identity_diff":
+                # Issue #52 — reflector proposes an identity change; goes to
+                # pending-actions queue for Jack's approval (ADR-0008).
+                result = propose_identity_diff(
+                    args.get("identity_section_text", ""),
+                    pending_actions=self.pending_actions,
+                    description=args.get("description", ""),
+                )
+
+            elif name == "apply_identity_diff":
+                # Issue #52 — called by the pending-actions executor after Jack
+                # approves a diff. Never exposed to the LLM in the tool list.
+                result = apply_identity_diff(args)
+                # Invalidate identity cache so the next turn renders the new block.
+                from agent import identity as _identity_mod
+                _identity_mod._invalidate_cache()
+
+            elif name == "update_identity_questions":
+                # Issue #52 — reflector free-write path; no approval gate.
+                result = update_identity_questions(args)
+                from agent import identity as _identity_mod
+                _identity_mod._invalidate_cache()
 
             elif name == "get_driving_time":
                 api_key = self.config.GOOGLE_MAPS_API_KEY

--- a/agent/identity.py
+++ b/agent/identity.py
@@ -1,0 +1,319 @@
+"""Identity module — load, parse, and update data/pepper_identity.md.
+
+Governance: propose-then-approve (ADR-0008, issue #52).
+
+The file has two top-level sections:
+
+  ## Identity               — committed self-model; approval-gated.
+  ## Questions Pepper …     — observational; reflector-writable, no gate.
+
+Public API
+----------
+- ``load_identity_doc()``       — parse the file into a dict; graceful on
+                                  missing file (returns empty dict).
+- ``get_identity_block()``      — rendered ## Identity text or "".
+- ``get_questions_block()``     — rendered ## Questions … text or "".
+- ``identity_version()``        — parse identity_version: N or None.
+- ``propose_identity_diff()``   — queue a pending identity diff for approval.
+- ``apply_identity_diff()``     — apply an approved diff (called by executor).
+- ``update_identity_questions()``
+                               — replace Questions section directly (no gate).
+"""
+from __future__ import annotations
+
+import re
+import structlog
+from pathlib import Path
+from typing import Any, Optional
+
+logger = structlog.get_logger(__name__)
+
+# Repo root = parent of the agent/ directory this file lives in.
+_REPO_ROOT = Path(__file__).parent.parent
+_IDENTITY_PATH = _REPO_ROOT / "data" / "pepper_identity.md"
+
+# Section heading strings (matched case-sensitively after normalisation).
+_IDENTITY_HEADING = "Identity"
+_QUESTIONS_HEADING = "Questions Pepper is asking about herself"
+
+# In-process cache: populated on first load, cleared on write.
+_cached_identity: Optional[dict[str, str]] = None
+
+
+# ── Loader ────────────────────────────────────────────────────────────────────
+
+
+def _identity_path() -> Path:
+    """Return the resolved path to data/pepper_identity.md."""
+    return _IDENTITY_PATH
+
+
+def load_identity_doc(*, _force_reload: bool = False) -> dict[str, str]:
+    """Read and parse data/pepper_identity.md.
+
+    Returns a dict keyed by section heading (without the leading '## ').
+    Returns an empty dict if the file is missing — Pepper boots fine without
+    an identity doc; the selector will return empty blocks.
+
+    Caches the result in-process (``_cached_identity``) so repeated calls
+    within a session do not hit disk. Call with ``_force_reload=True`` or
+    clear ``_cached_identity = None`` externally to invalidate.
+    """
+    global _cached_identity
+    if _cached_identity is not None and not _force_reload:
+        return _cached_identity
+
+    path = _identity_path()
+    if not path.exists():
+        logger.debug("identity.missing", path=str(path))
+        _cached_identity = {}
+        return _cached_identity
+
+    text = path.read_text(encoding="utf-8")
+    _cached_identity = _parse_sections(text)
+    logger.debug(
+        "identity.loaded",
+        path=str(path),
+        sections=list(_cached_identity.keys()),
+    )
+    return _cached_identity
+
+
+def _parse_sections(text: str) -> dict[str, str]:
+    """Split markdown ## headings into {heading_text: body_text} pairs.
+
+    Only top-level '## ' headings are treated as section boundaries.
+    Lines starting with '# ' (the file-level comment header) are ignored.
+    """
+    sections: dict[str, str] = {}
+    current_heading: Optional[str] = None
+    current_lines: list[str] = []
+
+    for line in text.splitlines():
+        if line.startswith("## "):
+            if current_heading is not None:
+                sections[current_heading] = "\n".join(current_lines).strip()
+            current_heading = line[3:].strip()
+            current_lines = []
+        else:
+            if current_heading is not None:
+                current_lines.append(line)
+
+    if current_heading is not None:
+        sections[current_heading] = "\n".join(current_lines).strip()
+
+    return sections
+
+
+def _invalidate_cache() -> None:
+    global _cached_identity
+    _cached_identity = None
+
+
+# ── Public accessors ──────────────────────────────────────────────────────────
+
+
+def get_identity_block() -> str:
+    """Return the '## Identity' section text, or empty string if absent."""
+    doc = load_identity_doc()
+    return doc.get(_IDENTITY_HEADING, "")
+
+
+def get_questions_block() -> str:
+    """Return the '## Questions Pepper is asking about herself' text, or ''."""
+    doc = load_identity_doc()
+    return doc.get(_QUESTIONS_HEADING, "")
+
+
+def identity_version() -> Optional[int]:
+    """Parse and return the identity_version: N value from the Identity section.
+
+    Returns None if the section is missing or the line is absent/malformed.
+    """
+    block = get_identity_block()
+    if not block:
+        return None
+    m = re.search(r"^identity_version:\s*(\d+)", block, re.MULTILINE)
+    if m:
+        return int(m.group(1))
+    return None
+
+
+# ── Write path: propose_identity_diff ────────────────────────────────────────
+
+
+def propose_identity_diff(
+    diff_text: str,
+    *,
+    pending_actions: Any,
+    description: str = "",
+) -> dict:
+    """Queue a proposed identity diff for Jack's approval.
+
+    Enqueues an ``apply_identity_diff`` action in the pending-actions queue.
+    Jack approves, edits, or rejects it via the Pepper status panel.
+
+    Args:
+        diff_text:       The proposed new text for the '## Identity' section.
+        pending_actions: A ``PendingActionsQueue`` instance (injected by core).
+        description:     Optional model-supplied rationale shown as advisory.
+
+    Returns the enqueued action as a dict.
+    """
+    if not diff_text.strip():
+        return {"error": "propose_identity_diff: diff_text must be non-empty"}
+
+    action = pending_actions.queue(
+        tool_name="apply_identity_diff",
+        args={"identity_section_text": diff_text},
+        preview=description or f"Identity diff: {diff_text[:120]}…",
+    )
+    logger.info(
+        "identity.diff_proposed",
+        action_id=action.id,
+        diff_preview=diff_text[:80],
+    )
+    return {
+        "ok": True,
+        "queued": True,
+        "action_id": action.id,
+        "message": (
+            "Identity diff queued for Jack's review. "
+            "Visible in the Pepper status panel."
+        ),
+    }
+
+
+# ── Write path: apply_identity_diff ──────────────────────────────────────────
+
+
+def apply_identity_diff(args: dict) -> dict:
+    """Apply an approved identity diff to the ## Identity section.
+
+    Called by the pending-actions executor after Jack approves. Replaces the
+    entire ## Identity section with the new text, bumps identity_version, and
+    writes the file atomically.
+
+    Args:
+        args: dict with key ``"identity_section_text"`` — the new full body of
+              the Identity section (not including the '## Identity' heading).
+
+    Returns {"ok": True, "identity_version": N} on success.
+    """
+    new_body = args.get("identity_section_text", "")
+    if not new_body.strip():
+        return {"error": "apply_identity_diff: identity_section_text must be non-empty"}
+
+    path = _identity_path()
+    if not path.exists():
+        return {"error": f"apply_identity_diff: {path} not found"}
+
+    text = path.read_text(encoding="utf-8")
+
+    # Bump identity_version in the new body.
+    current_ver = _parse_version_in_block(new_body, "identity_version")
+    new_ver = (current_ver or 0) + 1
+    if re.search(r"^identity_version:\s*\d+", new_body, re.MULTILINE):
+        new_body = re.sub(
+            r"^(identity_version:\s*)\d+",
+            rf"\g<1>{new_ver}",
+            new_body,
+            flags=re.MULTILINE,
+        )
+    else:
+        new_body = new_body.rstrip() + f"\n\nidentity_version: {new_ver}"
+
+    # Replace the ## Identity section in the full document.
+    new_text = _replace_section(text, _IDENTITY_HEADING, new_body)
+    path.write_text(new_text, encoding="utf-8")
+    _invalidate_cache()
+
+    logger.info("identity.diff_applied", identity_version=new_ver)
+    return {"ok": True, "identity_version": new_ver}
+
+
+# ── Write path: update_identity_questions ────────────────────────────────────
+
+
+def update_identity_questions(args: dict) -> dict:
+    """Replace the '## Questions Pepper is asking about herself' section.
+
+    No approval gate — this is the reflector's low-stakes self-observation
+    path (ADR-0008). Bumps questions_version.
+
+    Args:
+        args: dict with key ``"new_questions"`` — the new full body of the
+              Questions section (not including the heading line).
+
+    Returns {"ok": True, "questions_version": N}.
+    """
+    new_body = args.get("new_questions", "")
+    if not new_body.strip():
+        return {"error": "update_identity_questions: new_questions must be non-empty"}
+
+    path = _identity_path()
+    if not path.exists():
+        return {"error": f"update_identity_questions: {path} not found"}
+
+    text = path.read_text(encoding="utf-8")
+
+    current_ver = _parse_version_in_block(new_body, "questions_version")
+    # Also check current file if the caller didn't include a version line.
+    if current_ver is None:
+        existing_questions = _parse_sections(text).get(_QUESTIONS_HEADING, "")
+        current_ver = _parse_version_in_block(existing_questions, "questions_version")
+
+    new_ver = (current_ver or 0) + 1
+    if re.search(r"^questions_version:\s*\d+", new_body, re.MULTILINE):
+        new_body = re.sub(
+            r"^(questions_version:\s*)\d+",
+            rf"\g<1>{new_ver}",
+            new_body,
+            flags=re.MULTILINE,
+        )
+    else:
+        new_body = new_body.rstrip() + f"\n\nquestions_version: {new_ver}"
+
+    new_text = _replace_section(text, _QUESTIONS_HEADING, new_body)
+    path.write_text(new_text, encoding="utf-8")
+    _invalidate_cache()
+
+    logger.info("identity.questions_updated", questions_version=new_ver)
+    return {"ok": True, "questions_version": new_ver}
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+
+def _parse_version_in_block(block: str, key: str) -> Optional[int]:
+    """Parse 'key: N' from a section body. Returns None if absent."""
+    m = re.search(rf"^{re.escape(key)}:\s*(\d+)", block, re.MULTILINE)
+    return int(m.group(1)) if m else None
+
+
+def _replace_section(full_text: str, heading: str, new_body: str) -> str:
+    """Replace the body of '## <heading>' in full_text with new_body.
+
+    If the section is not found, appends it as a new section.
+    """
+    lines = full_text.splitlines(keepends=True)
+    result: list[str] = []
+    in_target = False
+    replaced = False
+
+    for line in lines:
+        if line.rstrip() == f"## {heading}":
+            in_target = True
+            result.append(line)
+            result.append(new_body.rstrip() + "\n")
+            replaced = True
+            continue
+        if in_target and line.startswith("## "):
+            in_target = False
+        if not in_target:
+            result.append(line)
+
+    if not replaced:
+        result.append(f"\n## {heading}\n\n{new_body.rstrip()}\n")
+
+    return "".join(result)

--- a/agent/optimizer/runners.py
+++ b/agent/optimizer/runners.py
@@ -60,6 +60,25 @@ if TYPE_CHECKING:  # pragma: no cover — type-only
 
 logger = structlog.get_logger(__name__)
 
+# ── Identity exclusion (ADR-0008, issue #52) ─────────────────────────────────
+#
+# The optimizer is explicitly forbidden from optimizing the identity and
+# questions sections of data/pepper_identity.md. Identity is a sacred artifact
+# — values and voice that Jack and Pepper author together — not a tunable
+# prompt. Silent mutation of the identity surface via optimizer runs is
+# precisely the hazard ADR-0008 §Context warns about (Pepper quietly becomes
+# someone else). The propose-then-approve diff flow is the only approved path
+# for identity changes.
+#
+# Enforcement: run_optimizer() raises ValueError if the adapter target is in
+# this set. Targets that produce identity-adjacent prompts (e.g. a reflector
+# adapter) must use a different target name for their non-identity sections.
+EXCLUDED_TARGETS: frozenset[str] = frozenset({
+    "identity",           # ## Identity section
+    "identity_questions", # ## Questions Pepper is asking about herself
+    "pepper_identity",    # catch-all alias
+})
+
 
 @runtime_checkable
 class OptimizerAdapter(Protocol):
@@ -446,7 +465,17 @@ def run_optimizer(
     fails partway through, ``record.candidate_count`` reflects the
     list size returned by the runner (i.e. what *would* have been
     written) and ``record.error`` carries the persistence error.
+
+    Raises ValueError if ``adapter.target`` is in ``EXCLUDED_TARGETS``.
+    Identity and questions sections are sacred artifacts that the optimizer
+    must not tune. See ADR-0008 and issue #52.
     """
+    if adapter.target in EXCLUDED_TARGETS:
+        raise ValueError(
+            f"run_optimizer: target {adapter.target!r} is excluded from optimizer "
+            f"tuning. Identity sections are governed by propose-then-approve "
+            f"(ADR-0008). See agent/optimizer/runners.py EXCLUDED_TARGETS."
+        )
     store = store or PromptStore()
     audit_log = audit_log or AuditLog()
     run_id = uuid.uuid4().hex

--- a/agent/tests/test_identity.py
+++ b/agent/tests/test_identity.py
@@ -1,0 +1,268 @@
+"""Tests for issue #52 — PEPPER_IDENTITY.md loader, selector, assembler wiring.
+
+Three required tests from the issue spec:
+  1. test_identity_loader_missing_file      — graceful on absent file
+  2. test_identity_loader_present_file      — parses fixture correctly
+  3. test_identity_selector_in_assembler    — assembler includes identity block
+
+Additional tests for the parse/write helpers and optimizer exclusion.
+"""
+from __future__ import annotations
+
+import pytest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+FIXTURE_CONTENT = """\
+## Identity
+
+Core values: directness over diplomacy.
+
+Voice: concise and specific.
+
+identity_version: 3
+
+## Questions Pepper is asking about herself
+
+- What is the right balance?
+
+questions_version: 2
+"""
+
+
+# ── 1. test_identity_loader_missing_file ─────────────────────────────────────
+
+
+def test_identity_loader_missing_file(tmp_path):
+    """Missing data/pepper_identity.md → load_identity_doc returns empty dict."""
+    import agent.identity as identity_mod
+
+    nonexistent = tmp_path / "nope.md"
+    original_path = identity_mod._IDENTITY_PATH
+    identity_mod._IDENTITY_PATH = nonexistent
+    identity_mod._cached_identity = None  # reset cache
+    try:
+        doc = identity_mod.load_identity_doc()
+        assert doc == {}
+        # Selector must return empty content (not raise).
+        from agent.context.selectors.identity import IdentitySelector
+        sel = IdentitySelector()
+        record = sel.select()
+        assert record.content == ""
+        assert record.provenance["identity_present"] is False
+        assert record.provenance["questions_present"] is False
+    finally:
+        identity_mod._IDENTITY_PATH = original_path
+        identity_mod._cached_identity = None
+
+
+# ── 2. test_identity_loader_present_file ─────────────────────────────────────
+
+
+def test_identity_loader_present_file(tmp_path):
+    """With a fixture identity file, loader returns correctly parsed dict."""
+    import agent.identity as identity_mod
+
+    fixture_path = tmp_path / "pepper_identity.md"
+    fixture_path.write_text(FIXTURE_CONTENT, encoding="utf-8")
+
+    original_path = identity_mod._IDENTITY_PATH
+    identity_mod._IDENTITY_PATH = fixture_path
+    identity_mod._cached_identity = None
+    try:
+        doc = identity_mod.load_identity_doc(_force_reload=True)
+        assert "Identity" in doc
+        assert "Questions Pepper is asking about herself" in doc
+        assert "directness" in doc["Identity"]
+        assert "right balance" in doc["Questions Pepper is asking about herself"]
+
+        # identity_version parsed correctly.
+        ver = identity_mod.identity_version()
+        assert ver == 3
+
+        # get_identity_block / get_questions_block.
+        ib = identity_mod.get_identity_block()
+        assert "identity_version: 3" in ib
+        qb = identity_mod.get_questions_block()
+        assert "questions_version: 2" in qb
+    finally:
+        identity_mod._IDENTITY_PATH = original_path
+        identity_mod._cached_identity = None
+
+
+# ── 3. test_identity_selector_in_assembler ───────────────────────────────────
+
+
+def test_identity_selector_in_assembler(tmp_path):
+    """Assembler includes identity block in assembled context when doc exists."""
+    import agent.identity as identity_mod
+    from agent.context.assembler import ContextAssembler
+    from agent.context.types import Turn
+
+    fixture_path = tmp_path / "pepper_identity.md"
+    fixture_path.write_text(FIXTURE_CONTENT, encoding="utf-8")
+
+    original_path = identity_mod._IDENTITY_PATH
+    identity_mod._IDENTITY_PATH = fixture_path
+    identity_mod._cached_identity = None
+
+    try:
+        # Build a minimal assembler — all dependencies mocked.
+        life_ctx = MagicMock()
+        life_ctx.name = "life_context"
+        life_ctx.content = "base system prompt"
+        life_ctx.provenance = {
+            "selector": "life_context",
+            "life_context_path": "data/life_context.md",
+            "owner_name": "Jack",
+            "sections_loaded": [],
+            "life_context_sections_used": [],
+            "section_count": 0,
+            "system_prompt_chars": 20,
+        }
+        cap = MagicMock()
+        cap.name = "capability_block"
+        cap.content = ""
+        cap.provenance = {
+            "selector": "capability_block",
+            "available_sources": [],
+            "block_chars": 0,
+            "registry_present": False,
+            "capability_block_version": "abc123",
+        }
+        mem = MagicMock()
+        mem.name = "retrieved_memory"
+        mem.content = ""
+        mem.provenance = {"selector": "retrieved_memory", "memory_ids": []}
+        sk = MagicMock()
+        sk.name = "skill_match"
+        sk.content = ""
+        sk.provenance = {"selector": "skill_match", "skill_match": None}
+        ln = MagicMock()
+        ln.name = "last_n_turns"
+        ln.content = []
+        ln.provenance = {"selector": "last_n_turns", "last_n_turns": 0}
+
+        assembler = ContextAssembler.__new__(ContextAssembler)
+        assembler._timezone = "UTC"
+
+        # Inject mocked sub-selectors.
+        mock_lc = MagicMock()
+        mock_lc.select.return_value = life_ctx
+        assembler._life_context = mock_lc
+
+        mock_cap = MagicMock()
+        mock_cap.select.return_value = cap
+        assembler._capability_block = mock_cap
+
+        mock_mem = MagicMock()
+        mock_mem.select.return_value = mem
+        assembler._retrieved_memory = mock_mem
+
+        # Real IdentitySelector so we get actual file-backed content.
+        from agent.context.selectors.identity import IdentitySelector
+        assembler._identity = IdentitySelector()
+
+        mock_sk = MagicMock()
+        mock_sk.select.return_value = sk
+        assembler._skill_match = mock_sk
+
+        mock_ln = MagicMock()
+        mock_ln.select.return_value = ln
+        assembler._last_n_turns = mock_ln
+
+        from datetime import datetime, timezone
+
+        turn = Turn(
+            user_message="hello",
+            now_override=datetime(2026, 5, 3, 12, 0, tzinfo=timezone.utc),
+        )
+        ctx = assembler.assemble(turn)
+
+        assert "identity" in ctx.selectors
+        id_rec = ctx.selectors["identity"]
+        assert id_rec.provenance["identity_present"] is True
+        assert "directness" in ctx.system_prompt
+        assert "Pepper" in ctx.system_prompt or "Identity" in ctx.system_prompt
+    finally:
+        identity_mod._IDENTITY_PATH = original_path
+        identity_mod._cached_identity = None
+
+
+# ── Additional: _parse_sections ──────────────────────────────────────────────
+
+
+def test_parse_sections_basic():
+    from agent.identity import _parse_sections
+
+    doc = _parse_sections(FIXTURE_CONTENT)
+    assert set(doc.keys()) == {"Identity", "Questions Pepper is asking about herself"}
+    assert "directness" in doc["Identity"]
+
+
+def test_parse_sections_empty():
+    from agent.identity import _parse_sections
+
+    assert _parse_sections("") == {}
+    assert _parse_sections("# comment only\nno sections here") == {}
+
+
+# ── Additional: identity_version when missing ─────────────────────────────────
+
+
+def test_identity_version_returns_none_on_empty(tmp_path):
+    import agent.identity as identity_mod
+
+    nonexistent = tmp_path / "nope.md"
+    original_path = identity_mod._IDENTITY_PATH
+    identity_mod._IDENTITY_PATH = nonexistent
+    identity_mod._cached_identity = None
+    try:
+        assert identity_mod.identity_version() is None
+    finally:
+        identity_mod._IDENTITY_PATH = original_path
+        identity_mod._cached_identity = None
+
+
+# ── Additional: optimizer exclusion ──────────────────────────────────────────
+
+
+def test_optimizer_excludes_identity_target():
+    """run_optimizer raises ValueError for excluded identity targets."""
+    from agent.optimizer.runners import run_optimizer, EXCLUDED_TARGETS
+
+    assert "identity" in EXCLUDED_TARGETS
+    assert "identity_questions" in EXCLUDED_TARGETS
+
+    for target in EXCLUDED_TARGETS:
+        adapter = MagicMock()
+        adapter.target = target
+        with pytest.raises(ValueError, match="excluded from optimizer"):
+            run_optimizer(
+                runner=MagicMock(),
+                adapter=adapter,
+                examples=[],
+                baseline_prompt="test",
+            )
+
+
+# ── Additional: gitignore covers data/pepper_identity.md ─────────────────────
+
+
+def test_gitignore_covers_pepper_identity(tmp_path):
+    """data/pepper_identity.md must be gitignored (covered by data/*)."""
+    import subprocess
+
+    result = subprocess.run(
+        ["git", "check-ignore", "-q", "data/pepper_identity.md"],
+        cwd=str(Path(__file__).parent.parent.parent),
+        capture_output=True,
+    )
+    # exit code 0 → file is gitignored
+    assert result.returncode == 0, (
+        "data/pepper_identity.md is NOT gitignored. "
+        "Add it to .gitignore (or ensure data/* covers it)."
+    )


### PR DESCRIPTION
Closes #52

## Summary

- `data/pepper_identity.md` seeded with initial identity (values, voice, things Pepper finds boring, how she handles being wrong) and an open-questions section; covered by existing `data/*` gitignore rule
- `agent/identity.py`: full module — loader with in-process cache, `get_identity_block` / `get_questions_block` / `identity_version`, `propose_identity_diff` (queues to pending-actions), `apply_identity_diff` (executor path), `update_identity_questions` (reflector free-write)
- `agent/context/selectors/identity.py`: `IdentitySelector` — injects both sections into the system prompt; questions framed as "things you are still working out about yourself"; graceful on missing file
- `agent/context/assembler.py`: `IdentitySelector` wired in as step 4 of `assemble()`
- `agent/optimizer/runners.py`: `EXCLUDED_TARGETS` frozenset + `ValueError` guard in `run_optimizer` — optimizer cannot tune identity/questions sections (ADR-0008)
- `agent/core.py`: `_IDENTITY_TOOLS` schema + handlers for `propose_identity_diff`, `apply_identity_diff`, `update_identity_questions`
- `agent/tests/test_identity.py`: 8 tests — missing file, present file, assembler wiring (the three required specs), plus parse helpers, version parsing, optimizer exclusion, gitignore coverage

## Test plan

- `pytest agent/tests/test_identity.py` — all 8 pass
- Pre-existing failure `test_cmd_gate_passes_committed_baseline` is unrelated to this PR (confirmed failing on `main` before these changes)