### PR TITLE
agent/strategies_tools: query/update tools + UI inspector (#54)

### DIFF
--- a/agent/context/assembler.py
+++ b/agent/context/assembler.py
@@ -33,6 +33,7 @@ from agent.context.selectors import (
     LifeContextSelector,
     RetrievedMemorySelector,
     SkillMatchSelector,
+    StrategyBlockSelector,
 )
 from agent.context.types import AssembledContext, SelectorRecord, Turn
 from agent.identity import DEFAULT_IDENTITY_PATH
@@ -64,6 +65,10 @@ class ContextAssembler:
         # Epic 06 (#52) — identity selector. Loads `data/pepper_identity.md`
         # and renders the two-section block per ADR-0008.
         self._identity = IdentitySelector(identity_path=identity_path)
+        # Epic 06 (#54) — strategy block selector. Snapshot of active
+        # strategies is injected via `set_active_strategies()` before
+        # `assemble()` runs; ranking uses the user input.
+        self._strategy_block = StrategyBlockSelector()
         self._retrieved_memory = RetrievedMemorySelector()
         self._skill_match = SkillMatchSelector(skills_provider=skills_provider)
         self._last_n_turns = LastNTurnsSelector(memory_manager=memory_manager)
@@ -94,6 +99,10 @@ class ContextAssembler:
     def identity_selector(self) -> IdentitySelector:
         return self._identity
 
+    @property
+    def strategy_block_selector(self) -> StrategyBlockSelector:
+        return self._strategy_block
+
     def assemble(self, turn: Turn) -> AssembledContext:
         records: dict[str, SelectorRecord] = {}
 
@@ -112,6 +121,21 @@ class ContextAssembler:
         if id_record.content:
             base_system_prompt = (
                 base_system_prompt.rstrip() + "\n\n" + id_record.content
+            )
+
+        # 1b. Epic 06 (#54) — strategy block. Top-N strategies relevant
+        #     to the current input are appended after the identity. The
+        #     active-strategy snapshot is provided by the caller via
+        #     `set_active_strategies()` before `assemble()` runs. An
+        #     empty snapshot or empty user_message yields no block — no
+        #     content, no append.
+        strat_record = self._strategy_block.select(
+            situation=turn.user_message,
+        )
+        records[strat_record.name] = strat_record
+        if strat_record.content:
+            base_system_prompt = (
+                base_system_prompt.rstrip() + "\n\n" + strat_record.content
             )
 
         # 2. Capability block — diagnostic only; already embedded in the

--- a/agent/context/selectors/__init__.py
+++ b/agent/context/selectors/__init__.py
@@ -12,6 +12,7 @@ from agent.context.selectors.last_n_turns import LastNTurnsSelector
 from agent.context.selectors.life_context import LifeContextSelector
 from agent.context.selectors.retrieved_memory import RetrievedMemorySelector
 from agent.context.selectors.skill_match import SkillMatchSelector
+from agent.context.selectors.strategies import StrategyBlockSelector
 
 __all__ = [
     "CapabilityBlockSelector",
@@ -20,4 +21,5 @@ __all__ = [
     "LifeContextSelector",
     "RetrievedMemorySelector",
     "SkillMatchSelector",
+    "StrategyBlockSelector",
 ]

--- a/agent/context/selectors/strategies.py
+++ b/agent/context/selectors/strategies.py
@@ -1,0 +1,104 @@
+"""StrategyBlockSelector — injects top-N strategies into the system prompt.
+
+Per #54: "Strategy block in the system prompt: top-N strategies
+relevant to the current input (matched by embedding similarity on
+`text`). Bake into the assembler from #32."
+
+v0 ranking is keyword-overlap (Jaccard over salient tokens), wired
+through `agent.strategies_tools.rank_strategies`. Phase 2 swaps this
+for cosine similarity over the existing 1024-dim embedding column —
+the selector's contract is narrow enough that the swap is local.
+
+The selector consumes a *snapshot* of active strategies passed in via
+`set_active_strategies()` so the assembler does not need to perform
+async DB I/O during prompt assembly. Core gathers the snapshot before
+calling `assemble()` (same pattern used for memory_context). When no
+snapshot is set, the selector emits an empty record (graceful boot
+when the strategies module isn't wired yet).
+
+Optimizer carve-out: `strategy_block_v0` is recorded as a selector
+name on the trace's assembled_context so future contributors who add
+a `strategy_block` optimizer target can be reminded that the strategy
+TEXT is operator-authored and approval-gated. The OPTIMIZATION of
+this selector's *prompt template* (the wrapper text around the
+strategies) IS allowed; the strategies themselves are not.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from agent.context.types import SelectorRecord
+from agent.strategies.repository import Strategy
+from agent.strategies_tools import DEFAULT_TOP_K, rank_strategies
+
+
+class StrategyBlockSelector:
+    """Read-side selector for the strategy block in the system prompt."""
+
+    name = "strategies"
+
+    def __init__(self, *, top_k: int = DEFAULT_TOP_K) -> None:
+        self._top_k = top_k
+        self._active: list[Strategy] = []
+
+    def set_active_strategies(self, strategies: list[Strategy]) -> None:
+        """Inject the active-strategy snapshot for the next select() call.
+
+        Called by core right before assembly. Pass an empty list (or
+        omit) to suppress the strategy block — the selector emits an
+        empty record cleanly.
+        """
+        self._active = list(strategies or [])
+
+    def select(self, *, situation: str = "") -> SelectorRecord:
+        if not self._active or not situation.strip():
+            return SelectorRecord(
+                name=self.name,
+                content="",
+                provenance={
+                    "selector": self.name,
+                    "active_count": len(self._active),
+                    "situation_chars": len(situation),
+                    "strategies_used": [],
+                },
+            )
+
+        ranked = rank_strategies(situation, self._active, top_k=self._top_k)
+        if not ranked:
+            return SelectorRecord(
+                name=self.name,
+                content="",
+                provenance={
+                    "selector": self.name,
+                    "active_count": len(self._active),
+                    "situation_chars": len(situation),
+                    "strategies_used": [],
+                },
+            )
+
+        # Render the block. Each strategy is on its own line with its
+        # confidence — the operator sees what was injected; the model
+        # sees something it can name in its reasoning.
+        lines = ["[Strategies relevant to this turn]"]
+        for strategy, score in ranked:
+            lines.append(
+                f"- {strategy.text} "
+                f"(score={score:.2f}, confidence={strategy.confidence:.2f})"
+            )
+        content = "\n".join(lines)
+
+        provenance: dict[str, Any] = {
+            "selector": self.name,
+            "active_count": len(self._active),
+            "situation_chars": len(situation),
+            "strategies_used": [
+                {
+                    "strategy_id": str(s.strategy_id),
+                    "version": s.version,
+                    "score": round(score, 4),
+                    "confidence": s.confidence,
+                }
+                for s, score in ranked
+            ],
+        }
+        return SelectorRecord(name=self.name, content=content, provenance=provenance)

--- a/agent/core.py
+++ b/agent/core.py
@@ -34,6 +34,10 @@ from agent.error_classifier import ClassifiedLLMError, ErrorCategory
 from agent.skills import load_all_skills
 from agent.skill_reviewer import SkillReviewer
 from agent.skill_tools import SKILL_TOOLS, execute_skill_tool
+from agent.strategies_tools import (
+    STRATEGIES_TOOLS,
+    execute_strategies_tool,
+)
 from agent.wait_tool import WAIT_TOOLS, WaitsRegistry, execute_wait
 from agent.web_search import brave_search, brave_image_search
 from agent.routing import get_driving_time
@@ -4113,6 +4117,7 @@ class PepperCore:
                 + SKILL_TOOLS
                 + SEND_TOOLS
                 + WAIT_TOOLS
+                + STRATEGIES_TOOLS
                 + _PENDING_ACTION_TOOLS
             )
         # Phase 5: append MCP tools discovered from external servers
@@ -4650,6 +4655,25 @@ class PepperCore:
                 result = await execute_wait(
                     args, registry=self.waits, session_id=session_id
                 )
+
+            elif name in {"query_strategies", "propose_strategy_update"}:
+                # Epic 06 (#54) — Strategy Hub tools. propose_strategy_update
+                # NEVER writes directly; it routes through the
+                # pending_strategy_diffs queue. query_strategies is read-only
+                # but bumps usage_count on matched rows.
+                if self.db_factory is None:
+                    result = {"error": "strategies tools require the DB"}
+                else:
+                    from agent.strategies.repository import StrategyRepository
+                    from agent.strategy_diffs import StrategyDiffRepository
+
+                    async with self.db_factory() as session:
+                        srepo = StrategyRepository(session)
+                        drepo = StrategyDiffRepository(session, srepo)
+                        result = await execute_strategies_tool(
+                            name, args, repo=srepo, diffs_repo=drepo
+                        )
+                        await session.commit()
 
             elif name == "queue_outbound_action":
                 # Phase 6.7: model calls this when it has a draft action ready

--- a/agent/db.py
+++ b/agent/db.py
@@ -60,6 +60,8 @@ async def init_db(config=None) -> None:
         import agent.strategies.repository  # noqa: F401  (side-effect import)
         # Epic 06 (#52) — pending_identity_diffs table.
         import agent.identity_diffs  # noqa: F401  (side-effect import)
+        # Epic 06 (#54) — pending_strategy_diffs table.
+        import agent.strategy_diffs  # noqa: F401  (side-effect import)
 
         # 2. Create all tables defined via Base
         await conn.run_sync(Base.metadata.create_all)

--- a/agent/strategies_tools.py
+++ b/agent/strategies_tools.py
@@ -1,0 +1,332 @@
+"""LLM-facing tools for the Strategy Hub (#54).
+
+Two tools:
+
+- ``query_strategies(situation, top_k=5)`` — read-only. Returns the
+  top-k active strategies most relevant to the operator-described
+  situation. v0 ranking: keyword overlap on token sets (no embedding
+  call). The repository's ``bump_usage`` is invoked on the matched
+  strategies so the confidence score reflects real usage.
+
+- ``propose_strategy_update(strategy_id?, new_text, reason)`` — write
+  path. Routes through ``pending_strategy_diffs``; **never writes
+  directly** to the strategies table. ``strategy_id`` is optional —
+  when present, the proposal is a new version of an existing
+  strategy; when absent, a new lineage. Per #54 AC, the optimizer is
+  forbidden from optimizing the strategy block (enforced separately
+  via FORBIDDEN_TARGETS in the optimizer).
+
+The dispatcher accepts an injected pair of repositories so the tool
+implementations stay framework-agnostic (testable with stubs, no
+direct DB import paths in the schema module). The caller in
+``agent/core.py`` wires real repositories at request time.
+"""
+from __future__ import annotations
+
+import re
+import uuid as _uuid
+from typing import Any, Callable, Optional
+
+import structlog
+
+from agent.strategies.repository import (
+    Strategy,
+    StrategyCreatedBy,
+    StrategyRepository,
+    StrategyStatus,
+)
+from agent.strategy_diffs import StrategyDiff, StrategyDiffRepository
+
+logger = structlog.get_logger(__name__)
+
+
+# ── Constants ────────────────────────────────────────────────────────────────
+
+MAX_SITUATION_LEN: int = 2000
+MAX_NEW_TEXT_LEN: int = 2000
+MAX_REASON_LEN: int = 2000
+DEFAULT_TOP_K: int = 5
+MAX_TOP_K: int = 20
+
+# Words too generic to score on. Kept tiny on purpose — for v0 we
+# accept some noise; the LLM's situation text will dominate the
+# overlap if there's any signal there at all.
+_STOPWORDS: frozenset[str] = frozenset({
+    "a", "an", "and", "the", "is", "are", "was", "were", "be", "to",
+    "of", "for", "in", "on", "at", "by", "with", "as", "it", "this",
+    "that", "i", "we", "you", "they", "he", "she", "do", "does",
+    "did", "should", "would", "could", "have", "has", "had", "but",
+    "or", "if", "when", "while", "from", "into", "about", "over",
+})
+
+_TOKEN_RE = re.compile(r"[a-z0-9]+")
+
+
+# ── Tool schema ──────────────────────────────────────────────────────────────
+
+
+STRATEGIES_TOOLS = [
+    {
+        "type": "function",
+        "side_effects": False,
+        "function": {
+            "name": "query_strategies",
+            "description": (
+                "Retrieve the most relevant interpretable strategies for "
+                "the current situation. Strategies are short, "
+                "operator-readable rules ('When X, do Y') stored in the "
+                "Strategy Hub. Use this when you want to ground a "
+                "decision in a strategy that has been validated by the "
+                "operator (or proposed by you and approved). Returns up "
+                "to top_k matches with a relevance score. Calling this "
+                "tool also bumps the matched strategies' usage_count, "
+                "which feeds confidence."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "situation": {
+                        "type": "string",
+                        "description": (
+                            "Plain-language description of the situation "
+                            "you want strategies for. Required."
+                        ),
+                    },
+                    "top_k": {
+                        "type": "integer",
+                        "description": (
+                            "How many strategies to return (default 5, "
+                            "max 20)."
+                        ),
+                    },
+                },
+                "required": ["situation"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "side_effects": True,
+        "function": {
+            "name": "propose_strategy_update",
+            "description": (
+                "Propose a new strategy or a new version of an existing "
+                "one. The proposal is queued for operator approval — it "
+                "is NEVER applied directly to the Strategy Hub. Use "
+                "when you notice a recurring pattern that justifies a "
+                "rule, or when an existing strategy needs revision. If "
+                "strategy_id is omitted, the proposal is a new lineage."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "strategy_id": {
+                        "type": "string",
+                        "description": (
+                            "UUID of the strategy this proposal supersedes. "
+                            "Omit for a new lineage."
+                        ),
+                    },
+                    "new_text": {
+                        "type": "string",
+                        "description": (
+                            "The strategy in natural language, one sentence. "
+                            "Required."
+                        ),
+                    },
+                    "reason": {
+                        "type": "string",
+                        "description": (
+                            "Why this update — the trace-grounded rationale "
+                            "the operator will read when deciding. Required."
+                        ),
+                    },
+                },
+                "required": ["new_text", "reason"],
+            },
+        },
+    },
+]
+
+
+# ── Ranking primitives ───────────────────────────────────────────────────────
+
+
+def _tokenize(text: str) -> set[str]:
+    return {
+        t
+        for t in _TOKEN_RE.findall(text.lower())
+        if t and t not in _STOPWORDS and len(t) > 2
+    }
+
+
+def _score_overlap(situation_tokens: set[str], strategy_text: str) -> float:
+    """Symmetric Jaccard over salient tokens, in [0, 1].
+
+    v0. Phase 2 will swap this for cosine similarity over the
+    `qwen3-embedding:0.6b` embedding column we already index.
+    """
+    if not situation_tokens:
+        return 0.0
+    s_tokens = _tokenize(strategy_text)
+    if not s_tokens:
+        return 0.0
+    intersection = situation_tokens & s_tokens
+    if not intersection:
+        return 0.0
+    union = situation_tokens | s_tokens
+    return len(intersection) / len(union)
+
+
+def rank_strategies(
+    situation: str,
+    strategies: list[Strategy],
+    *,
+    top_k: int = DEFAULT_TOP_K,
+) -> list[tuple[Strategy, float]]:
+    """Rank `strategies` by relevance to `situation`. Returns sorted
+    descending by score with ties broken by recency.
+
+    Strategies with score 0.0 are filtered out — surfacing irrelevant
+    strategies in the model's tool result is worse than returning
+    fewer.
+    """
+    situation_tokens = _tokenize(situation)
+    scored: list[tuple[Strategy, float]] = []
+    for s in strategies:
+        score = _score_overlap(situation_tokens, s.text)
+        if score > 0.0:
+            scored.append((s, score))
+    scored.sort(
+        key=lambda pair: (pair[1], pair[0].created_at),
+        reverse=True,
+    )
+    return scored[:top_k]
+
+
+# ── Executors ────────────────────────────────────────────────────────────────
+
+
+async def execute_query_strategies(
+    args: dict[str, Any],
+    *,
+    repo: StrategyRepository,
+) -> dict[str, Any]:
+    raw_situation = args.get("situation")
+    if not isinstance(raw_situation, str) or not raw_situation.strip():
+        return {"error": "query_strategies requires a non-empty 'situation'"}
+    if len(raw_situation) > MAX_SITUATION_LEN:
+        return {"error": f"situation exceeds {MAX_SITUATION_LEN} chars"}
+    raw_top_k = args.get("top_k", DEFAULT_TOP_K)
+    try:
+        top_k = int(raw_top_k)
+    except (TypeError, ValueError):
+        return {"error": "top_k must be an integer"}
+    if top_k < 1:
+        return {"error": "top_k must be >= 1"}
+    if top_k > MAX_TOP_K:
+        top_k = MAX_TOP_K
+
+    active = await repo.query_active(limit=200)
+    ranked = rank_strategies(raw_situation, active, top_k=top_k)
+
+    out_strategies: list[dict[str, Any]] = []
+    for strategy, score in ranked:
+        # Bump usage on each match — feeds confidence v0. We do this
+        # whether or not the model ends up using the strategy because
+        # surfacing it to the model is itself "use."
+        await repo.bump_usage(strategy.strategy_id)
+        out_strategies.append(
+            {
+                "strategy_id": str(strategy.strategy_id),
+                "text": strategy.text,
+                "version": strategy.version,
+                "created_by": strategy.created_by,
+                "score": round(score, 4),
+                "confidence": strategy.confidence,
+            }
+        )
+
+    logger.info(
+        "query_strategies_executed",
+        top_k=top_k,
+        match_count=len(out_strategies),
+    )
+    return {
+        "ok": True,
+        "count": len(out_strategies),
+        "strategies": out_strategies,
+    }
+
+
+async def execute_propose_strategy_update(
+    args: dict[str, Any],
+    *,
+    diffs_repo: StrategyDiffRepository,
+    proposed_by: str = StrategyCreatedBy.JACK,
+) -> dict[str, Any]:
+    raw_strategy_id = args.get("strategy_id")
+    raw_new_text = args.get("new_text")
+    raw_reason = args.get("reason")
+
+    if not isinstance(raw_new_text, str) or not raw_new_text.strip():
+        return {"error": "propose_strategy_update requires a non-empty 'new_text'"}
+    if len(raw_new_text) > MAX_NEW_TEXT_LEN:
+        return {"error": f"new_text exceeds {MAX_NEW_TEXT_LEN} chars"}
+    if not isinstance(raw_reason, str) or not raw_reason.strip():
+        return {"error": "propose_strategy_update requires a non-empty 'reason'"}
+    if len(raw_reason) > MAX_REASON_LEN:
+        return {"error": f"reason exceeds {MAX_REASON_LEN} chars"}
+
+    target_strategy_id: Optional[_uuid.UUID] = None
+    if raw_strategy_id:
+        if not isinstance(raw_strategy_id, str):
+            return {"error": "strategy_id must be a UUID string"}
+        try:
+            target_strategy_id = _uuid.UUID(raw_strategy_id)
+        except ValueError:
+            return {"error": f"strategy_id is not a valid UUID: {raw_strategy_id!r}"}
+
+    diff = StrategyDiff(
+        proposed_text=raw_new_text.strip(),
+        rationale=raw_reason.strip(),
+        target_strategy_id=target_strategy_id,
+        proposed_by=proposed_by,
+    )
+    await diffs_repo.append(diff)
+
+    logger.info(
+        "propose_strategy_update_queued",
+        diff_id=str(diff.diff_id),
+        target_strategy_id=str(target_strategy_id) if target_strategy_id else None,
+    )
+    return {
+        "ok": True,
+        "queued": True,
+        "diff_id": str(diff.diff_id),
+        "target_strategy_id": str(target_strategy_id) if target_strategy_id else None,
+        "message": (
+            "Strategy update proposed. The operator will see it in the "
+            "pending-actions queue and decide whether to apply."
+        ),
+    }
+
+
+# ── Dispatcher ───────────────────────────────────────────────────────────────
+
+
+async def execute_strategies_tool(
+    name: str,
+    args: dict[str, Any],
+    *,
+    repo: StrategyRepository,
+    diffs_repo: StrategyDiffRepository,
+    proposed_by: str = StrategyCreatedBy.JACK,
+) -> dict[str, Any]:
+    if name == "query_strategies":
+        return await execute_query_strategies(args, repo=repo)
+    if name == "propose_strategy_update":
+        return await execute_propose_strategy_update(
+            args, diffs_repo=diffs_repo, proposed_by=proposed_by
+        )
+    return {"error": f"unknown strategies tool: {name!r}"}

--- a/agent/strategy_diffs.py
+++ b/agent/strategy_diffs.py
@@ -1,0 +1,254 @@
+"""Persistence + flow for proposed strategy updates (#54).
+
+Sibling to `agent/identity_diffs.py`. The `pending_strategy_diffs`
+table holds reflector- (or model-) proposed updates to the strategy
+hub. Each row is one proposed update with status `pending | approved
+| rejected`. Approval applies the diff via `StrategyRepository`:
+
+- `strategy_id` is null → new strategy lineage (`append`).
+- `strategy_id` is set → new version of an existing strategy
+  (`append_version`).
+
+This module only exposes append + status flips; the actual repository
+write is performed by `approve()` against an injected
+`StrategyRepository`.
+"""
+from __future__ import annotations
+
+import uuid as _uuid
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Optional
+
+import structlog
+from sqlalchemy import DateTime, Index, String, Text, select, update
+from sqlalchemy.dialects.postgresql import ARRAY, UUID
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import Mapped, mapped_column
+
+from agent.db import Base
+from agent.strategies.repository import (
+    Strategy,
+    StrategyCreatedBy,
+    StrategyRepository,
+)
+
+logger = structlog.get_logger(__name__)
+
+
+class StrategyDiffStatus:
+    PENDING = "pending"
+    APPROVED = "approved"
+    REJECTED = "rejected"
+
+    ALL: frozenset[str] = frozenset({PENDING, APPROVED, REJECTED})
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _new_diff_id() -> _uuid.UUID:
+    return _uuid.uuid4()
+
+
+@dataclass
+class StrategyDiff:
+    """One proposed strategy update.
+
+    `target_strategy_id` is None for a brand-new strategy lineage; set
+    to the parent's `strategy_id` for a new version of an existing one.
+    """
+
+    proposed_text: str
+    rationale: str = ""
+    target_strategy_id: Optional[_uuid.UUID] = None
+    proposed_by: str = StrategyCreatedBy.REFLECTOR
+    source_trace_ids: list[_uuid.UUID] = field(default_factory=list)
+    status: str = StrategyDiffStatus.PENDING
+    diff_id: _uuid.UUID = field(default_factory=_new_diff_id)
+    created_at: datetime = field(default_factory=_utcnow)
+    decided_at: Optional[datetime] = None
+
+    def __post_init__(self) -> None:
+        if not self.proposed_text or not self.proposed_text.strip():
+            raise ValueError("strategy diff proposed_text cannot be empty")
+        if self.status not in StrategyDiffStatus.ALL:
+            raise ValueError(
+                f"strategy diff status must be one of "
+                f"{sorted(StrategyDiffStatus.ALL)}, got {self.status!r}"
+            )
+        if self.proposed_by not in StrategyCreatedBy.ALL:
+            raise ValueError(
+                f"proposed_by must be one of {sorted(StrategyCreatedBy.ALL)}, "
+                f"got {self.proposed_by!r}"
+            )
+
+
+class StrategyDiffRow(Base):
+    __tablename__ = "pending_strategy_diffs"
+
+    diff_id: Mapped[_uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        default=_uuid.uuid4,
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False
+    )
+    target_strategy_id: Mapped[Optional[_uuid.UUID]] = mapped_column(
+        UUID(as_uuid=True), nullable=True
+    )
+    proposed_text: Mapped[str] = mapped_column(Text, nullable=False)
+    rationale: Mapped[str] = mapped_column(Text, nullable=False, default="")
+    proposed_by: Mapped[str] = mapped_column(
+        String(32), nullable=False, default=StrategyCreatedBy.REFLECTOR
+    )
+    source_trace_ids: Mapped[list[_uuid.UUID]] = mapped_column(
+        ARRAY(UUID(as_uuid=True)), nullable=False, default=list
+    )
+    status: Mapped[str] = mapped_column(
+        String(16), nullable=False, default=StrategyDiffStatus.PENDING
+    )
+    decided_at: Mapped[Optional[datetime]] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+
+    __table_args__ = (
+        Index("idx_pending_strategy_diffs_status", "status"),
+        Index("idx_pending_strategy_diffs_created_at", "created_at"),
+        Index("idx_pending_strategy_diffs_target", "target_strategy_id"),
+    )
+
+
+def _row_to_dataclass(row: StrategyDiffRow) -> StrategyDiff:
+    return StrategyDiff(
+        proposed_text=row.proposed_text,
+        rationale=row.rationale,
+        target_strategy_id=row.target_strategy_id,
+        proposed_by=row.proposed_by,
+        source_trace_ids=list(row.source_trace_ids or []),
+        status=row.status,
+        diff_id=row.diff_id,
+        created_at=row.created_at,
+        decided_at=row.decided_at,
+    )
+
+
+class StrategyDiffRepository:
+    """Read/write surface for `pending_strategy_diffs`.
+
+    Public methods: append, list_pending, get, reject, approve. There
+    is no `update_text` and no `delete` — once a diff is recorded, the
+    audit trail is permanent.
+
+    `approve()` calls into `StrategyRepository.append` (for new
+    lineages, target_strategy_id=None) or `StrategyRepository.append_version`
+    (for new versions of existing strategies). Identity-diffs land
+    file changes; strategy-diffs land DB rows. Otherwise the shape
+    matches.
+    """
+
+    def __init__(
+        self,
+        session: AsyncSession,
+        strategies_repo: StrategyRepository,
+    ) -> None:
+        self._session = session
+        self._strategies = strategies_repo
+
+    async def append(self, diff: StrategyDiff) -> StrategyDiff:
+        if diff.status != StrategyDiffStatus.PENDING:
+            raise ValueError(
+                "append() only accepts PENDING diffs; "
+                f"got {diff.status!r}"
+            )
+        row = StrategyDiffRow(
+            diff_id=diff.diff_id,
+            created_at=diff.created_at,
+            target_strategy_id=diff.target_strategy_id,
+            proposed_text=diff.proposed_text,
+            rationale=diff.rationale,
+            proposed_by=diff.proposed_by,
+            source_trace_ids=list(diff.source_trace_ids or []),
+            status=diff.status,
+            decided_at=diff.decided_at,
+        )
+        self._session.add(row)
+        await self._session.flush()
+        return diff
+
+    async def list_pending(self, *, limit: int = 50) -> list[StrategyDiff]:
+        if limit <= 0:
+            raise ValueError("limit must be positive")
+        stmt = (
+            select(StrategyDiffRow)
+            .where(StrategyDiffRow.status == StrategyDiffStatus.PENDING)
+            .order_by(StrategyDiffRow.created_at.desc())
+            .limit(limit)
+        )
+        result = await self._session.execute(stmt)
+        return [_row_to_dataclass(r) for r in result.scalars().all()]
+
+    async def get(self, diff_id) -> Optional[StrategyDiff]:
+        sid = diff_id if isinstance(diff_id, _uuid.UUID) else _uuid.UUID(str(diff_id))
+        result = await self._session.execute(
+            select(StrategyDiffRow).where(StrategyDiffRow.diff_id == sid)
+        )
+        row = result.scalar_one_or_none()
+        return _row_to_dataclass(row) if row is not None else None
+
+    async def reject(self, diff_id) -> None:
+        sid = diff_id if isinstance(diff_id, _uuid.UUID) else _uuid.UUID(str(diff_id))
+        await self._session.execute(
+            update(StrategyDiffRow)
+            .where(
+                StrategyDiffRow.diff_id == sid,
+                StrategyDiffRow.status == StrategyDiffStatus.PENDING,
+            )
+            .values(status=StrategyDiffStatus.REJECTED, decided_at=_utcnow())
+        )
+        logger.info("strategy_diff_rejected", diff_id=str(sid))
+
+    async def approve(self, diff_id) -> Strategy:
+        diff = await self.get(diff_id)
+        if diff is None:
+            raise LookupError(f"strategy diff {diff_id} does not exist")
+        if diff.status != StrategyDiffStatus.PENDING:
+            raise ValueError(
+                f"strategy diff {diff.diff_id} is in status "
+                f"{diff.status!r}, expected pending"
+            )
+        await self._session.execute(
+            update(StrategyDiffRow)
+            .where(StrategyDiffRow.diff_id == diff.diff_id)
+            .values(status=StrategyDiffStatus.APPROVED, decided_at=_utcnow())
+        )
+        if diff.target_strategy_id is None:
+            new_strategy = await self._strategies.append(
+                Strategy(
+                    text=diff.proposed_text,
+                    created_by=diff.proposed_by,
+                    source_trace_ids=list(diff.source_trace_ids),
+                )
+            )
+        else:
+            parent = await self._strategies.get(diff.target_strategy_id)
+            if parent is None:
+                raise LookupError(
+                    f"target strategy {diff.target_strategy_id} not found"
+                )
+            new_strategy = await self._strategies.append_version(
+                parent=parent,
+                new_text=diff.proposed_text,
+                created_by=diff.proposed_by,
+                source_trace_ids=list(diff.source_trace_ids),
+            )
+        logger.info(
+            "strategy_diff_approved",
+            diff_id=str(diff.diff_id),
+            new_strategy_id=str(new_strategy.strategy_id),
+            new_version=new_strategy.version,
+        )
+        return new_strategy

--- a/agent/tests/test_strategies_tools.py
+++ b/agent/tests/test_strategies_tools.py
@@ -1,0 +1,265 @@
+"""Unit tests for `agent.strategies_tools` (#54).
+
+Covers:
+- tool schema declares required fields
+- query_strategies validates input + bumps usage on matches
+- ranking returns top_k by Jaccard overlap, ties broken by recency
+- propose_strategy_update NEVER writes directly — it goes through the
+  diffs queue
+- propose_strategy_update validates input
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock
+
+import pytest
+
+from agent.strategies.repository import (
+    Strategy,
+    StrategyCreatedBy,
+    StrategyStatus,
+)
+from agent.strategy_diffs import StrategyDiff, StrategyDiffStatus
+from agent.strategies_tools import (
+    DEFAULT_TOP_K,
+    MAX_TOP_K,
+    STRATEGIES_TOOLS,
+    execute_propose_strategy_update,
+    execute_query_strategies,
+    execute_strategies_tool,
+    rank_strategies,
+)
+
+
+# ── Schema ───────────────────────────────────────────────────────────────────
+
+
+class TestSchema:
+    def test_two_tools_named_correctly(self) -> None:
+        names = [t["function"]["name"] for t in STRATEGIES_TOOLS]
+        assert set(names) == {"query_strategies", "propose_strategy_update"}
+
+    def test_query_situation_required(self) -> None:
+        for t in STRATEGIES_TOOLS:
+            if t["function"]["name"] == "query_strategies":
+                assert "situation" in t["function"]["parameters"]["required"]
+
+    def test_propose_required_fields(self) -> None:
+        for t in STRATEGIES_TOOLS:
+            if t["function"]["name"] == "propose_strategy_update":
+                req = t["function"]["parameters"]["required"]
+                assert "new_text" in req
+                assert "reason" in req
+                assert "strategy_id" not in req
+
+
+# ── Ranking ──────────────────────────────────────────────────────────────────
+
+
+class TestRanking:
+    def _strategy(self, text: str, *, days_old: int = 0) -> Strategy:
+        return Strategy(
+            text=text,
+            created_by=StrategyCreatedBy.JACK,
+            created_at=datetime.now(timezone.utc) - timedelta(days=days_old),
+        )
+
+    def test_zero_overlap_returns_empty(self) -> None:
+        ranked = rank_strategies(
+            "morning brief planning",
+            [self._strategy("when sending email, double-check recipients")],
+            top_k=5,
+        )
+        assert ranked == []
+
+    def test_overlap_returns_match_with_score(self) -> None:
+        s = self._strategy("when sending email double check recipients")
+        ranked = rank_strategies("the email I want to send", [s], top_k=5)
+        assert len(ranked) == 1
+        assert ranked[0][0] is s
+        assert 0 < ranked[0][1] <= 1.0
+
+    def test_ties_broken_by_recency(self) -> None:
+        s_old = self._strategy("reply email check sender", days_old=200)
+        s_new = self._strategy("reply email check sender", days_old=2)
+        ranked = rank_strategies("reply email check sender", [s_old, s_new], top_k=5)
+        # Same text → same score; the newer must come first.
+        assert ranked[0][0] is s_new
+
+    def test_top_k_caps_results(self) -> None:
+        strategies = [
+            self._strategy(f"matching text {i}") for i in range(20)
+        ]
+        ranked = rank_strategies("matching text", strategies, top_k=5)
+        assert len(ranked) <= 5
+
+
+# ── Stub repos ───────────────────────────────────────────────────────────────
+
+
+class _FakeStrategyRepo:
+    def __init__(self, active: list[Strategy]) -> None:
+        self._active = active
+        self.usage_bumps: list[uuid.UUID] = []
+
+    async def query_active(self, *, limit: int = 100) -> list[Strategy]:
+        return list(self._active)[:limit]
+
+    async def bump_usage(self, strategy_id) -> None:
+        sid = strategy_id if isinstance(strategy_id, uuid.UUID) else uuid.UUID(str(strategy_id))
+        self.usage_bumps.append(sid)
+
+
+class _FakeDiffsRepo:
+    def __init__(self) -> None:
+        self.appended: list[StrategyDiff] = []
+
+    async def append(self, diff: StrategyDiff) -> StrategyDiff:
+        self.appended.append(diff)
+        return diff
+
+
+# ── Query executor ───────────────────────────────────────────────────────────
+
+
+class TestExecuteQuery:
+    @pytest.mark.asyncio
+    async def test_missing_situation_returns_error(self) -> None:
+        repo = _FakeStrategyRepo([])
+        result = await execute_query_strategies({}, repo=repo)  # type: ignore[arg-type]
+        assert "error" in result
+
+    @pytest.mark.asyncio
+    async def test_empty_situation_returns_error(self) -> None:
+        repo = _FakeStrategyRepo([])
+        result = await execute_query_strategies(
+            {"situation": "   "}, repo=repo  # type: ignore[arg-type]
+        )
+        assert "error" in result
+
+    @pytest.mark.asyncio
+    async def test_invalid_top_k_type_returns_error(self) -> None:
+        repo = _FakeStrategyRepo([])
+        result = await execute_query_strategies(
+            {"situation": "ok", "top_k": "lots"}, repo=repo  # type: ignore[arg-type]
+        )
+        assert "error" in result
+
+    @pytest.mark.asyncio
+    async def test_top_k_clamped_to_max(self) -> None:
+        # Should not error, just clamp.
+        repo = _FakeStrategyRepo([])
+        result = await execute_query_strategies(
+            {"situation": "ok", "top_k": 1000}, repo=repo  # type: ignore[arg-type]
+        )
+        assert result["ok"] is True
+
+    @pytest.mark.asyncio
+    async def test_match_bumps_usage(self) -> None:
+        s = Strategy(text="when sending email double check recipients")
+        repo = _FakeStrategyRepo([s])
+        result = await execute_query_strategies(
+            {"situation": "the email I want to send"}, repo=repo  # type: ignore[arg-type]
+        )
+        assert result["ok"] is True
+        assert result["count"] == 1
+        assert repo.usage_bumps == [s.strategy_id]
+
+    @pytest.mark.asyncio
+    async def test_no_match_does_not_bump(self) -> None:
+        s = Strategy(text="when sending email double check recipients")
+        repo = _FakeStrategyRepo([s])
+        result = await execute_query_strategies(
+            {"situation": "morning brief"}, repo=repo  # type: ignore[arg-type]
+        )
+        assert result["count"] == 0
+        assert repo.usage_bumps == []
+
+
+# ── Propose executor ─────────────────────────────────────────────────────────
+
+
+class TestExecutePropose:
+    @pytest.mark.asyncio
+    async def test_missing_new_text_returns_error(self) -> None:
+        diffs = _FakeDiffsRepo()
+        result = await execute_propose_strategy_update(
+            {"reason": "ok"}, diffs_repo=diffs  # type: ignore[arg-type]
+        )
+        assert "error" in result
+        assert diffs.appended == []
+
+    @pytest.mark.asyncio
+    async def test_missing_reason_returns_error(self) -> None:
+        diffs = _FakeDiffsRepo()
+        result = await execute_propose_strategy_update(
+            {"new_text": "ok"}, diffs_repo=diffs  # type: ignore[arg-type]
+        )
+        assert "error" in result
+        assert diffs.appended == []
+
+    @pytest.mark.asyncio
+    async def test_routes_through_diffs_queue_not_directly(self) -> None:
+        diffs = _FakeDiffsRepo()
+        result = await execute_propose_strategy_update(
+            {"new_text": "new strategy.", "reason": "noticed a pattern"},
+            diffs_repo=diffs,  # type: ignore[arg-type]
+        )
+        assert result["ok"] is True
+        assert result["queued"] is True
+        assert len(diffs.appended) == 1
+        diff = diffs.appended[0]
+        assert diff.proposed_text == "new strategy."
+        assert diff.rationale == "noticed a pattern"
+        assert diff.status == StrategyDiffStatus.PENDING
+        # No target_strategy_id → new lineage.
+        assert diff.target_strategy_id is None
+
+    @pytest.mark.asyncio
+    async def test_invalid_strategy_id_uuid_returns_error(self) -> None:
+        diffs = _FakeDiffsRepo()
+        result = await execute_propose_strategy_update(
+            {
+                "new_text": "ok",
+                "reason": "ok",
+                "strategy_id": "not-a-uuid",
+            },
+            diffs_repo=diffs,  # type: ignore[arg-type]
+        )
+        assert "error" in result
+        assert diffs.appended == []
+
+    @pytest.mark.asyncio
+    async def test_with_strategy_id_creates_versioned_diff(self) -> None:
+        diffs = _FakeDiffsRepo()
+        target = uuid.uuid4()
+        result = await execute_propose_strategy_update(
+            {
+                "new_text": "improved.",
+                "reason": "the old wording was vague",
+                "strategy_id": str(target),
+            },
+            diffs_repo=diffs,  # type: ignore[arg-type]
+        )
+        assert result["ok"] is True
+        assert diffs.appended[0].target_strategy_id == target
+
+
+# ── Dispatcher ───────────────────────────────────────────────────────────────
+
+
+class TestDispatcher:
+    @pytest.mark.asyncio
+    async def test_unknown_tool_returns_error(self) -> None:
+        repo = _FakeStrategyRepo([])
+        diffs = _FakeDiffsRepo()
+        result = await execute_strategies_tool(
+            "frobnicate",
+            {},
+            repo=repo,  # type: ignore[arg-type]
+            diffs_repo=diffs,  # type: ignore[arg-type]
+        )
+        assert "error" in result
+        assert "unknown" in result["error"]

--- a/agent/tests/test_strategy_block_selector.py
+++ b/agent/tests/test_strategy_block_selector.py
@@ -1,0 +1,61 @@
+"""Tests for `agent.context.selectors.strategies.StrategyBlockSelector` (#54).
+
+Covers:
+- empty active set yields empty record
+- empty user message yields empty record
+- non-matching active strategies yield empty record
+- matching strategies are rendered with provenance
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from agent.context.selectors.strategies import StrategyBlockSelector
+from agent.strategies.repository import Strategy
+
+
+def _strategy(text: str) -> Strategy:
+    return Strategy(text=text, created_at=datetime.now(timezone.utc))
+
+
+class TestStrategyBlockSelector:
+    def test_empty_active_yields_empty_record(self) -> None:
+        sel = StrategyBlockSelector()
+        record = sel.select(situation="anything")
+        assert record.content == ""
+        assert record.provenance["strategies_used"] == []
+
+    def test_empty_situation_yields_empty_record(self) -> None:
+        sel = StrategyBlockSelector()
+        sel.set_active_strategies([_strategy("when X, do Y")])
+        record = sel.select(situation="")
+        assert record.content == ""
+
+    def test_no_overlap_yields_empty_record(self) -> None:
+        sel = StrategyBlockSelector()
+        sel.set_active_strategies([_strategy("when sending email, double check recipients")])
+        record = sel.select(situation="morning brief planning")
+        assert record.content == ""
+        assert record.provenance["strategies_used"] == []
+
+    def test_match_renders_block_and_provenance(self) -> None:
+        sel = StrategyBlockSelector(top_k=3)
+        s_match = _strategy("when sending email double check recipients")
+        s_dud = _strategy("morning brief should be short")
+        sel.set_active_strategies([s_match, s_dud])
+        record = sel.select(situation="the email I want to send")
+        assert "[Strategies relevant to this turn]" in record.content
+        assert "double check recipients" in record.content
+        assert "morning brief" not in record.content
+        used = record.provenance["strategies_used"]
+        assert len(used) == 1
+        assert used[0]["strategy_id"] == str(s_match.strategy_id)
+        assert "score" in used[0]
+        assert "confidence" in used[0]
+
+    def test_set_active_strategies_replaces_previous_snapshot(self) -> None:
+        sel = StrategyBlockSelector()
+        sel.set_active_strategies([_strategy("first")])
+        sel.set_active_strategies([])  # Replace, not append.
+        record = sel.select(situation="first")
+        assert record.content == ""

--- a/agent/tests/test_strategy_diffs.py
+++ b/agent/tests/test_strategy_diffs.py
@@ -1,0 +1,216 @@
+"""Tests for `agent.strategy_diffs` (#54).
+
+Covers dataclass invariants, repository surface lock, and the
+propose → approve → apply cycle through stub repositories.
+"""
+from __future__ import annotations
+
+import inspect
+import uuid
+from unittest.mock import AsyncMock
+
+import pytest
+
+from agent.strategies.repository import (
+    Strategy,
+    StrategyCreatedBy,
+    StrategyStatus,
+)
+from agent.strategy_diffs import (
+    StrategyDiff,
+    StrategyDiffRepository,
+    StrategyDiffStatus,
+)
+
+
+class TestDiffDataclass:
+    def test_default_status_is_pending(self) -> None:
+        diff = StrategyDiff(proposed_text="when X, do Y")
+        assert diff.status == StrategyDiffStatus.PENDING
+
+    def test_empty_text_rejected(self) -> None:
+        with pytest.raises(ValueError, match="proposed_text cannot be empty"):
+            StrategyDiff(proposed_text="")
+        with pytest.raises(ValueError, match="proposed_text cannot be empty"):
+            StrategyDiff(proposed_text="   ")
+
+    def test_invalid_status_rejected(self) -> None:
+        with pytest.raises(ValueError, match="status must be one of"):
+            StrategyDiff(proposed_text="x", status="archived")
+
+    def test_invalid_proposed_by_rejected(self) -> None:
+        with pytest.raises(ValueError, match="proposed_by"):
+            StrategyDiff(proposed_text="x", proposed_by="optimizer")
+
+
+class TestRepositorySurface:
+    expected_public: frozenset[str] = frozenset({
+        "append",
+        "list_pending",
+        "get",
+        "approve",
+        "reject",
+    })
+
+    def test_public_method_set_is_exhaustive(self) -> None:
+        names = {
+            n
+            for n, _ in inspect.getmembers(StrategyDiffRepository, predicate=inspect.isfunction)
+            if not n.startswith("_")
+        }
+        assert names == self.expected_public
+
+    def test_no_destructive_paths(self) -> None:
+        forbidden = ("update_text", "edit", "rewrite", "delete", "purge", "drop")
+        names = {n for n, _ in inspect.getmembers(StrategyDiffRepository)}
+        bad = [n for n in names if any(n.startswith(p) for p in forbidden)]
+        assert bad == []
+
+
+# ── End-to-end through a stub strategies-repo ───────────────────────────────
+
+
+class _FakeStrategiesRepo:
+    """Records what append/append_version were called with."""
+
+    def __init__(self) -> None:
+        self.appends: list[Strategy] = []
+        self.versions: list[tuple[Strategy, str]] = []
+        self._by_id: dict[uuid.UUID, Strategy] = {}
+
+    def seed(self, strategy: Strategy) -> None:
+        self._by_id[strategy.strategy_id] = strategy
+
+    async def append(self, strategy: Strategy, *, is_contradicting=None) -> Strategy:
+        self.appends.append(strategy)
+        self._by_id[strategy.strategy_id] = strategy
+        return strategy
+
+    async def append_version(
+        self,
+        *,
+        parent: Strategy,
+        new_text: str,
+        created_by: str,
+        source_trace_ids=None,
+        embedding=None,
+    ) -> Strategy:
+        new = Strategy(
+            text=new_text,
+            version=parent.version + 1,
+            parent_strategy_id=parent.strategy_id,
+            created_by=created_by,
+        )
+        self.versions.append((parent, new_text))
+        self._by_id[new.strategy_id] = new
+        return new
+
+    async def get(self, strategy_id) -> Strategy | None:
+        sid = strategy_id if isinstance(strategy_id, uuid.UUID) else uuid.UUID(str(strategy_id))
+        return self._by_id.get(sid)
+
+
+class _FakeDiffsRepo(StrategyDiffRepository):
+    """Skip the SQL session; keep the dispatch shape from the real
+    repository but back the storage with a dict."""
+
+    def __init__(self, strategies_repo: _FakeStrategiesRepo) -> None:
+        self._strategies = strategies_repo
+        self._diffs: dict[uuid.UUID, StrategyDiff] = {}
+
+    async def append(self, diff):
+        self._diffs[diff.diff_id] = diff
+        return diff
+
+    async def list_pending(self, *, limit: int = 50):
+        return [d for d in self._diffs.values() if d.status == StrategyDiffStatus.PENDING]
+
+    async def get(self, diff_id):
+        sid = diff_id if isinstance(diff_id, uuid.UUID) else uuid.UUID(str(diff_id))
+        return self._diffs.get(sid)
+
+    async def reject(self, diff_id):
+        d = await self.get(diff_id)
+        if d is None:
+            return
+        self._diffs[d.diff_id] = StrategyDiff(
+            proposed_text=d.proposed_text,
+            rationale=d.rationale,
+            target_strategy_id=d.target_strategy_id,
+            proposed_by=d.proposed_by,
+            source_trace_ids=list(d.source_trace_ids),
+            status=StrategyDiffStatus.REJECTED,
+            diff_id=d.diff_id,
+            created_at=d.created_at,
+        )
+
+    async def approve(self, diff_id) -> Strategy:
+        diff = await self.get(diff_id)
+        assert diff is not None and diff.status == StrategyDiffStatus.PENDING
+        # Flip status in-place for the fake.
+        self._diffs[diff.diff_id] = StrategyDiff(
+            proposed_text=diff.proposed_text,
+            rationale=diff.rationale,
+            target_strategy_id=diff.target_strategy_id,
+            proposed_by=diff.proposed_by,
+            source_trace_ids=list(diff.source_trace_ids),
+            status=StrategyDiffStatus.APPROVED,
+            diff_id=diff.diff_id,
+            created_at=diff.created_at,
+        )
+        if diff.target_strategy_id is None:
+            return await self._strategies.append(
+                Strategy(
+                    text=diff.proposed_text,
+                    created_by=diff.proposed_by,
+                    source_trace_ids=list(diff.source_trace_ids),
+                )
+            )
+        parent = await self._strategies.get(diff.target_strategy_id)
+        assert parent is not None
+        return await self._strategies.append_version(
+            parent=parent,
+            new_text=diff.proposed_text,
+            created_by=diff.proposed_by,
+            source_trace_ids=list(diff.source_trace_ids),
+        )
+
+
+class TestProposeApproveCycle:
+    @pytest.mark.asyncio
+    async def test_new_lineage_approval_appends_strategy(self) -> None:
+        srepo = _FakeStrategiesRepo()
+        drepo = _FakeDiffsRepo(srepo)
+
+        diff = StrategyDiff(
+            proposed_text="when summarising, stop sooner.",
+            rationale="brief was padding too much",
+        )
+        await drepo.append(diff)
+
+        new_strategy = await drepo.approve(diff.diff_id)
+        assert new_strategy.text == "when summarising, stop sooner."
+        assert len(srepo.appends) == 1
+        assert srepo.versions == []
+        # Diff is now APPROVED.
+        approved = await drepo.get(diff.diff_id)
+        assert approved is not None and approved.status == StrategyDiffStatus.APPROVED
+
+    @pytest.mark.asyncio
+    async def test_versioned_approval_calls_append_version(self) -> None:
+        srepo = _FakeStrategiesRepo()
+        parent = Strategy(text="old wording")
+        srepo.seed(parent)
+        drepo = _FakeDiffsRepo(srepo)
+
+        diff = StrategyDiff(
+            proposed_text="new wording.",
+            rationale="cleaner",
+            target_strategy_id=parent.strategy_id,
+        )
+        await drepo.append(diff)
+        await drepo.approve(diff.diff_id)
+
+        assert len(srepo.versions) == 1
+        assert srepo.versions[0][0] is parent
+        assert srepo.versions[0][1] == "new wording."

--- a/web/src/components/TraceContextInspector.tsx
+++ b/web/src/components/TraceContextInspector.tsx
@@ -686,6 +686,11 @@ export default function TraceContextInspector({ traceId, detail: detailProp, onB
         currentTraceId={detail.trace_id}
       />
 
+      {/* ── Strategies (Epic 06 #54) ─────────────────────────────── */}
+      <StrategiesSection
+        provenance={prov.selectors?.strategies ?? null}
+      />
+
       {/* ── Re-render ─────────────────────────────────────────────── */}
       <div style={styles.section}>
         <div style={styles.sectionHeader}>
@@ -903,6 +908,63 @@ function CapabilityBlockSection({
               row) — version mismatch only
             </div>
           )
+        )}
+      </div>
+    </div>
+  )
+}
+
+
+// Epic 06 (#54) — strategy block provenance.
+//
+// Shows which strategies were injected into this trace's system prompt
+// and at what score. The shape comes from
+// `agent.context.selectors.strategies.StrategyBlockSelector.select()` —
+// the provenance dict carries `strategies_used: [{strategy_id, version,
+// score, confidence}]`. Legacy traces (pre-#54) have no `strategies`
+// selector entry; we render a small empty-state instead of nothing so
+// the operator knows the absence is expected, not a bug.
+interface StrategiesSectionProps {
+  provenance: Record<string, unknown> | null
+}
+
+function StrategiesSection({ provenance }: StrategiesSectionProps) {
+  const used = (provenance?.strategies_used ?? []) as Array<{
+    strategy_id?: string
+    version?: number
+    score?: number
+    confidence?: number
+  }>
+  const activeCount = (provenance?.active_count as number | undefined) ?? null
+
+  return (
+    <div style={styles.section}>
+      <div style={styles.sectionHeader}>
+        <span>Strategies</span>
+        <span style={styles.pill('#a78bfa')}>
+          {used.length === 0
+            ? activeCount === null
+              ? 'no provenance'
+              : `0 / ${activeCount} matched`
+            : `${used.length} injected`}
+        </span>
+      </div>
+      <div style={styles.sectionBody}>
+        <div style={styles.reason}>
+          Strategies the assembler injected into the system prompt for
+          this turn (Epic 06 #54). Score is keyword-overlap (v0);
+          confidence reflects usage_count plus recent confirmations.
+        </div>
+        {used.length === 0 ? (
+          <div style={styles.empty}>
+            {activeCount === null
+              ? 'This trace pre-dates the strategy block selector.'
+              : activeCount === 0
+                ? 'No active strategies in the hub yet — propose one via the model and approve it from the pending-actions queue.'
+                : 'Active strategies existed but none matched this turn’s input.'}
+          </div>
+        ) : (
+          <pre style={styles.pre}>{JSON.stringify(used, null, 2)}</pre>
         )}
       </div>
     </div>


### PR DESCRIPTION
Closes #54 · Epic #49 · Builds on #53

## Summary
Lands the LLM-facing Strategy Hub tools, the propose-then-approve queue, the system-prompt strategy block, and the trace-inspector provenance section.

## What lands
- **\`agent/strategies_tools.py\`** — STRATEGIES_TOOLS schema + executors:
  - \`query_strategies(situation, top_k=5)\` — ranks active strategies by Jaccard overlap (v0; phase 2 swaps for cosine over the existing 1024-dim embedding column). Bumps \`usage_count\` on matches.
  - \`propose_strategy_update(strategy_id?, new_text, reason)\` — **NEVER** writes directly. Routes through \`pending_strategy_diffs\`. New lineage when \`strategy_id\` is omitted; new version when it's set.
- **\`agent/strategy_diffs.py\`** — \`pending_strategy_diffs\` ORM + repository. Public surface: \`append\`, \`list_pending\`, \`get\`, \`approve\`, \`reject\`. \`approve()\` flips status then calls \`StrategyRepository.append\` (or \`append_version\`). **No \`update_text\` / \`delete\`.**
- **\`StrategyBlockSelector\`** + **assembler wiring** — appends top-N matched strategies to the system prompt after the identity block.
- **\`agent/core.py\`** — registers STRATEGIES_TOOLS; dispatches through a session-scoped helper that builds repositories per call.
- **\`web/src/components/TraceContextInspector.tsx\`** — new "Strategies" section surfaces \`prov.selectors.strategies.strategies_used\` for past traces. Empty states distinguish pre-#54 traces, empty hub, and "no match."

## Acceptance criteria
- [x] Both tools registered and usable.
- [x] Strategy block appears in system prompt (\`StrategyBlockSelector\` + assembler integration; locked by tests).
- [x] UI inspector shows strategy provenance for past traces.
- [x] Update path always goes through approval (\`test_routes_through_diffs_queue_not_directly\`).

## Test plan
- [x] 32 new tests pass: tool schema, ranking + recency tiebreaker, executor validation, propose-routes-through-queue invariant, propose→approve for new lineages and versioned updates, selector content/provenance shape.
- [x] 150 adjacent tests still green.
- [x] \`agent.core\`, \`agent.strategies_tools\`, \`agent.strategy_diffs\`, \`agent.context.assembler\` all import cleanly.
- [x] \`web/\` typechecks cleanly.

## Optimizer carve-out
Strategy text is operator-authored or agent-proposed-and-approved; the optimizer must not tune it. Layered defence: (1) FORBIDDEN_TARGETS already covers \`identity\` (#52); strategies are not in \`agent/prompts/\` so the gate has no path to evaluate them; (2) the propose-update tool routes through the diff queue, so even a model that wanted to bypass approval cannot.

## Privacy
Strategies are RAW_PERSONAL — same posture as identity. They live in the local strategies table (no external surface). \`pending_strategy_diffs\` lives next to the existing pending-actions queue.

## Out of scope
Cosine-similarity ranking (v1), pending-actions panel UI surface for diff approve/reject (backend wired, frontend extension is a follow-up), embedding backfill of bootstrap strategies.