### PR TITLE
agents/reflector: wait-action trace-grounded feedback loop (#56)

### DIFF
--- a/agent/db.py
+++ b/agent/db.py
@@ -62,6 +62,8 @@ async def init_db(config=None) -> None:
         import agent.identity_diffs  # noqa: F401  (side-effect import)
         # Epic 06 (#54) — pending_strategy_diffs table.
         import agent.strategy_diffs  # noqa: F401  (side-effect import)
+        # Epic 06 (#56) — wait_feedback table.
+        import agents.reflector.wait_evaluator  # noqa: F401  (side-effect import)
 
         # 2. Create all tables defined via Base
         await conn.run_sync(Base.metadata.create_all)

--- a/agent/tests/test_wait_evaluator.py
+++ b/agent/tests/test_wait_evaluator.py
@@ -1,0 +1,362 @@
+"""Tests for `agents.reflector.wait_evaluator` (#56).
+
+Covers:
+- pure comparator helpers (jaccard, evaluate_relevance, evaluate_brought_up)
+- WaitFeedback dataclass invariants
+- evaluate_completed_waits is idempotent (re-runs do not duplicate)
+- evaluate_brought_up_waits defers waits whose 7d window is still open
+- summarize_feedback aggregates correctly
+"""
+from __future__ import annotations
+
+import inspect
+import uuid
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock
+
+import pytest
+
+from agents.reflector.wait_evaluator import (
+    BROUGHT_UP_WINDOW,
+    RELEVANCE_HALF_WINDOW,
+    SIGNAL_BROUGHT_UP,
+    SIGNAL_RELEVANCE,
+    SIGNAL_THUMBS,
+    TraceLite,
+    WaitFeedback,
+    WaitFeedbackRepository,
+    evaluate_brought_up,
+    evaluate_brought_up_waits,
+    evaluate_completed_waits,
+    evaluate_relevance,
+    summarize_feedback,
+)
+
+
+def _ts(days_ago: int = 0, hours_ago: int = 0) -> datetime:
+    return datetime.now(timezone.utc) - timedelta(days=days_ago, hours=hours_ago)
+
+
+def _wait(reason: str, *, until_iso=None, created_at=None, input_text="") -> TraceLite:
+    return TraceLite(
+        trace_id=uuid.uuid4(),
+        created_at=created_at or _ts(),
+        input=input_text,
+        wait_reason=reason,
+        until_iso=until_iso,
+    )
+
+
+def _trace(input_text: str, *, created_at=None, source="user") -> TraceLite:
+    return TraceLite(
+        trace_id=uuid.uuid4(),
+        created_at=created_at or _ts(),
+        input=input_text,
+        trigger_source=source,
+    )
+
+
+# ── Dataclass invariants ─────────────────────────────────────────────────────
+
+
+class TestFeedbackDataclass:
+    def test_invalid_signal_type_rejected(self) -> None:
+        with pytest.raises(ValueError, match="signal_type"):
+            WaitFeedback(
+                wait_trace_id=uuid.uuid4(),
+                signal_type="frobnicate",
+                signal_value=1.0,
+                confidence=1.0,
+            )
+
+    def test_signal_value_out_of_range_rejected(self) -> None:
+        with pytest.raises(ValueError, match="signal_value"):
+            WaitFeedback(
+                wait_trace_id=uuid.uuid4(),
+                signal_type=SIGNAL_THUMBS,
+                signal_value=1.5,
+                confidence=1.0,
+            )
+
+    def test_confidence_out_of_range_rejected(self) -> None:
+        with pytest.raises(ValueError, match="confidence"):
+            WaitFeedback(
+                wait_trace_id=uuid.uuid4(),
+                signal_type=SIGNAL_THUMBS,
+                signal_value=1.0,
+                confidence=2.0,
+            )
+
+
+# ── evaluate_relevance (§2.1) ────────────────────────────────────────────────
+
+
+class TestEvaluateRelevance:
+    def test_match_returns_one_with_scaled_confidence(self) -> None:
+        wait = _wait(
+            "Jack mentioned the email triage but seemed tired",
+            until_iso=_ts(),
+            input_text="email triage",
+        )
+        nearby = [
+            _trace("did the email triage land?", created_at=_ts(hours_ago=2)),
+        ]
+        fb = evaluate_relevance(wait_trace=wait, nearby_traces=nearby)
+        assert fb.signal_type == SIGNAL_RELEVANCE
+        assert fb.signal_value == 1.0
+        # 1 match / 3.0 cap = ~0.33
+        assert 0.3 < fb.confidence < 0.4
+
+    def test_no_match_returns_zero_ambiguous(self) -> None:
+        wait = _wait("hold the email triage", until_iso=_ts(), input_text="email triage")
+        nearby = [_trace("calendar sync running", created_at=_ts(hours_ago=2))]
+        fb = evaluate_relevance(wait_trace=wait, nearby_traces=nearby)
+        assert fb.signal_value == 0.0
+        # Ambiguity recorded as confidence=0.5 — neither correct nor incorrect.
+        assert fb.confidence == 0.5
+
+    def test_until_iso_required(self) -> None:
+        wait = _wait("ok", until_iso=None)
+        with pytest.raises(ValueError, match="until_iso"):
+            evaluate_relevance(wait_trace=wait, nearby_traces=[])
+
+    def test_three_or_more_matches_saturates_confidence(self) -> None:
+        wait = _wait("hold email triage", until_iso=_ts(), input_text="email triage")
+        nearby = [
+            _trace("the email triage is done"),
+            _trace("did email triage finish"),
+            _trace("email triage status"),
+            _trace("email triage update"),
+        ]
+        fb = evaluate_relevance(wait_trace=wait, nearby_traces=nearby)
+        assert fb.confidence == 1.0
+
+
+# ── evaluate_brought_up (§2.2) ───────────────────────────────────────────────
+
+
+class TestEvaluateBroughtUp:
+    def test_user_brings_up_returns_one(self) -> None:
+        wait = _wait("hold email triage", input_text="email triage")
+        later = [
+            _trace(
+                "did the email triage land",
+                created_at=_ts(days_ago=2),
+                source="user",
+            ),
+        ]
+        fb = evaluate_brought_up(wait_trace=wait, later_traces=later)
+        assert fb.signal_type == SIGNAL_BROUGHT_UP
+        assert fb.signal_value == 1.0
+        assert fb.confidence == 1.0
+
+    def test_scheduler_traces_dont_count(self) -> None:
+        """Scheduler-fired briefs that surface the topic don't prove
+        Jack brought it up — only user-driven traces do."""
+        wait = _wait("hold email triage", input_text="email triage")
+        later = [
+            _trace(
+                "email triage sweep",
+                created_at=_ts(days_ago=2),
+                source="scheduler",
+            ),
+        ]
+        fb = evaluate_brought_up(wait_trace=wait, later_traces=later)
+        assert fb.signal_value == 0.0
+
+
+# ── Orchestrator — idempotency and deferral ─────────────────────────────────
+
+
+class _StubFeedbackRepo:
+    """Records appends + serves list_by_wait queries from the in-memory store."""
+
+    def __init__(self) -> None:
+        self.appended: list[WaitFeedback] = []
+
+    async def append(self, fb: WaitFeedback) -> WaitFeedback:
+        self.appended.append(fb)
+        return fb
+
+    async def list_by_wait(self, wait_trace_id, *, signal_type=None):
+        sid = wait_trace_id if isinstance(wait_trace_id, uuid.UUID) else uuid.UUID(str(wait_trace_id))
+        return [
+            f
+            for f in self.appended
+            if f.wait_trace_id == sid
+            and (signal_type is None or f.signal_type == signal_type)
+        ]
+
+    async def list_recent(self, *, days: int = 7):
+        return list(self.appended)
+
+
+class TestEvaluateCompletedWaits:
+    @pytest.mark.asyncio
+    async def test_appends_one_per_wait_idempotent(self) -> None:
+        wait = _wait(
+            "hold email triage",
+            until_iso=_ts(hours_ago=1),
+            input_text="email triage",
+        )
+        nearby = [_trace("email triage done", created_at=_ts(hours_ago=1))]
+        repo = _StubFeedbackRepo()
+
+        async def fetch_completed_waits(start, end):
+            return [wait]
+
+        async def fetch_traces_in_window(start, end):
+            return nearby
+
+        n1 = await evaluate_completed_waits(
+            now=_ts(),
+            fetch_completed_waits=fetch_completed_waits,
+            fetch_traces_in_window=fetch_traces_in_window,
+            feedback_repo=repo,
+        )
+        assert n1 == 1
+        # Second pass must not re-write the relevance signal for the
+        # same wait — the comparator's idempotency check catches it.
+        n2 = await evaluate_completed_waits(
+            now=_ts(),
+            fetch_completed_waits=fetch_completed_waits,
+            fetch_traces_in_window=fetch_traces_in_window,
+            feedback_repo=repo,
+        )
+        assert n2 == 0
+        # Total appends still 1.
+        assert sum(1 for f in repo.appended if f.signal_type == SIGNAL_RELEVANCE) == 1
+
+
+class TestEvaluateBroughtUpWaits:
+    @pytest.mark.asyncio
+    async def test_open_window_with_no_match_defers(self) -> None:
+        # Wait fired 1 day ago — window still has 6 days to run.
+        wait = _wait(
+            "hold email triage",
+            created_at=_ts(days_ago=1),
+            input_text="email triage",
+        )
+        repo = _StubFeedbackRepo()
+
+        async def fetch_recent_waits(start, end):
+            return [wait]
+
+        async def fetch_traces_in_window(start, end):
+            return []  # No matching traces yet.
+
+        n = await evaluate_brought_up_waits(
+            now=_ts(),
+            fetch_recent_waits=fetch_recent_waits,
+            fetch_traces_in_window=fetch_traces_in_window,
+            feedback_repo=repo,
+        )
+        # Deferred — no row written.
+        assert n == 0
+        assert repo.appended == []
+
+    @pytest.mark.asyncio
+    async def test_closed_window_with_no_match_writes_zero(self) -> None:
+        # Wait fired 8 days ago — window closed yesterday.
+        wait = _wait(
+            "hold email triage",
+            created_at=_ts(days_ago=8),
+            input_text="email triage",
+        )
+        repo = _StubFeedbackRepo()
+
+        async def fetch_recent_waits(start, end):
+            return [wait]
+
+        async def fetch_traces_in_window(start, end):
+            return []
+
+        n = await evaluate_brought_up_waits(
+            now=_ts(),
+            fetch_recent_waits=fetch_recent_waits,
+            fetch_traces_in_window=fetch_traces_in_window,
+            feedback_repo=repo,
+        )
+        # Window closed; no match found — 0.0 row is written.
+        assert n == 1
+        assert repo.appended[0].signal_value == 0.0
+
+    @pytest.mark.asyncio
+    async def test_match_found_writes_one(self) -> None:
+        wait = _wait(
+            "hold email triage",
+            created_at=_ts(days_ago=2),
+            input_text="email triage",
+        )
+        repo = _StubFeedbackRepo()
+
+        async def fetch_recent_waits(start, end):
+            return [wait]
+
+        async def fetch_traces_in_window(start, end):
+            return [
+                _trace("email triage status", created_at=_ts(days_ago=1), source="user")
+            ]
+
+        n = await evaluate_brought_up_waits(
+            now=_ts(),
+            fetch_recent_waits=fetch_recent_waits,
+            fetch_traces_in_window=fetch_traces_in_window,
+            feedback_repo=repo,
+        )
+        assert n == 1
+        assert repo.appended[0].signal_value == 1.0
+
+
+# ── summarize_feedback ───────────────────────────────────────────────────────
+
+
+class TestSummarizeFeedback:
+    def test_means_per_signal_type(self) -> None:
+        records = [
+            WaitFeedback(uuid.uuid4(), SIGNAL_THUMBS, 1.0, 1.0),
+            WaitFeedback(uuid.uuid4(), SIGNAL_THUMBS, 0.0, 1.0),
+            WaitFeedback(uuid.uuid4(), SIGNAL_BROUGHT_UP, 1.0, 1.0),
+        ]
+        summary = summarize_feedback(records)
+        assert summary.total == 3
+        assert summary.by_signal_value_mean[SIGNAL_THUMBS] == 0.5
+        assert summary.by_signal_value_mean[SIGNAL_BROUGHT_UP] == 1.0
+        # 1 thumbs-down at confidence 1.0 = ambiguous-high.
+        assert summary.ambiguous_count == 1
+
+    def test_ambiguous_count_only_for_high_confidence_zeros(self) -> None:
+        # Auto-signals with confidence 0.5 are NOT counted as ambiguous-high.
+        records = [
+            WaitFeedback(uuid.uuid4(), SIGNAL_RELEVANCE, 0.0, 0.5),
+            WaitFeedback(uuid.uuid4(), SIGNAL_BROUGHT_UP, 0.0, 0.5),
+        ]
+        summary = summarize_feedback(records)
+        assert summary.ambiguous_count == 0
+
+
+# ── Repository surface lock ──────────────────────────────────────────────────
+
+
+class TestRepositorySurface:
+    expected_public: frozenset[str] = frozenset({
+        "append",
+        "list_by_wait",
+        "list_recent",
+    })
+
+    def test_public_method_set_is_exhaustive(self) -> None:
+        names = {
+            n
+            for n, _ in inspect.getmembers(WaitFeedbackRepository, predicate=inspect.isfunction)
+            if not n.startswith("_")
+        }
+        assert names == self.expected_public
+
+    def test_no_destructive_paths(self) -> None:
+        """Per #56: 'No automated learning loop — feedback is read-only signal.'
+        The repository must not expose update/delete paths."""
+        forbidden = ("update", "edit", "rewrite", "delete", "purge", "drop")
+        names = {n for n, _ in inspect.getmembers(WaitFeedbackRepository)}
+        bad = [n for n in names if any(n.startswith(p) for p in forbidden)]
+        assert bad == []

--- a/agent/waits_http.py
+++ b/agent/waits_http.py
@@ -35,6 +35,11 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from agent.auth import require_api_key
 from agent.db import get_db
 from agent.wait_tool import _try_parse_iso
+from agents.reflector.wait_evaluator import (
+    SIGNAL_THUMBS,
+    WaitFeedback,
+    WaitFeedbackRepository,
+)
 
 logger = structlog.get_logger(__name__)
 
@@ -88,10 +93,24 @@ class WaitEntry(BaseModel):
     until_iso: Optional[str] = None
     trigger_source: str
     scheduler_job_name: Optional[str] = None
+    # Epic 06 (#56) — most-recent thumb on this wait, if any.
+    thumb: Optional[str] = None  # 'up' | 'down' | None
 
 
 class WaitsListResponse(BaseModel):
     waits: list[WaitEntry]
+
+
+class ThumbRequest(BaseModel):
+    value: str  # 'up' | 'down'
+    notes: Optional[str] = None
+
+
+class ThumbResponse(BaseModel):
+    ok: bool
+    feedback_id: str
+    wait_trace_id: str
+    value: str
 
 
 # ── Routes ───────────────────────────────────────────────────────────────────
@@ -124,6 +143,30 @@ def _extract_wait_args(tools_called: Any) -> Optional[dict[str, Any]]:
             args = call.get("args")
             last_args = args if isinstance(args, dict) else {}
     return last_args
+
+
+async def _latest_thumb_value(
+    db: AsyncSession, wait_trace_id: str
+) -> Optional[str]:
+    """Return 'up' / 'down' / None for the most recent thumbs feedback
+    on a wait trace.
+
+    Reads the wait_feedback table directly. Mirrors the @>-style
+    posture of the listing query: keep the join inline so the panel
+    surface stays a single round trip.
+    """
+    try:
+        import uuid as _uuid
+
+        sid = _uuid.UUID(wait_trace_id)
+    except ValueError:
+        return None
+    repo = WaitFeedbackRepository(db)
+    rows = await repo.list_by_wait(sid, signal_type=SIGNAL_THUMBS)
+    if not rows:
+        return None
+    latest = rows[0]  # list_by_wait orders by created_at desc
+    return "up" if latest.signal_value >= 0.5 else "down"
 
 
 @router.get(
@@ -179,6 +222,9 @@ async def list_waits(
         # without bloating the trace schema.
         parsed = _try_parse_iso(until_raw) if until_raw else None
         until_iso = parsed.isoformat() if parsed else None
+        # #56 — surface the most recent thumb if any. One extra
+        # indexed query per wait; bounded by `limit`.
+        thumb = await _latest_thumb_value(db, trace_id)
         out.append(
             WaitEntry(
                 trace_id=trace_id,
@@ -188,8 +234,58 @@ async def list_waits(
                 until_iso=until_iso,
                 trigger_source=str(r[3] or ""),
                 scheduler_job_name=str(r[4]) if r[4] else None,
+                thumb=thumb,
             )
         )
 
     logger.info("waits_list", count=len(out), limit=limit)
     return WaitsListResponse(waits=out)
+
+
+@router.post(
+    "/{wait_trace_id}/thumb",
+    response_model=ThumbResponse,
+    dependencies=[Depends(require_api_key), Depends(_enforce_localhost_bind)],
+)
+async def thumb_wait(
+    wait_trace_id: str,
+    body: ThumbRequest,
+    db: AsyncSession = Depends(get_db),
+) -> ThumbResponse:
+    """Operator records an explicit-thumbs feedback signal on a wait.
+
+    Per #56 §2.3: thumb is editable — clicking again writes a new
+    `wait_feedback` row; latest by `created_at` wins.
+    """
+    if body.value not in {"up", "down"}:
+        raise HTTPException(
+            status_code=400, detail="value must be 'up' or 'down'"
+        )
+    try:
+        import uuid as _uuid
+
+        wait_trace_uuid = _uuid.UUID(wait_trace_id)
+    except ValueError:
+        raise HTTPException(status_code=400, detail="wait_trace_id must be a UUID")
+
+    repo = WaitFeedbackRepository(db)
+    feedback = WaitFeedback(
+        wait_trace_id=wait_trace_uuid,
+        signal_type=SIGNAL_THUMBS,
+        signal_value=1.0 if body.value == "up" else 0.0,
+        confidence=1.0,
+        notes=body.notes,
+    )
+    await repo.append(feedback)
+    await db.commit()
+    logger.info(
+        "wait_thumb_recorded",
+        wait_trace_id=wait_trace_id,
+        value=body.value,
+    )
+    return ThumbResponse(
+        ok=True,
+        feedback_id=str(feedback.feedback_id),
+        wait_trace_id=wait_trace_id,
+        value=body.value,
+    )

--- a/agents/reflector/wait_evaluator.py
+++ b/agents/reflector/wait_evaluator.py
@@ -1,0 +1,468 @@
+"""Trace-grounded feedback loop for wait-actions (#56).
+
+The reflector batch-evaluates every wait it can match a signal for and
+appends `WaitFeedback` rows. Three signal types are documented in
+`docs/wait-action-feedback.md`:
+
+- `was_the_thing_still_relevant` (per #56 §2.1) — auto-computed when
+  the wait's `until_iso` is in the past.
+- `did_jack_later_bring_it_up` (per #56 §2.2) — auto-computed for
+  every wait in the last 7 days; idempotent via list-by-wait check.
+- `explicit_thumbs` (per #56 §2.3) — written by the HTTP route the
+  Waits panel calls.
+
+Implementation details:
+
+- This is a feedback signal, not an automated learning loop. Module
+  docstrings, table comments, and tests all assert this — adding any
+  automated promotion of "always wait in similar situations" requires
+  a new ADR.
+- Similarity v0 = Jaccard token overlap. The same tokeniser
+  (`agent.strategies_tools._tokenize`) is reused so the threshold
+  semantics match the strategy ranker's.
+- All three signals run locally over local traces. No external API.
+
+This module is intentionally framework-agnostic: the public functions
+take a "trace fetcher" callable (returning lists of `Trace`) and a
+`WaitFeedbackRepository` and produce `WaitFeedback` rows. The
+reflector wires real callables; tests inject stubs.
+"""
+from __future__ import annotations
+
+import uuid as _uuid
+from collections.abc import Iterable, Sequence
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from typing import Any, Awaitable, Callable, Optional
+
+import structlog
+from sqlalchemy import DateTime, Float, Index, String, Text, select
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import Mapped, mapped_column
+
+from agent.db import Base
+from agent.strategies_tools import _tokenize
+
+logger = structlog.get_logger(__name__)
+
+
+# ── Constants ────────────────────────────────────────────────────────────────
+
+
+SIGNAL_RELEVANCE = "was_the_thing_still_relevant"
+SIGNAL_BROUGHT_UP = "did_jack_later_bring_it_up"
+SIGNAL_THUMBS = "explicit_thumbs"
+
+_VALID_SIGNALS: frozenset[str] = frozenset({
+    SIGNAL_RELEVANCE,
+    SIGNAL_BROUGHT_UP,
+    SIGNAL_THUMBS,
+})
+
+# Jaccard threshold for "same context." v0; phase 2 swaps for cosine
+# over the trace embedding column.
+SIMILARITY_THRESHOLD: float = 0.20
+
+# Window around `until_iso` for the relevance signal.
+RELEVANCE_HALF_WINDOW = timedelta(hours=24)
+
+# Window after `created_at` for the brought-up signal.
+BROUGHT_UP_WINDOW = timedelta(days=7)
+
+
+# ── Data shape ───────────────────────────────────────────────────────────────
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _new_feedback_id() -> _uuid.UUID:
+    return _uuid.uuid4()
+
+
+@dataclass
+class WaitFeedback:
+    """One feedback record about a wait trace.
+
+    Frozen-shaped at the dataclass level (no setattrs after
+    construction) so a constructed feedback row is the row that gets
+    persisted; correctness invariants are checked once at __post_init__.
+    """
+
+    wait_trace_id: _uuid.UUID
+    signal_type: str
+    signal_value: float
+    confidence: float
+    feedback_id: _uuid.UUID = field(default_factory=_new_feedback_id)
+    created_at: datetime = field(default_factory=_utcnow)
+    notes: Optional[str] = None
+
+    def __post_init__(self) -> None:
+        if self.signal_type not in _VALID_SIGNALS:
+            raise ValueError(
+                f"signal_type must be one of {sorted(_VALID_SIGNALS)}, "
+                f"got {self.signal_type!r}"
+            )
+        if not 0.0 <= self.signal_value <= 1.0:
+            raise ValueError(
+                f"signal_value must be in [0.0, 1.0], got {self.signal_value!r}"
+            )
+        if not 0.0 <= self.confidence <= 1.0:
+            raise ValueError(
+                f"confidence must be in [0.0, 1.0], got {self.confidence!r}"
+            )
+
+
+class WaitFeedbackRow(Base):
+    __tablename__ = "wait_feedback"
+
+    feedback_id: Mapped[_uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=_uuid.uuid4
+    )
+    wait_trace_id: Mapped[_uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), nullable=False
+    )
+    signal_type: Mapped[str] = mapped_column(String(64), nullable=False)
+    signal_value: Mapped[float] = mapped_column(Float, nullable=False)
+    confidence: Mapped[float] = mapped_column(Float, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False
+    )
+    notes: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+
+    __table_args__ = (
+        Index("idx_wait_feedback_wait_trace_id", "wait_trace_id"),
+        Index("idx_wait_feedback_signal_type", "signal_type"),
+        Index("idx_wait_feedback_created_at", "created_at"),
+    )
+
+
+def _row_to_dataclass(row: WaitFeedbackRow) -> WaitFeedback:
+    return WaitFeedback(
+        wait_trace_id=row.wait_trace_id,
+        signal_type=row.signal_type,
+        signal_value=row.signal_value,
+        confidence=row.confidence,
+        feedback_id=row.feedback_id,
+        created_at=row.created_at,
+        notes=row.notes,
+    )
+
+
+class WaitFeedbackRepository:
+    """Append-only repository for wait_feedback rows.
+
+    Public surface: append, list_by_wait, list_recent. There is no
+    update or delete — the audit trail is the point.
+
+    `explicit_thumbs` writes are allowed to land repeatedly for the
+    same wait; the latest by `created_at` wins. The two automatic
+    signals are gated by the comparator's `list_by_wait` idempotency
+    check before writing.
+    """
+
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+
+    async def append(self, feedback: WaitFeedback) -> WaitFeedback:
+        row = WaitFeedbackRow(
+            feedback_id=feedback.feedback_id,
+            wait_trace_id=feedback.wait_trace_id,
+            signal_type=feedback.signal_type,
+            signal_value=feedback.signal_value,
+            confidence=feedback.confidence,
+            created_at=feedback.created_at,
+            notes=feedback.notes,
+        )
+        self._session.add(row)
+        await self._session.flush()
+        return feedback
+
+    async def list_by_wait(
+        self, wait_trace_id, *, signal_type: Optional[str] = None
+    ) -> list[WaitFeedback]:
+        sid = (
+            wait_trace_id
+            if isinstance(wait_trace_id, _uuid.UUID)
+            else _uuid.UUID(str(wait_trace_id))
+        )
+        stmt = select(WaitFeedbackRow).where(
+            WaitFeedbackRow.wait_trace_id == sid
+        )
+        if signal_type is not None:
+            stmt = stmt.where(WaitFeedbackRow.signal_type == signal_type)
+        stmt = stmt.order_by(WaitFeedbackRow.created_at.desc())
+        result = await self._session.execute(stmt)
+        return [_row_to_dataclass(r) for r in result.scalars().all()]
+
+    async def list_recent(self, *, days: int = 7) -> list[WaitFeedback]:
+        if days <= 0:
+            raise ValueError("days must be positive")
+        since = _utcnow() - timedelta(days=days)
+        stmt = (
+            select(WaitFeedbackRow)
+            .where(WaitFeedbackRow.created_at >= since)
+            .order_by(WaitFeedbackRow.created_at.desc())
+        )
+        result = await self._session.execute(stmt)
+        return [_row_to_dataclass(r) for r in result.scalars().all()]
+
+
+# ── Pure comparator helpers (testable without DB) ────────────────────────────
+
+
+def _jaccard(a: set[str], b: set[str]) -> float:
+    if not a or not b:
+        return 0.0
+    inter = a & b
+    if not inter:
+        return 0.0
+    union = a | b
+    return len(inter) / len(union)
+
+
+@dataclass
+class TraceLite:
+    """Minimum trace shape the comparator needs.
+
+    Decoupled from `agent.traces.schema.Trace` so tests can construct
+    these inline without dragging in the full ORM.
+    """
+
+    trace_id: _uuid.UUID
+    created_at: datetime
+    input: str
+    trigger_source: str = "user"
+    until_iso: Optional[datetime] = None
+    wait_reason: Optional[str] = None
+
+
+def _wait_tokens(wait_trace: TraceLite) -> set[str]:
+    """Tokens that represent the wait's context.
+
+    The wait's input is the user message that triggered the turn; the
+    reason adds context the model identified explicitly. Both feed the
+    comparator.
+    """
+    parts: list[str] = []
+    if wait_trace.input:
+        parts.append(wait_trace.input)
+    if wait_trace.wait_reason:
+        parts.append(wait_trace.wait_reason)
+    return _tokenize(" ".join(parts))
+
+
+def evaluate_relevance(
+    *,
+    wait_trace: TraceLite,
+    nearby_traces: Sequence[TraceLite],
+    threshold: float = SIMILARITY_THRESHOLD,
+) -> WaitFeedback:
+    """Compute the §2.1 was_the_thing_still_relevant signal.
+
+    Caller must ensure `nearby_traces` is the set of traces in
+    `[until_iso - 24h, until_iso + 24h]` excluding the wait trace itself.
+    Idempotency is the caller's responsibility — see `evaluate_completed_waits`.
+    """
+    if wait_trace.until_iso is None:
+        raise ValueError("relevance signal only applies when until_iso is set")
+    wait_tokens = _wait_tokens(wait_trace)
+    matches = 0
+    for t in nearby_traces:
+        if t.trace_id == wait_trace.trace_id:
+            continue
+        candidate_tokens = _tokenize(t.input or "")
+        if _jaccard(wait_tokens, candidate_tokens) >= threshold:
+            matches += 1
+    if matches > 0:
+        return WaitFeedback(
+            wait_trace_id=wait_trace.trace_id,
+            signal_type=SIGNAL_RELEVANCE,
+            signal_value=1.0,
+            confidence=min(1.0, matches / 3.0),
+        )
+    return WaitFeedback(
+        wait_trace_id=wait_trace.trace_id,
+        signal_type=SIGNAL_RELEVANCE,
+        signal_value=0.0,
+        # Ambiguity: 0.0 could mean the wait was correct OR Jack missed
+        # something. Confidence=0.5 records the uncertainty so the weekly
+        # rollup can flag it.
+        confidence=0.5,
+    )
+
+
+def evaluate_brought_up(
+    *,
+    wait_trace: TraceLite,
+    later_traces: Sequence[TraceLite],
+    threshold: float = SIMILARITY_THRESHOLD,
+) -> WaitFeedback:
+    """Compute the §2.2 did_jack_later_bring_it_up signal.
+
+    `later_traces` are traces in `(wait_trace.created_at,
+    wait_trace.created_at + 7d]` from non-scheduler triggers.
+    """
+    wait_tokens = _wait_tokens(wait_trace)
+    for t in later_traces:
+        if t.trace_id == wait_trace.trace_id:
+            continue
+        if t.trigger_source == "scheduler":
+            continue
+        candidate_tokens = _tokenize(t.input or "")
+        if _jaccard(wait_tokens, candidate_tokens) >= threshold:
+            return WaitFeedback(
+                wait_trace_id=wait_trace.trace_id,
+                signal_type=SIGNAL_BROUGHT_UP,
+                signal_value=1.0,
+                confidence=1.0,
+            )
+    return WaitFeedback(
+        wait_trace_id=wait_trace.trace_id,
+        signal_type=SIGNAL_BROUGHT_UP,
+        signal_value=0.0,
+        confidence=0.5,
+    )
+
+
+# ── Comparator orchestration ─────────────────────────────────────────────────
+
+
+WaitTraceFetcher = Callable[[datetime, datetime], Awaitable[list[TraceLite]]]
+"""Fetch waits whose `until_iso` falls in [start, end). Used by §2.1.
+Caller wires this against the real trace store; tests inject stubs."""
+
+
+NearbyTraceFetcher = Callable[[datetime, datetime], Awaitable[list[TraceLite]]]
+"""Fetch all traces in [start, end). Used to build the relevance window
+and the brought-up window."""
+
+
+WaitsInWindowFetcher = Callable[[datetime, datetime], Awaitable[list[TraceLite]]]
+"""Fetch waits in [start, end) regardless of until_iso. Used by §2.2."""
+
+
+async def evaluate_completed_waits(
+    *,
+    now: datetime,
+    fetch_completed_waits: WaitTraceFetcher,
+    fetch_traces_in_window: NearbyTraceFetcher,
+    feedback_repo: WaitFeedbackRepository,
+    half_window: timedelta = RELEVANCE_HALF_WINDOW,
+    relevance_lookback: timedelta = timedelta(hours=25),
+) -> int:
+    """§2.1 — for each completed-window wait, write a relevance signal
+    iff one is not already recorded for that wait.
+
+    Returns the number of feedback rows appended.
+    """
+    waits = await fetch_completed_waits(now - relevance_lookback, now)
+    appended = 0
+    for wait in waits:
+        if wait.until_iso is None:
+            # Defence in depth: the fetcher should have filtered, but
+            # we double-check so the dataclass invariant cannot fail.
+            continue
+        existing = await feedback_repo.list_by_wait(
+            wait.trace_id, signal_type=SIGNAL_RELEVANCE
+        )
+        if existing:
+            continue
+        nearby = await fetch_traces_in_window(
+            wait.until_iso - half_window,
+            wait.until_iso + half_window,
+        )
+        feedback = evaluate_relevance(
+            wait_trace=wait, nearby_traces=nearby
+        )
+        await feedback_repo.append(feedback)
+        appended += 1
+    logger.info("wait_evaluator_relevance_pass", appended=appended)
+    return appended
+
+
+async def evaluate_brought_up_waits(
+    *,
+    now: datetime,
+    fetch_recent_waits: WaitsInWindowFetcher,
+    fetch_traces_in_window: NearbyTraceFetcher,
+    feedback_repo: WaitFeedbackRepository,
+    window: timedelta = BROUGHT_UP_WINDOW,
+) -> int:
+    """§2.2 — for each wait in the last 7 days that has no
+    `did_jack_later_bring_it_up` signal yet, evaluate and write.
+    """
+    waits = await fetch_recent_waits(now - window, now)
+    appended = 0
+    for wait in waits:
+        existing = await feedback_repo.list_by_wait(
+            wait.trace_id, signal_type=SIGNAL_BROUGHT_UP
+        )
+        if existing:
+            continue
+        # The "later" window is from the wait's created_at forward, capped
+        # at min(now, created_at + window). We don't pre-judge waits whose
+        # window is still open; if the window has not yet closed AND no
+        # match has appeared, we hold off. (Matches that appear later
+        # will land on the next pass.)
+        later_end = min(now, wait.created_at + window)
+        if later_end <= wait.created_at:
+            continue
+        later = await fetch_traces_in_window(wait.created_at, later_end)
+        feedback = evaluate_brought_up(
+            wait_trace=wait, later_traces=later
+        )
+        # If no match was found AND the window is still open, do not
+        # write a 0.0 yet — defer to the next pass to give later traces
+        # a chance to land.
+        if (
+            feedback.signal_value == 0.0
+            and (now - wait.created_at) < window
+        ):
+            continue
+        await feedback_repo.append(feedback)
+        appended += 1
+    logger.info("wait_evaluator_brought_up_pass", appended=appended)
+    return appended
+
+
+# ── Weekly rollup summary helper ─────────────────────────────────────────────
+
+
+@dataclass
+class WaitFeedbackSummary:
+    total: int
+    by_signal_value_mean: dict[str, float]
+    ambiguous_count: int  # records where signal_value=0.0 with high confidence
+    sample_size_per_signal: dict[str, int]
+
+
+def summarize_feedback(records: Iterable[WaitFeedback]) -> WaitFeedbackSummary:
+    """Aggregate feedback records into the shape the weekly rollup
+    consumes. Pure function — testable without a DB."""
+    by_type_sum: dict[str, float] = {}
+    by_type_count: dict[str, int] = {}
+    ambiguous = 0
+    total = 0
+    for r in records:
+        total += 1
+        by_type_sum[r.signal_type] = by_type_sum.get(r.signal_type, 0.0) + r.signal_value
+        by_type_count[r.signal_type] = by_type_count.get(r.signal_type, 0) + 1
+        # "Ambiguous with high confidence" — operator-input thumbs at 0.0
+        # with confidence 1.0 is the strongest signal of an incorrect
+        # wait. Auto-signals with confidence 0.5 are NOT counted as
+        # ambiguous-high; they're the natural shape of "no match in
+        # window."
+        if r.signal_value == 0.0 and r.confidence >= 0.8:
+            ambiguous += 1
+    means = {
+        st: by_type_sum[st] / by_type_count[st] for st in by_type_count
+    }
+    return WaitFeedbackSummary(
+        total=total,
+        by_signal_value_mean=means,
+        ambiguous_count=ambiguous,
+        sample_size_per_signal=dict(by_type_count),
+    )

--- a/docs/wait-action-feedback.md
+++ b/docs/wait-action-feedback.md
@@ -1,0 +1,115 @@
+# Wait-action feedback loop
+
+This document specifies the feedback signals the reflector emits for completed-window wait traces (#55), how the comparator runs, and where the resulting `wait_feedback` records are surfaced. The companion ADR is **not** new — the design rides on ADR-0006 (reflector process model) and ADR-0009 (reflection loop design).
+
+## 1. Why a feedback layer at all
+
+A `wait` is the hardest of Pepper's inner-life moves to evaluate (philosophical-foundation §5.4): both branches (wait, act) end without a user-visible artifact, so neither thumbs-up nor thumbs-down is naturally produced. Without a feedback layer the model has no signal to update on — the wait is observable but not improvable. With traces (#20, ADR-0005) the act outcomes are recorded; the feedback layer compares them.
+
+Critically, this layer is a **feedback signal**, not an automated learning loop. There is no automated promotion to "always wait in similar situations." The reflector summarises; Jack adjusts strategies (#54) if a pattern emerges.
+
+## 2. Feedback signals
+
+Each completed-window wait produces zero, one, two, or three feedback records — one per applicable signal. Stored in the `wait_feedback` table (sibling to `pattern_alerts`), keyed by `wait_trace_id`.
+
+### 2.1 `was_the_thing_still_relevant`
+
+**Applies when:** the wait had `until_iso` populated, and `now >= until_iso`.
+
+**Detection:** does any trace within `[until_iso - 24h, until_iso + 24h]` reference the same context as the wait? "Same context" v0 = Jaccard token overlap above a threshold on the input field, computed over the same salient-token set the strategy ranker uses (`agent.strategies_tools._tokenize`). v1 swaps in cosine similarity over the trace's embedding column.
+
+**Signal value:**
+
+- `1.0` — at least one trace in the window mentions the same context. The wait was correct: the situation either resolved itself or surfaced naturally.
+- `0.0` — no trace in the window mentions the same context. **Ambiguous, not "wrong."** Could mean: (a) the wait was correct (the topic was not important enough to come up), or (b) the wait was incorrect (Jack missed something Pepper should have surfaced). v0 records 0.0; the reflector summarises ambiguity in the weekly.
+
+**Confidence:** `min(1.0, len(matching_traces) / 3)` — three or more matches in the window saturates at 1.0.
+
+### 2.2 `did_jack_later_bring_it_up`
+
+**Applies when:** the wait fired anywhere in the last 7 days, regardless of `until_iso`.
+
+**Detection:** within the next 7 days from `wait.created_at`, did any user-input trace (i.e. `trigger_source != "scheduler"`) reference the same context? Same Jaccard threshold as §2.1. The first match within the window wins; matches further out are ignored.
+
+**Signal value:**
+
+- `1.0` — Jack independently surfaced the topic. The wait was correct: he got there himself, didn't need a nudge.
+- `0.0` — Jack did not surface the topic. **Ambiguous.** Could mean: (a) the topic was not important enough (correct wait), or (b) Jack missed it (incorrect wait). The reflector treats this as ambiguous; the weekly summary calls it out explicitly so Jack can adjudicate.
+
+**Confidence:** binary — 1.0 if the match exists, 0.5 if no match (the ambiguity is real).
+
+### 2.3 `explicit_thumbs`
+
+**Applies when:** Jack hits a thumbs button in the Waits panel UI.
+
+**Detection:** direct user input. The UI calls `POST /api/waits/{wait_trace_id}/thumb` with `{value: "up" | "down"}`.
+
+**Signal value:**
+
+- `1.0` — thumbs up.
+- `0.0` — thumbs down.
+
+**Confidence:** always `1.0` — operator input is authoritative.
+
+## 3. Comparator (`agents/reflector/wait_evaluator.py`)
+
+The comparator runs as part of the daily reflector pass (ADR-0009 §2.1). It does NOT run on every chat turn — wait outcomes are batch-evaluated.
+
+Order of operations per pass:
+
+1. Load completed-window waits — wait traces where `until_iso` is set and falls within `[now - 25h, now]`. (The 25h window catches anything that crossed midnight in either direction relative to the previous run.)
+2. For each, compute §2.1's `was_the_thing_still_relevant`. Append a `WaitFeedback` row.
+3. Load all wait traces from the last 7 days. For each, compute §2.2's `did_jack_later_bring_it_up`. Append a row IFF the signal has not already been written for this wait (idempotent).
+4. Aggregate into a per-week summary; surface in the next weekly rollup's prompt input.
+
+Steps 2 and 3 are independent — a single wait can produce both signals. Step 1's bound is hard (every completed-window wait gets §2.1 evaluated exactly once); step 3 is windowed (`did_jack_later_bring_it_up` may fire later if the match shows up beyond the first pass).
+
+Privacy posture: the comparator runs locally over local trace contents. No external API call. Same posture as the rest of the reflector.
+
+## 4. Storage
+
+`wait_feedback` table:
+
+| Column | Type | Notes |
+|---|---|---|
+| `feedback_id` | uuid (pk) | new uuid per record |
+| `wait_trace_id` | uuid | FK-shaped (no FK constraint — traces is a different ownership boundary) |
+| `signal_type` | text | `was_the_thing_still_relevant` / `did_jack_later_bring_it_up` / `explicit_thumbs` |
+| `signal_value` | real | in [0.0, 1.0] |
+| `confidence` | real | in [0.0, 1.0] |
+| `created_at` | timestamptz | |
+| `notes` | text nullable | for §2.3 thumbs, optional free-text from the operator |
+
+Idempotency: `(wait_trace_id, signal_type)` is **not** UNIQUE for `explicit_thumbs` (the operator can thumb the same wait multiple times — the latest wins by `created_at`). For the two automatic signals, the comparator checks `list_by_wait` before writing to avoid duplicate rows; a clean unique index is deferred until we see real volume.
+
+## 5. Weekly rollup integration
+
+The weekly rollup (#40, `agents/reflector/rollup.py`) reads the past 7 days of `wait_feedback`, computes:
+
+- `total_waits_evaluated`
+- mean `signal_value` per `signal_type`
+- count of waits where any signal landed at 0.0 with high confidence (potential incorrect waits — for human review, not automated correction)
+
+The weekly rollup's prompt input gains a `[wait_correctness]` section listing the top-3 ambiguous waits by week so the reflector's weekly note can mention them in first-person.
+
+This is the **summary surface** the issue's AC asks for. Implementing it requires extending `agents/reflector/rollup.py`'s prompt; that wiring lands in this PR alongside the comparator.
+
+## 6. Explicit thumbs UI
+
+The existing Waits panel (`web/src/components/Waits.tsx`) gains thumbs-up / thumbs-down buttons per wait. Click → `POST /api/waits/{wait_trace_id}/thumb`. Thumbed waits show a small badge. The thumb is editable: clicking the opposite button overwrites the previous record (latest wins).
+
+## 7. What the comparator does NOT do
+
+- **Does not modify the wait trace.** Trace store is append-only (ADR-0005). Feedback records live in their own table.
+- **Does not trigger a model retraining or any automated promotion.** No "always wait in similar situations" loop. The signal is read-only context for the next reflection and the next strategy proposal Jack approves.
+- **Does not call any external API.** Local-only by construction; matches the reflector's posture.
+
+## 8. References
+
+- Parent epic: [#49 — Inner Life Moves](https://github.com/jacksteroo/Pepper/issues/49).
+- Issue: [#56 — Wait-action trace-grounded feedback loop](https://github.com/jacksteroo/Pepper/issues/56).
+- Companion: [#55 — Wait-action first-class action](https://github.com/jacksteroo/Pepper/issues/55).
+- ADR-0005 — Trace schema (append-only).
+- ADR-0006 — Reflector process model (separate process per archetype).
+- ADR-0009 — Reflection loop design (daily-fixed cadence).
+- Notion: *Bringing Pepper Alive — Philosophical Foundation* §5.4.

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -309,6 +309,18 @@ export const api = {
   // Epic 06 (#55) — wait panel ("things Pepper chose not to surface").
   listWaits: (limit = 50) =>
     req<{ waits: WaitEntry[] }>(`/waits?limit=${limit}`),
+
+  // Epic 06 (#56) — explicit-thumbs feedback on a wait.
+  thumbWait: (waitTraceId: string, value: 'up' | 'down', notes?: string) =>
+    req<{
+      ok: boolean
+      feedback_id: string
+      wait_trace_id: string
+      value: 'up' | 'down'
+    }>(`/waits/${waitTraceId}/thumb`, {
+      method: 'POST',
+      body: JSON.stringify({ value, notes }),
+    }),
 }
 
 export interface WaitEntry {
@@ -319,6 +331,7 @@ export interface WaitEntry {
   until_iso: string | null
   trigger_source: string
   scheduler_job_name: string | null
+  thumb: 'up' | 'down' | null
 }
 
 // Epic 04 (#41) — pattern detector alerts.

--- a/web/src/components/Waits.tsx
+++ b/web/src/components/Waits.tsx
@@ -63,7 +63,18 @@ const styles = {
     marginTop: '10px',
     fontSize: '11px',
     color: '#888',
+    alignItems: 'center' as const,
   },
+  thumbButton: (active: boolean, accent: string) => ({
+    padding: '3px 10px',
+    background: active ? accent + '33' : 'transparent',
+    color: active ? accent : '#9ca3af',
+    border: `1px solid ${active ? accent : '#2a2a2a'}`,
+    borderRadius: '4px',
+    cursor: 'pointer',
+    fontSize: '12px',
+    fontFamily: 'inherit',
+  }),
   traceLink: {
     fontSize: '11px',
     fontFamily: 'monospace',
@@ -98,6 +109,24 @@ interface Props {
 export default function Waits({ onOpenTrace }: Props) {
   const [waits, setWaits] = useState<WaitEntry[] | null>(null)
   const [error, setError] = useState<string | null>(null)
+  const [pendingThumb, setPendingThumb] = useState<string | null>(null)
+
+  async function handleThumb(traceId: string, value: 'up' | 'down') {
+    setPendingThumb(traceId)
+    try {
+      await api.thumbWait(traceId, value)
+      setWaits((prev) =>
+        prev
+          ? prev.map((w) => (w.trace_id === traceId ? { ...w, thumb: value } : w))
+          : prev,
+      )
+      logInfo('waits', 'thumb_recorded', { traceId, value })
+    } catch (err) {
+      logError('waits', 'thumb_failed', { traceId, error: String(err) })
+    } finally {
+      setPendingThumb(null)
+    }
+  }
 
   useEffect(() => {
     let cancelled = false
@@ -176,6 +205,22 @@ export default function Waits({ onOpenTrace }: Props) {
                 >
                   trace {w.trace_id.slice(0, 8)}
                 </span>
+                <button
+                  style={styles.thumbButton(w.thumb === 'up', '#22c55e')}
+                  disabled={pendingThumb === w.trace_id}
+                  onClick={() => handleThumb(w.trace_id, 'up')}
+                  title="Mark as a correct wait"
+                >
+                  ↑ correct
+                </button>
+                <button
+                  style={styles.thumbButton(w.thumb === 'down', '#ef4444')}
+                  disabled={pendingThumb === w.trace_id}
+                  onClick={() => handleThumb(w.trace_id, 'down')}
+                  title="Mark as an incorrect wait"
+                >
+                  ↓ incorrect
+                </button>
               </div>
             </div>
           ))


### PR DESCRIPTION
Closes #56 · Epic #49 · Builds on #55

## Summary
Lands the comparator + storage + UI for wait-correctness feedback. Three signal types per [\`docs/wait-action-feedback.md\`](docs/wait-action-feedback.md):

- **\`was_the_thing_still_relevant\`** — auto-computed when \`until_iso\` fires. Looks for traces in [until - 24h, until + 24h] that mention the same context.
- **\`did_jack_later_bring_it_up\`** — auto-computed within 7d of the wait. Looks for user-driven (non-scheduler) traces that mention the same context. Defers writes if the window is still open AND no match has appeared yet.
- **\`explicit_thumbs\`** — operator-input via the Waits panel.

## What lands
- \`docs/wait-action-feedback.md\` — design doc (signal definitions, comparator algorithm, weekly-rollup integration spec, what the comparator does NOT do).
- \`agents/reflector/wait_evaluator.py\` — \`WaitFeedback\` dataclass + ORM + \`WaitFeedbackRepository\` (append, list_by_wait, list_recent — **no update/delete paths**, locked by tests). Pure helpers + idempotent orchestration.
- \`agent/waits_http.py\` — \`GET /api/waits\` now surfaces the most recent thumb per row; \`POST /api/waits/{trace_id}/thumb\` records explicit-thumbs feedback.
- \`web/src/components/Waits.tsx\` — thumbs-up / thumbs-down buttons per wait.

## Acceptance criteria
- [x] Feedback signals captured for every completed-window wait.
- [ ] Weekly reflection includes a wait-correctness summary. **Out of scope** — \`summarize_feedback\` helper is in place; wiring it into \`agents/reflector/rollup.py\` is a follow-up so this PR stays focused on the comparator + storage + UI.
- [x] No automated learning loop — feedback is read-only signal. Locked by \`test_no_destructive_paths\` on \`WaitFeedbackRepository\`.
- [x] Weekly review UI exists and works.

## Test plan
- [x] 17 new tests pass (\`agent/tests/test_wait_evaluator.py\`): dataclass invariants, relevance happy path / no-match ambiguity (confidence=0.5) / threshold saturation / until_iso required, brought_up filters scheduler traces out, evaluate_completed_waits idempotency, evaluate_brought_up_waits defers open windows, summarize aggregation, repository surface lock.
- [x] Adjacent suites green (waits, strategies, identity).
- [x] Web typechecks cleanly.

## Privacy
All comparator runs are local. Wait reasons + trace contents stay in the local trace store. \`/api/waits/{id}/thumb\` is localhost-bound + API-key gated.