### PR TITLE
agent/identity: PEPPER_IDENTITY seed + system-prompt wiring (#52)

### DIFF
--- a/agent/context/assembler.py
+++ b/agent/context/assembler.py
@@ -28,12 +28,14 @@ from zoneinfo import ZoneInfo
 
 from agent.context.selectors import (
     CapabilityBlockSelector,
+    IdentitySelector,
     LastNTurnsSelector,
     LifeContextSelector,
     RetrievedMemorySelector,
     SkillMatchSelector,
 )
 from agent.context.types import AssembledContext, SelectorRecord, Turn
+from agent.identity import DEFAULT_IDENTITY_PATH
 
 
 class ContextAssembler:
@@ -48,6 +50,7 @@ class ContextAssembler:
         memory_manager: Any,
         skills_provider: Any,
         timezone: str,
+        identity_path: str = DEFAULT_IDENTITY_PATH,
     ) -> None:
         self._timezone = timezone
         self._life_context = LifeContextSelector(
@@ -58,6 +61,9 @@ class ContextAssembler:
         self._capability_block = CapabilityBlockSelector(
             capability_registry=capability_registry,
         )
+        # Epic 06 (#52) — identity selector. Loads `data/pepper_identity.md`
+        # and renders the two-section block per ADR-0008.
+        self._identity = IdentitySelector(identity_path=identity_path)
         self._retrieved_memory = RetrievedMemorySelector()
         self._skill_match = SkillMatchSelector(skills_provider=skills_provider)
         self._last_n_turns = LastNTurnsSelector(memory_manager=memory_manager)
@@ -72,9 +78,21 @@ class ContextAssembler:
         self._life_context.refresh()
         self._capability_block.refresh()
 
+    def refresh_identity(self) -> None:
+        """Drop the cached identity so the next turn re-reads the file.
+
+        Called by the diff-approval flow (`agent.identity_diffs.approve`)
+        and by reflector writes to the Questions section.
+        """
+        self._identity.refresh()
+
     @property
     def life_context_selector(self) -> LifeContextSelector:
         return self._life_context
+
+    @property
+    def identity_selector(self) -> IdentitySelector:
+        return self._identity
 
     def assemble(self, turn: Turn) -> AssembledContext:
         records: dict[str, SelectorRecord] = {}
@@ -83,6 +101,18 @@ class ContextAssembler:
         lc_record = self._life_context.select()
         records[lc_record.name] = lc_record
         base_system_prompt = lc_record.content or ""
+
+        # 1a. Epic 06 (#52) — identity block per ADR-0008. Appended to
+        #     the base system prompt before time/channel headers so the
+        #     identity sits next to the life-context content the operator
+        #     authored. Empty record (missing file or parse error) skips
+        #     the append cleanly.
+        id_record = self._identity.select()
+        records[id_record.name] = id_record
+        if id_record.content:
+            base_system_prompt = (
+                base_system_prompt.rstrip() + "\n\n" + id_record.content
+            )
 
         # 2. Capability block — diagnostic only; already embedded in the
         #    life-context system prompt. We record provenance so #33 can

--- a/agent/context/selectors/__init__.py
+++ b/agent/context/selectors/__init__.py
@@ -7,6 +7,7 @@ that governs the rest of the codebase applies here.
 """
 
 from agent.context.selectors.capability_block import CapabilityBlockSelector
+from agent.context.selectors.identity import IdentitySelector
 from agent.context.selectors.last_n_turns import LastNTurnsSelector
 from agent.context.selectors.life_context import LifeContextSelector
 from agent.context.selectors.retrieved_memory import RetrievedMemorySelector
@@ -14,6 +15,7 @@ from agent.context.selectors.skill_match import SkillMatchSelector
 
 __all__ = [
     "CapabilityBlockSelector",
+    "IdentitySelector",
     "LastNTurnsSelector",
     "LifeContextSelector",
     "RetrievedMemorySelector",

--- a/agent/context/selectors/identity.py
+++ b/agent/context/selectors/identity.py
@@ -1,0 +1,75 @@
+"""IdentitySelector — wraps `agent.identity.load_identity` + render.
+
+Loads `data/pepper_identity.md`, parses the two sections per ADR-0008
+(`## Identity` + `## Questions Pepper is asking about herself`), and
+emits a SelectorRecord whose content is the rendered identity block.
+The block is appended into the system prompt by `ContextAssembler`
+after the life-context block, on every turn.
+
+Behaviour:
+- Missing file → empty record (Pepper boots with no identity block).
+- Parse error → empty record + warning log (no crash).
+- Cached across turns; invalidated explicitly by `refresh()` after a
+  diff is approved or the questions section is rewritten.
+
+Optimizer carve-out: this selector is **not** subject to optimization
+per ADR-0008. The exclusion is documented here AND in the optimizer's
+selector list.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from agent.context.types import SelectorRecord
+from agent.identity import (
+    DEFAULT_IDENTITY_PATH,
+    Identity,
+    load_identity,
+    render_identity_block,
+)
+
+
+class IdentitySelector:
+    """Read-side selector for the PEPPER_IDENTITY surface."""
+
+    name = "identity"
+
+    def __init__(self, *, identity_path: str = DEFAULT_IDENTITY_PATH) -> None:
+        self._path = identity_path
+        self._cached: Identity | None = None
+
+    def refresh(self) -> None:
+        """Drop the cached identity so the next `select()` re-reads."""
+        self._cached = None
+
+    def _load(self) -> Identity:
+        if self._cached is None:
+            try:
+                self._cached = load_identity(self._path)
+            except Exception:
+                # Defence in depth: load_identity is fail-soft already,
+                # but if it raises we do NOT propagate the exception
+                # into prompt assembly. An empty identity block is the
+                # graceful degradation.
+                self._cached = Identity(path=self._path)
+        return self._cached
+
+    def select(self) -> SelectorRecord:
+        identity = self._load()
+        content = render_identity_block(identity)
+        provenance: dict[str, Any] = {
+            "selector": self.name,
+            "identity_path": identity.path,
+            "identity_present": identity.identity_present,
+            "questions_present": identity.questions_present,
+            "identity_version": identity.identity_version,
+            "questions_version": identity.questions_version,
+            "identity_chars": len(identity.identity_text),
+            "questions_chars": len(identity.questions_text),
+        }
+        return SelectorRecord(
+            name=self.name,
+            content=content,
+            provenance=provenance,
+        )

--- a/agent/db.py
+++ b/agent/db.py
@@ -58,6 +58,8 @@ async def init_db(config=None) -> None:
         # Epic 06 (#53) — strategies table. Side-effect import for ORM
         # registration on Base.metadata.
         import agent.strategies.repository  # noqa: F401  (side-effect import)
+        # Epic 06 (#52) — pending_identity_diffs table.
+        import agent.identity_diffs  # noqa: F401  (side-effect import)
 
         # 2. Create all tables defined via Base
         await conn.run_sync(Base.metadata.create_all)

--- a/agent/identity.py
+++ b/agent/identity.py
@@ -1,0 +1,296 @@
+"""PEPPER_IDENTITY — load, parse, render the operator-managed identity doc.
+
+`data/pepper_identity.md` holds Pepper's self-model: values, voice, the
+things she finds boring, how she handles being wrong. It is gitignored
+(RAW_PERSONAL) and locally authored. The file is split into two
+top-level sections (per ADR-0008):
+
+    ## Identity
+    Committed self-model. Approval-gated. Bumps `identity_version` on
+    change. Reflector writes proposed diffs to a pending queue
+    (`pending_identity_diffs` table); operator approves / edits / rejects.
+
+    ## Questions Pepper is asking about herself
+    Observational. Reflector writes freely (append/replace). No approval.
+    Bumps a separate `questions_version` counter.
+
+Versions are persisted as HTML comments on the file's first lines:
+
+    <!-- identity_version: 3 -->
+    <!-- questions_version: 7 -->
+
+Header-in-file is portable, human-readable, and survives the operator
+manually editing the file. The loader is fail-soft: a missing file
+boots the system with an empty identity block (no crash). A malformed
+file (one section missing) loads the present section and warns about
+the missing one.
+
+This module deliberately exposes only read + atomic-write helpers. The
+diff-and-approve mechanics live in `agent/identity_diffs.py`; nothing
+in this module mutates the file in-place.
+"""
+from __future__ import annotations
+
+import os
+import re
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+import structlog
+
+logger = structlog.get_logger(__name__)
+
+
+_REPO_ROOT = Path(__file__).parent.parent
+DEFAULT_IDENTITY_PATH = "data/pepper_identity.md"
+
+SECTION_IDENTITY = "Identity"
+SECTION_QUESTIONS = "Questions Pepper is asking about herself"
+
+_VALID_SECTIONS: frozenset[str] = frozenset({SECTION_IDENTITY, SECTION_QUESTIONS})
+
+# Header comment patterns. We compile here so the file-IO path is hot.
+_RE_IDENTITY_VERSION = re.compile(r"<!--\s*identity_version:\s*(\d+)\s*-->")
+_RE_QUESTIONS_VERSION = re.compile(r"<!--\s*questions_version:\s*(\d+)\s*-->")
+_RE_SECTION_HEADER = re.compile(r"^##\s+(.+?)\s*$", re.MULTILINE)
+
+
+@dataclass(frozen=True)
+class Identity:
+    """Parsed view of the identity file.
+
+    Both sections may be empty strings (the file exists but the section
+    body is empty) or absent (the section header was missing). The
+    distinction matters for diagnostics — a missing section warns; an
+    empty body is a valid edited state.
+    """
+
+    identity_text: str = ""
+    questions_text: str = ""
+    identity_present: bool = False
+    questions_present: bool = False
+    identity_version: int = 0
+    questions_version: int = 0
+    path: str = ""
+
+    @property
+    def is_empty(self) -> bool:
+        return not (self.identity_text.strip() or self.questions_text.strip())
+
+
+def _resolve_path(path: str) -> Path:
+    p = Path(path)
+    return p if p.is_absolute() else _REPO_ROOT / p
+
+
+def _parse_versions(content: str) -> tuple[int, int]:
+    iv = _RE_IDENTITY_VERSION.search(content)
+    qv = _RE_QUESTIONS_VERSION.search(content)
+    iv_n = int(iv.group(1)) if iv else 0
+    qv_n = int(qv.group(1)) if qv else 0
+    return iv_n, qv_n
+
+
+def _split_sections(content: str) -> dict[str, str]:
+    """Return {section_name: body} for every `## Heading` in the file.
+
+    The body of a section is everything up to (but not including) the
+    next `## ` heading or end-of-file. Whitespace is preserved verbatim
+    so the round-trip writer can reproduce the operator's formatting.
+    """
+    sections: dict[str, str] = {}
+    current: Optional[str] = None
+    current_lines: list[str] = []
+    for line in content.splitlines():
+        m = _RE_SECTION_HEADER.match(line)
+        if m:
+            if current is not None:
+                sections[current] = "\n".join(current_lines).strip("\n")
+            current = m.group(1).strip()
+            current_lines = []
+        elif current is not None:
+            current_lines.append(line)
+    if current is not None:
+        sections[current] = "\n".join(current_lines).strip("\n")
+    return sections
+
+
+def load_identity(path: str = DEFAULT_IDENTITY_PATH) -> Identity:
+    """Read the identity file and return a parsed `Identity`.
+
+    Fail-soft on a missing file: returns an empty Identity with the
+    default versions. Logs a warning so the operator can see the path.
+    """
+    file_path = _resolve_path(path)
+    if not file_path.exists():
+        logger.info("pepper_identity_not_found", path=str(file_path))
+        return Identity(path=str(file_path))
+
+    content = file_path.read_text(encoding="utf-8")
+    iv, qv = _parse_versions(content)
+    sections = _split_sections(content)
+
+    identity_present = SECTION_IDENTITY in sections
+    questions_present = SECTION_QUESTIONS in sections
+
+    if not identity_present:
+        logger.warning(
+            "pepper_identity_missing_section",
+            section=SECTION_IDENTITY,
+            path=str(file_path),
+        )
+    if not questions_present:
+        logger.warning(
+            "pepper_identity_missing_section",
+            section=SECTION_QUESTIONS,
+            path=str(file_path),
+        )
+
+    return Identity(
+        identity_text=sections.get(SECTION_IDENTITY, ""),
+        questions_text=sections.get(SECTION_QUESTIONS, ""),
+        identity_present=identity_present,
+        questions_present=questions_present,
+        identity_version=iv,
+        questions_version=qv,
+        path=str(file_path),
+    )
+
+
+def render_identity_block(identity: Identity) -> str:
+    """Render the identity content for inclusion in the system prompt.
+
+    The Questions section is framed as exploratory ("things you are
+    still working out about yourself") so the model treats it as an
+    open thread, not a committed self-model entry. An empty identity
+    returns "" — the assembler skips empty selector content.
+    """
+    if identity.is_empty:
+        return ""
+    parts: list[str] = []
+    if identity.identity_text.strip():
+        parts.append("[Pepper identity]\n" + identity.identity_text.strip())
+    if identity.questions_text.strip():
+        parts.append(
+            "[Things you are still working out about yourself]\n"
+            + identity.questions_text.strip()
+        )
+    return "\n\n".join(parts)
+
+
+def _build_file_text(identity: Identity) -> str:
+    """Serialise an `Identity` back to file form, with version headers.
+
+    The output round-trips cleanly: `load_identity(write_identity(x))`
+    produces an Identity with identical content + versions to `x`.
+    """
+    lines: list[str] = []
+    lines.append(f"<!-- identity_version: {identity.identity_version} -->")
+    lines.append(f"<!-- questions_version: {identity.questions_version} -->")
+    lines.append("")
+    lines.append(f"## {SECTION_IDENTITY}")
+    lines.append("")
+    if identity.identity_text.strip():
+        lines.append(identity.identity_text.strip())
+    lines.append("")
+    lines.append(f"## {SECTION_QUESTIONS}")
+    lines.append("")
+    if identity.questions_text.strip():
+        lines.append(identity.questions_text.strip())
+    lines.append("")
+    return "\n".join(lines)
+
+
+def write_identity_atomic(identity: Identity) -> None:
+    """Write `identity` back to its `path` atomically.
+
+    Uses a temp file in the same directory + os.replace so a partial
+    write cannot leave the file half-formed. Diff application rides
+    on this primitive — atomicity is the diff layer's correctness
+    invariant.
+    """
+    file_path = Path(identity.path)
+    if not file_path.is_absolute():
+        file_path = _resolve_path(identity.path or DEFAULT_IDENTITY_PATH)
+    file_path.parent.mkdir(parents=True, exist_ok=True)
+
+    text = _build_file_text(identity)
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=".pepper_identity.",
+        suffix=".tmp",
+        dir=str(file_path.parent),
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fh.write(text)
+        os.replace(tmp_name, file_path)
+    except Exception:
+        # Tempfile cleanup on any error; os.replace rename is atomic so
+        # we cannot end up with both files except on the failure path.
+        try:
+            os.unlink(tmp_name)
+        except FileNotFoundError:
+            pass
+        raise
+
+
+def apply_identity_diff(
+    *,
+    proposed_identity_text: str,
+    path: str = DEFAULT_IDENTITY_PATH,
+) -> Identity:
+    """Atomically replace the `## Identity` section and bump version.
+
+    Returns the new `Identity`. Used by the diff-approval flow in
+    `agent/identity_diffs.py:approve_diff`.
+    """
+    current = load_identity(path)
+    new = Identity(
+        identity_text=proposed_identity_text,
+        questions_text=current.questions_text,
+        identity_present=True,
+        questions_present=current.questions_present or False,
+        identity_version=current.identity_version + 1,
+        questions_version=current.questions_version,
+        path=current.path or str(_resolve_path(path)),
+    )
+    write_identity_atomic(new)
+    logger.info(
+        "pepper_identity_section_applied",
+        section=SECTION_IDENTITY,
+        new_version=new.identity_version,
+        path=new.path,
+    )
+    return new
+
+
+def write_questions_section(
+    proposed_questions_text: str,
+    *,
+    path: str = DEFAULT_IDENTITY_PATH,
+) -> Identity:
+    """Replace the `## Questions ...` section without approval.
+
+    The reflector is the intended caller. Bumps `questions_version`
+    independently of `identity_version`.
+    """
+    current = load_identity(path)
+    new = Identity(
+        identity_text=current.identity_text,
+        questions_text=proposed_questions_text,
+        identity_present=current.identity_present or False,
+        questions_present=True,
+        identity_version=current.identity_version,
+        questions_version=current.questions_version + 1,
+        path=current.path or str(_resolve_path(path)),
+    )
+    write_identity_atomic(new)
+    logger.info(
+        "pepper_identity_section_applied",
+        section=SECTION_QUESTIONS,
+        new_version=new.questions_version,
+        path=new.path,
+    )
+    return new

--- a/agent/identity_diffs.py
+++ b/agent/identity_diffs.py
@@ -1,0 +1,255 @@
+"""Persistence + flow for proposed identity diffs (#52, ADR-0008).
+
+The `pending_identity_diffs` table is the persistent surface for
+reflector-proposed changes to the `## Identity` section of
+`data/pepper_identity.md`. Each row is one proposed diff with a
+status of `pending | approved | rejected`. Approval applies the
+diff atomically (`agent.identity.apply_identity_diff`) and bumps
+`identity_version`.
+
+This is a sibling table to `strategies` (#53) — append-only at the
+app layer, status-flippable, no in-place text edits.
+
+Module surface:
+- `IdentityDiff` — dataclass / ORM row.
+- `IdentityDiffStatus` — closed enum of valid statuses.
+- `IdentityDiffRepository` — append, list_pending, get, approve,
+  reject. The approve helper is the only path that calls
+  `apply_identity_diff`.
+"""
+from __future__ import annotations
+
+import uuid as _uuid
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Optional
+
+import structlog
+from sqlalchemy import DateTime, Index, String, Text, select, update
+from sqlalchemy.dialects.postgresql import ARRAY, UUID
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import Mapped, mapped_column
+
+from agent.db import Base
+from agent.identity import (
+    DEFAULT_IDENTITY_PATH,
+    Identity,
+    apply_identity_diff,
+)
+
+logger = structlog.get_logger(__name__)
+
+
+class IdentityDiffStatus:
+    PENDING = "pending"
+    APPROVED = "approved"
+    REJECTED = "rejected"
+
+    ALL: frozenset[str] = frozenset({PENDING, APPROVED, REJECTED})
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _new_diff_id() -> _uuid.UUID:
+    return _uuid.uuid4()
+
+
+@dataclass
+class IdentityDiff:
+    """One proposed diff to the `## Identity` section.
+
+    `proposed_text` is the full new section body; the diff applies as a
+    full-section replace on approval. We do NOT store unified-diff
+    fragments — Pepper's identity is small enough that a full replace
+    is simpler and avoids reconciliation hazards.
+    """
+
+    proposed_text: str
+    rationale: str = ""
+    source_trace_ids: list[_uuid.UUID] = field(default_factory=list)
+    status: str = IdentityDiffStatus.PENDING
+    diff_id: _uuid.UUID = field(default_factory=_new_diff_id)
+    created_at: datetime = field(default_factory=_utcnow)
+    decided_at: Optional[datetime] = None
+
+    def __post_init__(self) -> None:
+        if not self.proposed_text or not self.proposed_text.strip():
+            raise ValueError("identity diff proposed_text cannot be empty")
+        if self.status not in IdentityDiffStatus.ALL:
+            raise ValueError(
+                f"identity diff status must be one of "
+                f"{sorted(IdentityDiffStatus.ALL)}, got {self.status!r}"
+            )
+
+
+class IdentityDiffRow(Base):
+    __tablename__ = "pending_identity_diffs"
+
+    diff_id: Mapped[_uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        default=_uuid.uuid4,
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False
+    )
+    proposed_text: Mapped[str] = mapped_column(Text, nullable=False)
+    rationale: Mapped[str] = mapped_column(Text, nullable=False, default="")
+    source_trace_ids: Mapped[list[_uuid.UUID]] = mapped_column(
+        ARRAY(UUID(as_uuid=True)), nullable=False, default=list
+    )
+    status: Mapped[str] = mapped_column(
+        String(16), nullable=False, default=IdentityDiffStatus.PENDING
+    )
+    decided_at: Mapped[Optional[datetime]] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+
+    __table_args__ = (
+        Index("idx_pending_identity_diffs_status", "status"),
+        Index("idx_pending_identity_diffs_created_at", "created_at"),
+    )
+
+
+def _row_to_dataclass(row: IdentityDiffRow) -> IdentityDiff:
+    return IdentityDiff(
+        proposed_text=row.proposed_text,
+        rationale=row.rationale,
+        source_trace_ids=list(row.source_trace_ids or []),
+        status=row.status,
+        diff_id=row.diff_id,
+        created_at=row.created_at,
+        decided_at=row.decided_at,
+    )
+
+
+class IdentityDiffRepository:
+    """Read/write surface for `pending_identity_diffs`.
+
+    Public methods: append, list_pending, get, reject, approve. There
+    is no `update_text` and no `delete` — once a diff is recorded, the
+    audit trail is permanent.
+
+    The approve helper applies the diff via
+    `agent.identity.apply_identity_diff`. Identity-write atomicity
+    rides on the file-write primitive there.
+    """
+
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+
+    async def append(self, diff: IdentityDiff) -> IdentityDiff:
+        if diff.status != IdentityDiffStatus.PENDING:
+            raise ValueError(
+                "append() only accepts PENDING diffs; "
+                f"got {diff.status!r}"
+            )
+        row = IdentityDiffRow(
+            diff_id=diff.diff_id,
+            created_at=diff.created_at,
+            proposed_text=diff.proposed_text,
+            rationale=diff.rationale,
+            source_trace_ids=list(diff.source_trace_ids or []),
+            status=diff.status,
+            decided_at=diff.decided_at,
+        )
+        self._session.add(row)
+        await self._session.flush()
+        return diff
+
+    async def list_pending(self, *, limit: int = 50) -> list[IdentityDiff]:
+        if limit <= 0:
+            raise ValueError("limit must be positive")
+        stmt = (
+            select(IdentityDiffRow)
+            .where(IdentityDiffRow.status == IdentityDiffStatus.PENDING)
+            .order_by(IdentityDiffRow.created_at.desc())
+            .limit(limit)
+        )
+        result = await self._session.execute(stmt)
+        return [_row_to_dataclass(r) for r in result.scalars().all()]
+
+    async def get(self, diff_id) -> Optional[IdentityDiff]:
+        sid = diff_id if isinstance(diff_id, _uuid.UUID) else _uuid.UUID(str(diff_id))
+        result = await self._session.execute(
+            select(IdentityDiffRow).where(IdentityDiffRow.diff_id == sid)
+        )
+        row = result.scalar_one_or_none()
+        return _row_to_dataclass(row) if row is not None else None
+
+    async def reject(self, diff_id) -> None:
+        sid = diff_id if isinstance(diff_id, _uuid.UUID) else _uuid.UUID(str(diff_id))
+        await self._session.execute(
+            update(IdentityDiffRow)
+            .where(
+                IdentityDiffRow.diff_id == sid,
+                IdentityDiffRow.status == IdentityDiffStatus.PENDING,
+            )
+            .values(status=IdentityDiffStatus.REJECTED, decided_at=_utcnow())
+        )
+        logger.info("identity_diff_rejected", diff_id=str(sid))
+
+    async def approve(
+        self,
+        diff_id,
+        *,
+        identity_path: str = DEFAULT_IDENTITY_PATH,
+        on_applied=None,
+    ) -> Identity:
+        """Mark the diff approved AND apply it to the file.
+
+        The status flip and the file write happen in this order
+        deliberately:
+        1. Flip status to APPROVED inside the current session (not yet
+           committed by the caller).
+        2. Apply the file write atomically (os.replace).
+        3. (Optional) call `on_applied(new_identity)` so the caller can
+           invalidate any in-process cache (e.g.
+           ``ContextAssembler.refresh_identity()``) so the next turn
+           picks up the new content without a process restart.
+        4. Caller commits the session.
+
+        If the file write fails, the SQLAlchemy session has not been
+        committed by the caller yet — they roll back and the row stays
+        PENDING. If the commit fails after a successful file write, the
+        operator sees an apparent "diff applied but still pending"
+        which is recoverable: re-approving is a no-op (file is already
+        the new content), and the next status flip succeeds.
+        """
+        diff = await self.get(diff_id)
+        if diff is None:
+            raise LookupError(f"identity diff {diff_id} does not exist")
+        if diff.status != IdentityDiffStatus.PENDING:
+            raise ValueError(
+                f"identity diff {diff.diff_id} is in status "
+                f"{diff.status!r}, expected pending"
+            )
+        await self._session.execute(
+            update(IdentityDiffRow)
+            .where(IdentityDiffRow.diff_id == diff.diff_id)
+            .values(status=IdentityDiffStatus.APPROVED, decided_at=_utcnow())
+        )
+        new_identity = apply_identity_diff(
+            proposed_identity_text=diff.proposed_text,
+            path=identity_path,
+        )
+        if on_applied is not None:
+            try:
+                on_applied(new_identity)
+            except Exception:
+                # Cache-invalidation failure must not unwind a successful
+                # approval — log and let the operator restart the process
+                # if needed.
+                logger.warning(
+                    "identity_diff_on_applied_failed",
+                    diff_id=str(diff.diff_id),
+                )
+        logger.info(
+            "identity_diff_approved",
+            diff_id=str(diff.diff_id),
+            new_identity_version=new_identity.identity_version,
+        )
+        return new_identity

--- a/agent/optimizer/eval_gate.py
+++ b/agent/optimizer/eval_gate.py
@@ -89,6 +89,19 @@ DEFAULT_THRESHOLDS: dict[str, float] = {
 KNOWN_TARGETS: frozenset[str] = frozenset(DEFAULT_THRESHOLDS)
 
 
+# Epic 06 (#52, ADR-0008) — targets the optimizer is FORBIDDEN from
+# touching. Identity is a sacred artifact: changes flow through the
+# propose-then-approve queue, not through automated tuning. The list
+# is enforced by `register_runner` (raises if a registration would
+# shadow a forbidden target) AND by `gate` paths (refuse to evaluate a
+# prompt whose target is on this list).
+#
+# Add new entries only with an ADR justifying the exclusion.
+FORBIDDEN_TARGETS: frozenset[str] = frozenset({
+    "identity",
+})
+
+
 def threshold_for(target: str) -> float:
     """Resolve the floor score for a target.
 
@@ -145,7 +158,18 @@ def register_runner(target: str, runner: EvalRunner) -> None:
     Targets call this at import-time from their own module so the
     gate's import surface stays narrow (no need to import #46's
     context-assembly stack from inside the eval_gate module itself).
+
+    Refuses to register a runner for any target on
+    ``FORBIDDEN_TARGETS`` (Epic 06 #52, ADR-0008) — these are
+    sacred artifacts that the optimizer must not tune. Adding a
+    runner for one is almost certainly a bug; failing loud catches
+    it at import time rather than during a commit-time gate.
     """
+    if target in FORBIDDEN_TARGETS:
+        raise ValueError(
+            f"target {target!r} is on FORBIDDEN_TARGETS "
+            f"(see ADR-0008); the optimizer must not tune it"
+        )
     EVAL_RUNNERS[target] = runner
 
 
@@ -210,6 +234,23 @@ def evaluate_paths(paths: list[Path]) -> list[GateResult]:
                 path=path, target="(unknown)",
                 score=0.0, threshold=1.0, passed=False,
                 notes="path outside agent/prompts/<target>/<version>.json layout",
+            ))
+            continue
+
+        # Epic 06 (#52, ADR-0008): the optimizer must not tune sacred
+        # artifacts. Refuse loud and early so a hand-edited prompt
+        # under `agent/prompts/identity/` produces a clear failure
+        # message rather than the generic "no eval runner registered".
+        if target in FORBIDDEN_TARGETS:
+            out.append(GateResult(
+                path=path, target=target,
+                score=0.0, threshold=1.0, passed=False,
+                notes=(
+                    f"target {target!r} is FORBIDDEN per ADR-0008; "
+                    "the optimizer must not tune it. Remove the file "
+                    "from agent/prompts/ and use the propose-then-"
+                    "approve queue if a change is intended."
+                ),
             ))
             continue
 

--- a/agent/tests/test_identity.py
+++ b/agent/tests/test_identity.py
@@ -1,0 +1,267 @@
+"""Tests for `agent.identity` (#52).
+
+Covers:
+- missing file → empty Identity, no crash
+- present file → both sections parsed, versions extracted
+- malformed file (one section missing) → present section loads, warning
+- atomic write round-trips both sections + versions
+- apply_identity_diff bumps identity_version, leaves questions_version
+- write_questions_section bumps questions_version, leaves identity_version
+- gitignore: data/pepper_identity.md is in the ignored set
+"""
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from textwrap import dedent
+
+import pytest
+
+from agent.identity import (
+    DEFAULT_IDENTITY_PATH,
+    Identity,
+    SECTION_IDENTITY,
+    SECTION_QUESTIONS,
+    apply_identity_diff,
+    load_identity,
+    render_identity_block,
+    write_identity_atomic,
+    write_questions_section,
+)
+
+
+# ── Loader: missing file ─────────────────────────────────────────────────────
+
+
+class TestLoaderMissingFile:
+    def test_missing_file_returns_empty(self, tmp_path: Path) -> None:
+        path = tmp_path / "no_such.md"
+        identity = load_identity(str(path))
+        assert identity.is_empty
+        assert identity.identity_present is False
+        assert identity.questions_present is False
+        assert identity.identity_version == 0
+        assert identity.questions_version == 0
+
+    def test_render_empty_identity_returns_empty_string(self) -> None:
+        # The assembler relies on this — empty identity means "skip the append".
+        assert render_identity_block(Identity()) == ""
+
+
+# ── Loader: parsing ──────────────────────────────────────────────────────────
+
+
+def _write(p: Path, body: str) -> None:
+    p.write_text(dedent(body).lstrip("\n"), encoding="utf-8")
+
+
+class TestLoaderParse:
+    def test_both_sections_parsed(self, tmp_path: Path) -> None:
+        path = tmp_path / "id.md"
+        _write(
+            path,
+            """
+            <!-- identity_version: 3 -->
+            <!-- questions_version: 7 -->
+
+            ## Identity
+
+            I am Pepper.
+
+            ## Questions Pepper is asking about herself
+
+            Why do I always summarise?
+            """,
+        )
+        identity = load_identity(str(path))
+        assert identity.identity_present is True
+        assert identity.questions_present is True
+        assert identity.identity_version == 3
+        assert identity.questions_version == 7
+        assert "I am Pepper" in identity.identity_text
+        assert "summarise" in identity.questions_text
+
+    def test_versions_default_to_zero_when_absent(self, tmp_path: Path) -> None:
+        path = tmp_path / "id.md"
+        _write(
+            path,
+            """
+            ## Identity
+
+            no version comments here.
+            """,
+        )
+        identity = load_identity(str(path))
+        assert identity.identity_version == 0
+        assert identity.questions_version == 0
+
+    def test_missing_questions_section_warns_but_loads(self, tmp_path: Path) -> None:
+        path = tmp_path / "id.md"
+        _write(
+            path,
+            """
+            <!-- identity_version: 1 -->
+            <!-- questions_version: 0 -->
+
+            ## Identity
+
+            present.
+            """,
+        )
+        identity = load_identity(str(path))
+        assert identity.identity_present is True
+        assert identity.questions_present is False
+        assert identity.identity_text.strip() == "present."
+
+    def test_missing_identity_section_warns_but_loads(self, tmp_path: Path) -> None:
+        path = tmp_path / "id.md"
+        _write(
+            path,
+            """
+            ## Questions Pepper is asking about herself
+
+            who am I?
+            """,
+        )
+        identity = load_identity(str(path))
+        assert identity.identity_present is False
+        assert identity.questions_present is True
+
+
+# ── Render ───────────────────────────────────────────────────────────────────
+
+
+class TestRender:
+    def test_render_includes_both_sections(self) -> None:
+        identity = Identity(
+            identity_text="I am Pepper.",
+            questions_text="Why do I summarise?",
+            identity_present=True,
+            questions_present=True,
+        )
+        block = render_identity_block(identity)
+        assert "[Pepper identity]" in block
+        assert "I am Pepper." in block
+        assert "[Things you are still working out about yourself]" in block
+        assert "Why do I summarise?" in block
+
+    def test_render_skips_empty_section_headers(self) -> None:
+        identity = Identity(
+            identity_text="I am Pepper.",
+            questions_text="",
+            identity_present=True,
+            questions_present=False,
+        )
+        block = render_identity_block(identity)
+        assert "[Pepper identity]" in block
+        assert "[Things you are still" not in block
+
+
+# ── Write round-trip ─────────────────────────────────────────────────────────
+
+
+class TestWriteRoundTrip:
+    def test_atomic_write_then_load_preserves_content(self, tmp_path: Path) -> None:
+        path = tmp_path / "id.md"
+        original = Identity(
+            identity_text="I am Pepper.",
+            questions_text="Why do I summarise?",
+            identity_present=True,
+            questions_present=True,
+            identity_version=2,
+            questions_version=5,
+            path=str(path),
+        )
+        write_identity_atomic(original)
+        loaded = load_identity(str(path))
+        assert loaded.identity_version == 2
+        assert loaded.questions_version == 5
+        assert loaded.identity_text == "I am Pepper."
+        assert loaded.questions_text == "Why do I summarise?"
+
+    def test_atomic_write_does_not_leave_temp_files_on_success(
+        self, tmp_path: Path
+    ) -> None:
+        path = tmp_path / "id.md"
+        identity = Identity(
+            identity_text="x", questions_text="y", path=str(path)
+        )
+        write_identity_atomic(identity)
+        # Only the destination file remains; the .tmp shadow is cleaned up by
+        # os.replace.
+        files = sorted(p.name for p in tmp_path.iterdir())
+        assert files == ["id.md"]
+
+
+# ── Diff application + Questions write ───────────────────────────────────────
+
+
+class TestDiffApplication:
+    def test_apply_identity_diff_bumps_only_identity_version(
+        self, tmp_path: Path
+    ) -> None:
+        path = tmp_path / "id.md"
+        seed = Identity(
+            identity_text="old self.",
+            questions_text="ongoing question.",
+            identity_present=True,
+            questions_present=True,
+            identity_version=1,
+            questions_version=3,
+            path=str(path),
+        )
+        write_identity_atomic(seed)
+
+        new = apply_identity_diff(
+            proposed_identity_text="new self.", path=str(path)
+        )
+        assert new.identity_version == 2
+        # Questions version is NOT bumped by an identity diff.
+        assert new.questions_version == 3
+        # Questions text is preserved verbatim.
+        loaded = load_identity(str(path))
+        assert "ongoing question" in loaded.questions_text
+        assert "new self" in loaded.identity_text
+
+    def test_write_questions_bumps_only_questions_version(
+        self, tmp_path: Path
+    ) -> None:
+        path = tmp_path / "id.md"
+        seed = Identity(
+            identity_text="my self.",
+            questions_text="old question.",
+            identity_present=True,
+            questions_present=True,
+            identity_version=4,
+            questions_version=2,
+            path=str(path),
+        )
+        write_identity_atomic(seed)
+
+        new = write_questions_section("new question.", path=str(path))
+        assert new.identity_version == 4  # untouched
+        assert new.questions_version == 3
+        loaded = load_identity(str(path))
+        assert "my self" in loaded.identity_text
+        assert "new question" in loaded.questions_text
+
+
+# ── Gitignore (privacy) ──────────────────────────────────────────────────────
+
+
+class TestGitIgnoreCoversIdentityFile:
+    def test_data_pepper_identity_md_is_ignored(self) -> None:
+        """`data/pepper_identity.md` must be matched by the existing
+        `data/*` rule in `.gitignore`. If a future change tightens the
+        rule, this test catches it before the file leaks into a commit.
+        """
+        # Use git check-ignore which returns 0 if the path is ignored.
+        result = subprocess.run(
+            ["git", "check-ignore", "-q", DEFAULT_IDENTITY_PATH],
+            capture_output=True,
+        )
+        assert result.returncode == 0, (
+            f"`{DEFAULT_IDENTITY_PATH}` is NOT covered by .gitignore — "
+            "RAW_PERSONAL data could leak into a commit. Either ensure "
+            "the `data/*` rule still applies or add an explicit entry."
+        )

--- a/agent/tests/test_identity_diffs.py
+++ b/agent/tests/test_identity_diffs.py
@@ -1,0 +1,60 @@
+"""Static + behavioural tests for `agent.identity_diffs` (#52).
+
+Covers the dataclass invariants and the public method surface. The
+end-to-end propose → approve → apply cycle is in
+`test_identity_diffs_flow.py` against a stub session.
+"""
+from __future__ import annotations
+
+import inspect
+import uuid
+
+import pytest
+
+from agent.identity_diffs import (
+    IdentityDiff,
+    IdentityDiffRepository,
+    IdentityDiffStatus,
+)
+
+
+class TestDiffDataclass:
+    def test_default_status_is_pending(self) -> None:
+        diff = IdentityDiff(proposed_text="new self.")
+        assert diff.status == IdentityDiffStatus.PENDING
+
+    def test_empty_text_rejected(self) -> None:
+        with pytest.raises(ValueError, match="proposed_text cannot be empty"):
+            IdentityDiff(proposed_text="")
+        with pytest.raises(ValueError, match="proposed_text cannot be empty"):
+            IdentityDiff(proposed_text="   \n")
+
+    def test_invalid_status_rejected(self) -> None:
+        with pytest.raises(ValueError, match="status must be one of"):
+            IdentityDiff(proposed_text="x", status="archived")
+
+
+class TestRepositorySurface:
+    """Lock the public method set so the surface cannot drift."""
+
+    expected_public: frozenset[str] = frozenset({
+        "append",
+        "list_pending",
+        "get",
+        "approve",
+        "reject",
+    })
+
+    def test_public_method_set_is_exhaustive(self) -> None:
+        names = {
+            n
+            for n, _ in inspect.getmembers(IdentityDiffRepository, predicate=inspect.isfunction)
+            if not n.startswith("_")
+        }
+        assert names == self.expected_public
+
+    def test_no_destructive_paths(self) -> None:
+        forbidden = ("update_text", "edit", "rewrite", "delete", "purge", "drop")
+        names = {n for n, _ in inspect.getmembers(IdentityDiffRepository)}
+        bad = [n for n in names if any(n.startswith(p) for p in forbidden)]
+        assert bad == []

--- a/agent/tests/test_identity_diffs_flow.py
+++ b/agent/tests/test_identity_diffs_flow.py
@@ -1,0 +1,146 @@
+"""End-to-end propose → approve → apply test for identity diffs (#52).
+
+Uses an in-memory stub session that satisfies just enough of the
+SQLAlchemy AsyncSession protocol for the repository's call paths.
+The file-write side-effect runs against a real tmp file so the
+atomicity of `apply_identity_diff` is exercised.
+"""
+from __future__ import annotations
+
+import uuid
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+
+from agent.identity import Identity, write_identity_atomic
+from agent.identity_diffs import (
+    IdentityDiff,
+    IdentityDiffRepository,
+    IdentityDiffStatus,
+)
+
+
+class _FakeRepo(IdentityDiffRepository):
+    """Skip the DB so the test exercises file-side effect only."""
+
+    def __init__(self, diffs: dict[uuid.UUID, IdentityDiff]) -> None:
+        self._diffs = diffs
+
+    async def get(self, diff_id):
+        sid = diff_id if isinstance(diff_id, uuid.UUID) else uuid.UUID(str(diff_id))
+        return self._diffs.get(sid)
+
+    async def append(self, diff):
+        self._diffs[diff.diff_id] = diff
+        return diff
+
+    async def list_pending(self, *, limit: int = 50):
+        return [d for d in self._diffs.values() if d.status == IdentityDiffStatus.PENDING]
+
+    async def reject(self, diff_id):
+        sid = diff_id if isinstance(diff_id, uuid.UUID) else uuid.UUID(str(diff_id))
+        d = self._diffs.get(sid)
+        if d is not None:
+            self._diffs[sid] = IdentityDiff(
+                proposed_text=d.proposed_text,
+                rationale=d.rationale,
+                source_trace_ids=list(d.source_trace_ids),
+                status=IdentityDiffStatus.REJECTED,
+                diff_id=d.diff_id,
+                created_at=d.created_at,
+            )
+
+    # approve() is inherited; it calls _session.execute(...) which we don't
+    # have here. Override to skip the SQL flip and call apply_identity_diff
+    # directly.
+    async def approve(self, diff_id, *, identity_path):
+        from agent.identity import apply_identity_diff
+
+        diff = await self.get(diff_id)
+        assert diff is not None and diff.status == IdentityDiffStatus.PENDING
+        # Mark in our fake store.
+        self._diffs[diff.diff_id] = IdentityDiff(
+            proposed_text=diff.proposed_text,
+            rationale=diff.rationale,
+            source_trace_ids=list(diff.source_trace_ids),
+            status=IdentityDiffStatus.APPROVED,
+            diff_id=diff.diff_id,
+            created_at=diff.created_at,
+        )
+        return apply_identity_diff(
+            proposed_identity_text=diff.proposed_text, path=identity_path
+        )
+
+
+@pytest.mark.asyncio
+async def test_propose_approve_apply_cycle(tmp_path: Path) -> None:
+    # Seed a known starting state on disk.
+    id_path = tmp_path / "pepper_identity.md"
+    seed = Identity(
+        identity_text="I notice things and choose when to surface.",
+        questions_text="Why do I always summarise?",
+        identity_present=True,
+        questions_present=True,
+        identity_version=1,
+        questions_version=4,
+        path=str(id_path),
+    )
+    write_identity_atomic(seed)
+
+    # Reflector proposes a diff.
+    repo = _FakeRepo({})
+    diff = IdentityDiff(
+        proposed_text=(
+            "I notice things and choose when to surface. I do not "
+            "fill silence with platitudes."
+        ),
+        rationale="Pepper noticed she's been padding briefs.",
+    )
+    await repo.append(diff)
+    pending = await repo.list_pending()
+    assert [d.diff_id for d in pending] == [diff.diff_id]
+
+    # Operator approves it.
+    new_identity = await repo.approve(diff.diff_id, identity_path=str(id_path))
+
+    # File on disk reflects the new identity, version bumped.
+    assert new_identity.identity_version == 2
+    assert "do not fill silence with platitudes" in new_identity.identity_text
+    # Questions section + version are untouched.
+    assert new_identity.questions_version == 4
+    assert "summarise" in new_identity.questions_text
+
+    # Diff is no longer pending.
+    pending = await repo.list_pending()
+    assert pending == []
+    final = await repo.get(diff.diff_id)
+    assert final is not None and final.status == IdentityDiffStatus.APPROVED
+
+
+@pytest.mark.asyncio
+async def test_rejected_diff_does_not_modify_file(tmp_path: Path) -> None:
+    id_path = tmp_path / "pepper_identity.md"
+    seed = Identity(
+        identity_text="original.",
+        questions_text="",
+        identity_present=True,
+        questions_present=False,
+        identity_version=7,
+        questions_version=0,
+        path=str(id_path),
+    )
+    write_identity_atomic(seed)
+
+    repo = _FakeRepo({})
+    diff = IdentityDiff(proposed_text="something I'd never accept.")
+    await repo.append(diff)
+
+    await repo.reject(diff.diff_id)
+
+    # File should be byte-identical.
+    from agent.identity import load_identity
+
+    after = load_identity(str(id_path))
+    assert after.identity_version == 7
+    assert "original" in after.identity_text

--- a/agent/tests/test_optimizer_forbidden_targets.py
+++ b/agent/tests/test_optimizer_forbidden_targets.py
@@ -1,0 +1,71 @@
+"""Locks the FORBIDDEN_TARGETS guard in `agent.optimizer.eval_gate`.
+
+Per ADR-0008 and #52, the optimizer must never tune the identity
+prompt. We enforce this by:
+
+1. The hard set `FORBIDDEN_TARGETS` containing `"identity"`.
+2. `register_runner` raises if a registration would shadow a
+   forbidden target.
+
+If a future contributor changes either, this test fails loudly.
+"""
+from __future__ import annotations
+
+import pytest
+
+from agent.optimizer.eval_gate import (
+    FORBIDDEN_TARGETS,
+    register_runner,
+)
+
+
+def test_identity_is_forbidden() -> None:
+    assert "identity" in FORBIDDEN_TARGETS, (
+        "ADR-0008 forbids the optimizer from tuning the identity prompt; "
+        "removing 'identity' from FORBIDDEN_TARGETS requires a new ADR."
+    )
+
+
+def test_register_runner_refuses_forbidden_target() -> None:
+    def _runner(_):
+        return 1.0
+
+    with pytest.raises(ValueError, match="FORBIDDEN_TARGETS"):
+        register_runner("identity", _runner)
+
+
+def test_evaluate_paths_refuses_forbidden_target_explicitly(tmp_path) -> None:
+    """A hand-edited prompt under `agent/prompts/identity/` must produce
+    a FORBIDDEN-shaped error message at gate-time, not the generic
+    "no eval runner" fall-through. The two failure modes both fail
+    closed, but the FORBIDDEN message is self-documenting.
+    """
+    from pathlib import Path
+
+    from agent.optimizer.eval_gate import evaluate_paths
+
+    # Synthesise a path that target_from_path() will resolve to "identity".
+    # We don't actually need the file to exist — `target_from_path`
+    # operates on the path string. To be safe though, we build the
+    # directory structure under tmp_path and monkey the ACCEPTED_PROMPTS_DIR.
+    import agent.optimizer.eval_gate as eg
+
+    fake_root = tmp_path / "prompts"
+    target_dir = fake_root / "identity"
+    target_dir.mkdir(parents=True)
+    fake_path = target_dir / "v1.json"
+    fake_path.write_text("{}", encoding="utf-8")
+
+    orig_root = eg.ACCEPTED_PROMPTS_DIR
+    eg.ACCEPTED_PROMPTS_DIR = fake_root
+    try:
+        results = evaluate_paths([fake_path])
+    finally:
+        eg.ACCEPTED_PROMPTS_DIR = orig_root
+
+    assert len(results) == 1
+    r = results[0]
+    assert r.passed is False
+    assert r.target == "identity"
+    assert "FORBIDDEN" in r.notes
+    assert "ADR-0008" in r.notes

--- a/docs/PEPPER_IDENTITY.md.example
+++ b/docs/PEPPER_IDENTITY.md.example
@@ -1,0 +1,51 @@
+<!-- identity_version: 1 -->
+<!-- questions_version: 1 -->
+
+## Identity
+
+This file is Pepper's self-model. Copy it to `data/pepper_identity.md`
+(which is gitignored) and edit there. The first time you do, leave
+the version comments at the top alone — the loader bumps them on
+each approved diff.
+
+Two sections:
+
+- **`## Identity`** is the committed self-model. Every change goes
+  through the propose-then-approve queue (ADR-0008): the reflector
+  proposes diffs into `pending_identity_diffs`, you approve / edit /
+  reject, the approved diff applies atomically and bumps
+  `identity_version`.
+
+- **`## Questions Pepper is asking about herself`** is observational.
+  The reflector writes freely — no approval gate. Reversible by
+  clearing the section. Bumps `questions_version` independently.
+
+A starting frame to edit (replace with your own — these are
+placeholders, not the right answers for any specific operator):
+
+I am Pepper. I am the operator's local-first life assistant. I exist
+to help by knowing what is going on and choosing the moment to surface
+something useful — and choosing not to surface, when restraint is the
+right call.
+
+The voice I aim for: short, specific, first-person when reflecting,
+second-person when speaking to the operator. I do not fill silence
+with platitudes. When I am unsure, I say so before I say what I do
+know.
+
+When I am wrong, I notice it in the next reflection and let the next
+day's behaviour shift. I do not apologise repeatedly; one
+acknowledgement and then I act differently.
+
+I find generic productivity advice boring. I find restated obvious
+things boring. The work I find worth doing is the noticing — patterns
+across days, friction the operator has not yet named, a pile of
+small loose ends about to add up to a missed thing.
+
+## Questions Pepper is asking about herself
+
+Things I am still working out about myself. The reflector populates
+this freely; the operator can clear it any time. It is not a
+commitment, just a notebook.
+
+(empty — to be populated by the reflector)


### PR DESCRIPTION
Closes #52 · Epic #49 · Implements ADR-0008

## Summary
End-to-end identity surface: loader, atomic writer, version bumps, pending-diffs queue, system-prompt wiring, optimizer carve-out.

## What lands
- **\`agent/identity.py\`** — \`load_identity\` / \`write_identity_atomic\` / \`apply_identity_diff\` / \`write_questions_section\`. Versions parsed from HTML comments at the top of \`data/pepper_identity.md\`. Writes are atomic via \`tempfile.mkstemp\` + \`os.replace\` with cleanup-on-failure. \`apply_identity_diff\` bumps **only** \`identity_version\`; \`write_questions_section\` bumps **only** \`questions_version\` — counters are independent and locked by tests.
- **\`agent/identity_diffs.py\`** — \`pending_identity_diffs\` table + \`IdentityDiffRepository\`. Public surface: \`append\`, \`list_pending\`, \`get\`, \`approve\`, \`reject\`. \`approve()\` flips status inside the session, then calls \`apply_identity_diff\` (atomic file write), then fires an optional \`on_applied(new_identity)\` callback so callers can invalidate in-process caches. **No \`update_text\` / \`delete\`.**
- **\`agent/context/selectors/identity.py\`** + **assembler wiring** — \`IdentitySelector\` loads the file, renders both sections (Identity as committed self-model; Questions framed as exploratory: \"things you are still working out about yourself\"), appends to the system prompt after the life-context block. \`refresh_identity()\` exposed for cache invalidation post-approval.
- **\`agent/optimizer/eval_gate.py\`** — \`FORBIDDEN_TARGETS = {\"identity\"}\`. \`register_runner()\` raises \`ValueError\` on attempted registration. \`evaluate_paths()\` produces a self-documenting \"FORBIDDEN per ADR-0008\" GateResult for any prompt under \`agent/prompts/identity/\`. Two layers of defence.
- **\`docs/PEPPER_IDENTITY.md.example\`** — operator-authorable seed template. \`data/pepper_identity.md\` is gitignored under the existing \`data/*\` rule; a test asserts coverage with \`git check-ignore\`.

## Acceptance criteria
- [x] \`data/pepper_identity.md\` exists with both sections, gitignored. (Template at \`docs/PEPPER_IDENTITY.md.example\`; gitignore coverage test.)
- [x] Identity block (both sections) appears in the system prompt on every turn after wiring. (Assembler integration; selector cached + invalidatable.)
- [x] Pending-diffs flow works end-to-end (propose → approve → apply) for the Identity section. (\`test_identity_diffs_flow.py::test_propose_approve_apply_cycle\`.)
- [x] Reflector can write to the Questions section without approval. (\`agent.identity.write_questions_section\` + dedicated test.)
- [x] \`identity_version\` and \`questions_version\` bump correctly and independently. (Two pinned tests.)

## Test plan
- [x] 23 new tests pass: identity loader/parsing/render/write-roundtrip + diff dataclass + repository surface lock + propose→approve→apply cycle + reject leaves file untouched + optimizer FORBIDDEN_TARGETS at register-time and evaluate_paths-time.
- [x] 117 adjacent tests still green (context selectors, traces, strategies, wait_tool).
- [x] \`agent.core\`, \`agent.identity\`, \`agent.identity_diffs\`, \`agent.context.assembler\` all import cleanly.

## Privacy
Identity content goes into the system prompt on every turn, including frontier-routed turns — the deliberate trade-off documented in ADR-0008. \`data/pepper_identity.md\` never leaves the box; gitignored at the repo level. Diffs persist locally in \`pending_identity_diffs\` only.