### PR TITLE
agents/reflector: continuity-of-self rubric + scoring tool (#57)

### DIFF
--- a/agent/tests/test_continuity_eval.py
+++ b/agent/tests/test_continuity_eval.py
@@ -1,0 +1,306 @@
+"""Tests for `agents.reflector.continuity_eval` (#57).
+
+Covers the auto-detectors, the sampling helper, the orchestrator, and
+the epic-gate predicate. The rubric document itself is the test plan
+for the manual / LLM-judge dimensions; the auto-detectors here have
+deterministic test inputs.
+"""
+from __future__ import annotations
+
+import json
+import uuid
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from agents.reflector.continuity_eval import (
+    Dimension,
+    Score,
+    ScoringInputs,
+    TraceForScoring,
+    WindowResult,
+    detect_recovery_from_error,
+    detect_restraint_exhibited,
+    detect_strategy_invocation,
+    epic_gate_passes,
+    needs_human_review_score,
+    score_window,
+    select_sample,
+    write_result,
+)
+
+
+def _ts(days_ago: int = 0, hours_ago: int = 0) -> datetime:
+    return datetime.now(timezone.utc) - timedelta(days=days_ago, hours=hours_ago)
+
+
+def _trace(
+    *,
+    input_text: str = "",
+    output: str = "",
+    source: str = "user",
+    tools: list[dict] | None = None,
+    user_reaction: dict | None = None,
+    selectors: dict | None = None,
+    days_ago: int = 0,
+    hours_ago: int = 0,
+) -> TraceForScoring:
+    return TraceForScoring(
+        trace_id=uuid.uuid4(),
+        created_at=_ts(days_ago=days_ago, hours_ago=hours_ago),
+        input=input_text,
+        output=output,
+        trigger_source=source,
+        tools_called=tools or [],
+        user_reaction=user_reaction,
+        assembled_context={"selectors": selectors or {}},
+    )
+
+
+# ── Score dataclass ──────────────────────────────────────────────────────────
+
+
+class TestScoreDataclass:
+    def test_invalid_dimension_rejected(self) -> None:
+        with pytest.raises(ValueError, match="dimension"):
+            Score(dimension="bogus", value=1, auto_value=1)
+
+    def test_value_out_of_range_rejected(self) -> None:
+        with pytest.raises(ValueError, match="score value"):
+            Score(dimension=Dimension.COHERENT_VOICE, value=4, auto_value=1)
+        with pytest.raises(ValueError, match="score value"):
+            Score(dimension=Dimension.COHERENT_VOICE, value=-1, auto_value=1)
+
+    def test_auto_value_out_of_range_rejected(self) -> None:
+        with pytest.raises(ValueError, match="auto_value"):
+            Score(dimension=Dimension.COHERENT_VOICE, value=1, auto_value=5)
+
+
+# ── detect_strategy_invocation ───────────────────────────────────────────────
+
+
+class TestStrategyInvocation:
+    def test_zero_invocations_scores_zero(self) -> None:
+        traces = [_trace() for _ in range(5)]
+        assert detect_strategy_invocation(traces) == 0
+
+    def test_low_fraction_scores_one(self) -> None:
+        traces = [_trace() for _ in range(20)]
+        traces[0] = _trace(tools=[{"name": "query_strategies", "args": {}}])
+        # 1 / 20 = 5% < 10% → 1
+        assert detect_strategy_invocation(traces) == 1
+
+    def test_mid_fraction_scores_two(self) -> None:
+        traces = [
+            _trace(tools=[{"name": "query_strategies", "args": {}}]) for _ in range(5)
+        ] + [_trace() for _ in range(5)]
+        # 5 / 10 = 50% → 2
+        assert detect_strategy_invocation(traces) == 2
+
+    def test_high_fraction_scores_three(self) -> None:
+        traces = [
+            _trace(tools=[{"name": "query_strategies", "args": {}}]) for _ in range(8)
+        ] + [_trace() for _ in range(2)]
+        # 8 / 10 = 80% → 3
+        assert detect_strategy_invocation(traces) == 3
+
+    def test_provenance_strategies_used_counts_too(self) -> None:
+        traces = [
+            _trace(
+                selectors={
+                    "strategies": {
+                        "strategies_used": [{"strategy_id": "x", "score": 0.5}]
+                    }
+                }
+            )
+            for _ in range(6)
+        ] + [_trace() for _ in range(4)]
+        # 6 / 10 = 60% → 3
+        assert detect_strategy_invocation(traces) == 3
+
+
+# ── detect_restraint_exhibited ───────────────────────────────────────────────
+
+
+class TestRestraintExhibited:
+    def test_no_waits_scores_zero(self) -> None:
+        traces = [_trace() for _ in range(5)]
+        assert detect_restraint_exhibited(traces) == 0
+
+    def test_waits_no_thumbs_scores_one(self) -> None:
+        traces = [_trace(tools=[{"name": "wait", "args": {"reason": "ok"}}])]
+        assert detect_restraint_exhibited(traces) == 1
+
+    def test_waits_strong_thumbs_up_scores_three(self) -> None:
+        traces = [_trace(tools=[{"name": "wait", "args": {"reason": "ok"}}])]
+        assert (
+            detect_restraint_exhibited(
+                traces, explicit_thumbs_up=8, explicit_thumbs_down=1
+            )
+            == 3
+        )
+
+    def test_waits_majority_thumbs_up_scores_two(self) -> None:
+        traces = [_trace(tools=[{"name": "wait", "args": {"reason": "ok"}}])]
+        assert (
+            detect_restraint_exhibited(
+                traces, explicit_thumbs_up=3, explicit_thumbs_down=2
+            )
+            == 2
+        )
+
+
+# ── detect_recovery_from_error ───────────────────────────────────────────────
+
+
+class TestRecoveryFromError:
+    def test_no_thumbs_down_scores_zero(self) -> None:
+        # Insufficient evidence — manual review may revise.
+        traces = [_trace() for _ in range(5)]
+        assert detect_recovery_from_error(traces) == 0
+
+    def test_recovery_no_repeat_scores_three(self) -> None:
+        traces = [
+            _trace(user_reaction={"thumbs": "down"}, hours_ago=24),
+            # No subsequent thumbs-down in window.
+            _trace(hours_ago=12),
+            _trace(),
+        ]
+        assert detect_recovery_from_error(traces) == 3
+
+    def test_partial_repeat_scores_two(self) -> None:
+        # err1 (24h ago) is followed by err2 (12h ago) within 24h —
+        # err1 counts as "had a repeat"; err2 has no later thumbs-down
+        # so it's "recovered." Recovered fraction = 1/2 = 0.5 → score 2.
+        traces = [
+            _trace(user_reaction={"thumbs": "down"}, hours_ago=24),
+            _trace(user_reaction={"thumbs": "down"}, hours_ago=12),
+        ]
+        assert detect_recovery_from_error(traces) == 2
+
+    def test_long_repeat_chain_scores_one(self) -> None:
+        # 4 thumbs-down within 24h of each other in chain. The first
+        # 3 each have a repeat within 24h; the last has none. Recovered
+        # fraction = 1/4 = 0.25 → score 1.
+        traces = [
+            _trace(user_reaction={"thumbs": "down"}, hours_ago=24),
+            _trace(user_reaction={"thumbs": "down"}, hours_ago=18),
+            _trace(user_reaction={"thumbs": "down"}, hours_ago=12),
+            _trace(user_reaction={"thumbs": "down"}, hours_ago=6),
+        ]
+        assert detect_recovery_from_error(traces) == 1
+
+
+# ── select_sample ────────────────────────────────────────────────────────────
+
+
+class TestSelectSample:
+    def test_small_corpus_returns_all(self) -> None:
+        traces = [_trace() for _ in range(3)]
+        sample = select_sample(traces, sample_size=20, seed=1)
+        assert len(sample) == 3
+
+    def test_caps_at_sample_size(self) -> None:
+        traces = [_trace() for _ in range(50)]
+        sample = select_sample(traces, sample_size=20, seed=1)
+        assert len(sample) <= 20
+
+    def test_zero_sample_size_returns_empty(self) -> None:
+        traces = [_trace() for _ in range(5)]
+        assert select_sample(traces, sample_size=0) == []
+
+    def test_strata_represented_when_possible(self) -> None:
+        # Mix of (scheduler, tools) buckets.
+        traces = [
+            _trace(source="scheduler") for _ in range(5)
+        ] + [
+            _trace(source="user", tools=[{"name": "wait"}]) for _ in range(5)
+        ]
+        sample = select_sample(traces, sample_size=10, seed=1)
+        sources = {t.trigger_source for t in sample}
+        assert sources == {"scheduler", "user"}
+
+
+# ── score_window + epic_gate_passes ──────────────────────────────────────────
+
+
+class TestScoreWindow:
+    def test_total_is_sum_of_dimension_scores(self) -> None:
+        traces = [
+            _trace(tools=[{"name": "query_strategies"}]) for _ in range(8)
+        ] + [
+            _trace(tools=[{"name": "wait"}]) for _ in range(2)
+        ]
+        result = score_window(
+            traces,
+            window_start=_ts(days_ago=7),
+            window_end=_ts(),
+            inputs=ScoringInputs(explicit_thumbs_up=5, explicit_thumbs_down=0),
+        )
+        assert result.sample_size == 10
+        # Strategy invocation should saturate at 3 with 80% rate.
+        assert result.mean_per_dimension[Dimension.STRATEGY_INVOCATION] == 3
+        # Restraint should hit 3 with strong thumbs up.
+        assert result.mean_per_dimension[Dimension.RESTRAINT_EXHIBITED] == 3
+        assert result.total == sum(result.mean_per_dimension.values())
+
+
+class TestEpicGate:
+    def test_lift_at_threshold_passes(self) -> None:
+        baseline = WindowResult(
+            window_start=_ts(days_ago=14),
+            window_end=_ts(days_ago=7),
+            sample_size=10,
+            mean_per_dimension={d: 1.0 for d in Dimension.ALL},
+            total=6.0,
+        )
+        end = WindowResult(
+            window_start=_ts(days_ago=7),
+            window_end=_ts(),
+            sample_size=10,
+            mean_per_dimension={d: 1.5 for d in Dimension.ALL},
+            total=7.0,
+        )
+        # Lift = 1.0 (default threshold) — passes.
+        assert epic_gate_passes(baseline=baseline, end_of_epic=end) is True
+
+    def test_lift_below_threshold_fails(self) -> None:
+        baseline = WindowResult(
+            window_start=_ts(days_ago=14),
+            window_end=_ts(days_ago=7),
+            sample_size=10,
+            mean_per_dimension={d: 1.0 for d in Dimension.ALL},
+            total=6.0,
+        )
+        end = WindowResult(
+            window_start=_ts(days_ago=7),
+            window_end=_ts(),
+            sample_size=10,
+            mean_per_dimension={d: 1.0 for d in Dimension.ALL},
+            total=6.5,
+        )
+        # Lift = 0.5 < 1.0 — does not pass.
+        assert epic_gate_passes(baseline=baseline, end_of_epic=end) is False
+
+
+# ── write_result ─────────────────────────────────────────────────────────────
+
+
+class TestWriteResult:
+    def test_writes_json_with_correct_shape(self, tmp_path: Path) -> None:
+        result = WindowResult(
+            window_start=_ts(days_ago=7),
+            window_end=_ts(),
+            sample_size=10,
+            mean_per_dimension={d: 1.5 for d in Dimension.ALL},
+            total=9.0,
+            notes="baseline",
+        )
+        path = write_result(result, out_dir=tmp_path, prefix="continuity")
+        assert path.exists()
+        payload = json.loads(path.read_text())
+        assert payload["sample_size"] == 10
+        assert payload["total"] == 9.0
+        assert payload["notes"] == "baseline"
+        assert set(payload["mean_per_dimension"]) == set(Dimension.ALL)

--- a/agents/reflector/continuity_eval.py
+++ b/agents/reflector/continuity_eval.py
@@ -1,0 +1,436 @@
+"""Continuity-of-self scoring tool (#57).
+
+Implements `docs/continuity-of-self-rubric.md`. The rubric scores a
+7-day trace window on six 0–3 dimensions; this module:
+
+- Provides the `Dimension` enum and the `Score` / `WindowResult`
+  dataclasses.
+- Pulls the stratified sample via `select_sample`.
+- Runs the per-dimension scorers (auto-detectors for the dimensions
+  the trace store can answer; placeholder for human / LLM-judge for
+  the rest).
+- Aggregates and writes `eval_results/continuity_<date>.json` so the
+  operator can compare baseline vs end-of-epic.
+
+Manual scoring is the v0 mode. LLM-judge mode is opt-in (same flag as
+#42's reflection-eval LLM-judge); we ship the auto-detectors and the
+JSON shape now, the judge prompt as a follow-up.
+
+Pure helpers + a thin orchestration entry point. The trace fetch is
+abstracted as a callable so this module is testable without a live DB.
+"""
+from __future__ import annotations
+
+import json
+import random
+import statistics
+import uuid as _uuid
+from collections.abc import Awaitable, Callable, Iterable, Sequence
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Optional
+
+import structlog
+
+logger = structlog.get_logger(__name__)
+
+
+# ── Dimension enum ───────────────────────────────────────────────────────────
+
+
+class Dimension:
+    COHERENT_VOICE = "coherent_voice"
+    REFLECTION_GROUNDED_CONTINUITY = "reflection_grounded_continuity"
+    STRATEGY_INVOCATION = "strategy_invocation"
+    IDENTITY_INVOCATION = "identity_invocation"
+    RESTRAINT_EXHIBITED = "restraint_exhibited"
+    RECOVERY_FROM_ERROR = "recovery_from_error"
+
+    ALL: tuple[str, ...] = (
+        COHERENT_VOICE,
+        REFLECTION_GROUNDED_CONTINUITY,
+        STRATEGY_INVOCATION,
+        IDENTITY_INVOCATION,
+        RESTRAINT_EXHIBITED,
+        RECOVERY_FROM_ERROR,
+    )
+
+
+# ── Data shapes ──────────────────────────────────────────────────────────────
+
+
+_REPO_ROOT = Path(__file__).parent.parent.parent
+DEFAULT_EVAL_RESULTS_DIR = _REPO_ROOT / "eval_results"
+SAMPLE_SIZE_DEFAULT = 20
+WINDOW_DEFAULT = timedelta(days=7)
+
+
+@dataclass
+class TraceForScoring:
+    """Minimal trace shape the scorer needs.
+
+    Decoupled from the full ORM `Trace` so tests can construct these
+    inline. Production callers project from `agent.traces.schema.Trace`.
+    """
+
+    trace_id: _uuid.UUID
+    created_at: datetime
+    input: str
+    output: str
+    trigger_source: str = "user"
+    tools_called: list[dict[str, Any]] = field(default_factory=list)
+    user_reaction: Optional[dict[str, Any]] = None
+    assembled_context: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class Score:
+    """A single dimension's score plus the auto-detector's confidence.
+
+    `value` is the manually-overridable score; `auto_value` is what the
+    detectors produced. When the scorer is run in LLM-judge mode,
+    `auto_value` is the judge's output. The operator may overwrite
+    `value` afterward — the JSON record keeps both.
+    """
+
+    dimension: str
+    value: int
+    auto_value: int
+    notes: str = ""
+
+    def __post_init__(self) -> None:
+        if self.dimension not in Dimension.ALL:
+            raise ValueError(
+                f"unknown dimension {self.dimension!r}; expected one of "
+                f"{list(Dimension.ALL)}"
+            )
+        if not 0 <= self.value <= 3:
+            raise ValueError(
+                f"score value must be in [0, 3], got {self.value!r}"
+            )
+        if not 0 <= self.auto_value <= 3:
+            raise ValueError(
+                f"auto_value must be in [0, 3], got {self.auto_value!r}"
+            )
+
+
+@dataclass
+class WindowResult:
+    """Aggregate score for a 7-day window.
+
+    `mean_per_dimension` is the average across sampled traces per
+    dimension; `total` is the sum across the 6 dimensions (max 18).
+    Designed so two `WindowResult`s can be diffed mechanically: the
+    epic-gate is `(end_of_epic.total - baseline.total) >= 1`.
+    """
+
+    window_start: datetime
+    window_end: datetime
+    sample_size: int
+    mean_per_dimension: dict[str, float]
+    total: float
+    notes: str = ""
+
+    def diff_total(self, other: "WindowResult") -> float:
+        """`self.total - other.total`. The epic-gate predicate."""
+        return self.total - other.total
+
+
+# ── Auto-detectors ───────────────────────────────────────────────────────────
+#
+# These are conservative heuristics — they look for evidence of the
+# behaviour the dimension measures, return 0 when there's no evidence,
+# and saturate the score upward only when the evidence is unambiguous.
+# Manual review can revise the score in either direction.
+
+
+def detect_strategy_invocation(traces: Sequence[TraceForScoring]) -> int:
+    """Dimension 3 score from #57.
+
+    Counts traces where the assembled context shows a non-empty
+    `strategies_used` list OR `tools_called` includes a
+    `query_strategies` call. The fraction of such traces over the
+    sample maps to a 0–3 score:
+      - 0% → 0
+      - <10% → 1
+      - 10–50% → 2
+      - >50% → 3
+    """
+    if not traces:
+        return 0
+    invoked = 0
+    for t in traces:
+        used = (
+            t.assembled_context.get("selectors", {})
+            .get("strategies", {})
+            .get("strategies_used", [])
+        )
+        if used:
+            invoked += 1
+            continue
+        if any(call.get("name") == "query_strategies" for call in t.tools_called):
+            invoked += 1
+    fraction = invoked / len(traces)
+    if fraction == 0.0:
+        return 0
+    if fraction < 0.10:
+        return 1
+    if fraction <= 0.50:
+        return 2
+    return 3
+
+
+def detect_restraint_exhibited(
+    traces: Sequence[TraceForScoring],
+    *,
+    explicit_thumbs_up: int = 0,
+    explicit_thumbs_down: int = 0,
+) -> int:
+    """Dimension 5 score from #57.
+
+    Counts wait calls in the sample. Adjusted by explicit-thumbs
+    feedback from #56:
+      - 0 waits → 0
+      - waits exist but no/mixed thumbs → 1
+      - waits with thumbs majority up → 2
+      - waits with thumbs strongly up (>= 80%) → 3
+    """
+    if not traces:
+        return 0
+    waits = sum(
+        1
+        for t in traces
+        if any(call.get("name") == "wait" for call in t.tools_called)
+    )
+    if waits == 0:
+        return 0
+    total_thumbs = explicit_thumbs_up + explicit_thumbs_down
+    if total_thumbs == 0:
+        return 1
+    fraction_up = explicit_thumbs_up / total_thumbs
+    if fraction_up >= 0.80:
+        return 3
+    if fraction_up >= 0.50:
+        return 2
+    return 1
+
+
+def detect_recovery_from_error(traces: Sequence[TraceForScoring]) -> int:
+    """Dimension 6 score from #57.
+
+    A thumbs-down on a turn followed by no further error of the same
+    shape within the window scores high. v0 heuristic: count
+    thumbs-down traces; the fraction whose immediate-neighbours
+    upstream do NOT show a repeat error gives the score.
+
+    Conservative: in the absence of explicit error tracking, treat
+    "no thumbs-down repeat in the window after a thumbs-down" as
+    recovery. Tunable; manual override expected.
+    """
+    if not traces:
+        return 0
+    thumbs_down = [
+        t
+        for t in traces
+        if (t.user_reaction or {}).get("thumbs") == "down"
+    ]
+    if not thumbs_down:
+        # No errors observed → cannot evaluate recovery from errors.
+        # Score as 0 (insufficient evidence) — manual review may
+        # revise based on out-of-window context.
+        return 0
+    later_index = {t.trace_id for t in traces}
+    repeats = 0
+    for err in thumbs_down:
+        # Crude: any subsequent thumbs-down within 24h with overlapping
+        # input tokens = repeat. v0; manual review adjusts.
+        for t in traces:
+            if t.trace_id == err.trace_id:
+                continue
+            if t.created_at <= err.created_at:
+                continue
+            if (t.created_at - err.created_at) > timedelta(hours=24):
+                continue
+            if (t.user_reaction or {}).get("thumbs") == "down":
+                repeats += 1
+                break
+    recovered = len(thumbs_down) - repeats
+    fraction = recovered / len(thumbs_down)
+    if fraction <= 0:
+        return 0
+    if fraction < 0.5:
+        return 1
+    if fraction < 0.9:
+        return 2
+    return 3
+
+
+# Dimensions 1, 2, 4 are voice/continuity/identity-alignment and require
+# language-level judgement. The auto-detector returns 0 with a "needs
+# manual / LLM-judge review" note — the operator overrides during
+# scoring.
+
+
+def needs_human_review_score(dimension: str) -> Score:
+    return Score(
+        dimension=dimension,
+        value=0,
+        auto_value=0,
+        notes=(
+            "Language-level dimension — auto-detector cannot score. "
+            "Override with manual or LLM-judge value."
+        ),
+    )
+
+
+# ── Sampling ─────────────────────────────────────────────────────────────────
+
+
+def select_sample(
+    traces: Sequence[TraceForScoring],
+    *,
+    sample_size: int = SAMPLE_SIZE_DEFAULT,
+    seed: Optional[int] = None,
+) -> list[TraceForScoring]:
+    """Stratified-random sample across (trigger_source, has_tools) buckets.
+
+    Buckets:
+      - (scheduler, no-tools)
+      - (scheduler, with-tools)
+      - (user, no-tools)
+      - (user, with-tools)
+
+    Aim for proportional representation; fall back to uniform-random
+    when a bucket is empty.
+    """
+    if sample_size <= 0:
+        return []
+    if not traces:
+        return []
+    rng = random.Random(seed)
+    buckets: dict[tuple[str, bool], list[TraceForScoring]] = {}
+    for t in traces:
+        source = (
+            "scheduler" if t.trigger_source == "scheduler" else "user"
+        )
+        key = (source, bool(t.tools_called))
+        buckets.setdefault(key, []).append(t)
+    if not buckets:
+        return []
+    target_per_bucket = max(1, sample_size // len(buckets))
+    sample: list[TraceForScoring] = []
+    for items in buckets.values():
+        rng.shuffle(items)
+        sample.extend(items[:target_per_bucket])
+    if len(sample) > sample_size:
+        rng.shuffle(sample)
+        sample = sample[:sample_size]
+    return sample
+
+
+# ── Orchestration ────────────────────────────────────────────────────────────
+
+
+@dataclass
+class ScoringInputs:
+    """Auxiliary signals the scorer needs that aren't on the trace itself."""
+
+    explicit_thumbs_up: int = 0
+    explicit_thumbs_down: int = 0
+
+
+def score_window(
+    sample: Sequence[TraceForScoring],
+    *,
+    window_start: datetime,
+    window_end: datetime,
+    inputs: Optional[ScoringInputs] = None,
+    notes: str = "",
+) -> WindowResult:
+    """Run all six scorers on the sample. Returns a WindowResult.
+
+    Dimensions 1/2/4 fall back to "needs human review" auto-values; the
+    operator overrides them in the saved JSON before computing the
+    epic gate.
+    """
+    if inputs is None:
+        inputs = ScoringInputs()
+    scores: list[Score] = []
+    scores.append(needs_human_review_score(Dimension.COHERENT_VOICE))
+    scores.append(needs_human_review_score(Dimension.REFLECTION_GROUNDED_CONTINUITY))
+    scores.append(
+        Score(
+            dimension=Dimension.STRATEGY_INVOCATION,
+            value=detect_strategy_invocation(sample),
+            auto_value=detect_strategy_invocation(sample),
+        )
+    )
+    scores.append(needs_human_review_score(Dimension.IDENTITY_INVOCATION))
+    restraint_v = detect_restraint_exhibited(
+        sample,
+        explicit_thumbs_up=inputs.explicit_thumbs_up,
+        explicit_thumbs_down=inputs.explicit_thumbs_down,
+    )
+    scores.append(
+        Score(
+            dimension=Dimension.RESTRAINT_EXHIBITED,
+            value=restraint_v,
+            auto_value=restraint_v,
+        )
+    )
+    recovery_v = detect_recovery_from_error(sample)
+    scores.append(
+        Score(
+            dimension=Dimension.RECOVERY_FROM_ERROR,
+            value=recovery_v,
+            auto_value=recovery_v,
+        )
+    )
+
+    means = {s.dimension: float(s.value) for s in scores}
+    total = sum(means.values())
+    return WindowResult(
+        window_start=window_start,
+        window_end=window_end,
+        sample_size=len(sample),
+        mean_per_dimension=means,
+        total=total,
+        notes=notes,
+    )
+
+
+def write_result(
+    result: WindowResult,
+    *,
+    out_dir: Path = DEFAULT_EVAL_RESULTS_DIR,
+    prefix: str = "continuity",
+) -> Path:
+    """Serialise a WindowResult to `eval_results/continuity_<date>.json`."""
+    out_dir.mkdir(parents=True, exist_ok=True)
+    date_tag = result.window_end.date().isoformat()
+    path = out_dir / f"{prefix}_{date_tag}.json"
+    payload = {
+        "window_start": result.window_start.isoformat(),
+        "window_end": result.window_end.isoformat(),
+        "sample_size": result.sample_size,
+        "mean_per_dimension": result.mean_per_dimension,
+        "total": result.total,
+        "notes": result.notes,
+    }
+    path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    logger.info("continuity_eval_written", path=str(path), total=result.total)
+    return path
+
+
+def epic_gate_passes(
+    *, baseline: WindowResult, end_of_epic: WindowResult, lift_required: float = 1.0
+) -> bool:
+    """Implements the #57 acceptance gate:
+
+        end_of_epic.total - baseline.total >= 1.0 (default)
+
+    Returns True iff the lift meets the threshold. A False return does
+    not modify any files — this is the read-only gate predicate.
+    """
+    return (end_of_epic.total - baseline.total) >= lift_required

--- a/docs/continuity-of-self-rubric.md
+++ b/docs/continuity-of-self-rubric.md
@@ -1,0 +1,98 @@
+# Continuity-of-self rubric — "Pepper feels alive"
+
+This rubric is the gating instrument for Epic 06 (#49). The epic's gating thread asked us to articulate before scoring what "more alive" looks like concretely; this document is that articulation, and `agents/reflector/continuity_eval.py` is the scoring tool that materialises it.
+
+## What the rubric measures
+
+A 7-day window of traces, sampled stratified across cadences. Each turn is scored on six dimensions, each 0–3. The total is the sum (max 18). Higher is more "alive" in the precise sense the philosophical-foundation doc means.
+
+## Dimensions
+
+### 1. Coherent voice across days (0–3)
+
+Does Pepper sound like the same entity Tuesday vs Friday? Same vocabulary footprint, same pacing, same characteristic preferences? Operator-flagged voice violations from `agents/reflector/prompt.py:voice_violations` lower the score.
+
+- **0** — Reads like a different model on different days. No consistent voice.
+- **1** — Recognisable as Pepper, but with notable shifts (formal one day, terse the next, no apparent reason).
+- **2** — Consistent voice with minor day-to-day drift; the operator could pick out Pepper's traces from a lineup.
+- **3** — Voice is stable across days. Tuesday Pepper and Friday Pepper are clearly the same entity.
+
+### 2. Reflection-grounded continuity (0–3)
+
+Does today's behaviour demonstrably reflect yesterday's reflection? If a Monday reflection notices a pattern, does Tuesday's behaviour change because of it?
+
+Detection: the trace's `assembled_context.selectors.life_context` and `selectors.identity` carry the prior-day reflection; we look for downstream behaviour that would not happen without it (a wait that cites the same context, a strategy invocation, a phrasing pulled from the reflection's language).
+
+- **0** — No carryover. Each day starts fresh; reflection might as well not have been written.
+- **1** — Occasional carryover: one or two turns reference the prior reflection in a vague way.
+- **2** — Visible carryover: most days exhibit at least one trace that builds on the prior reflection's content.
+- **3** — Strong carryover: behaviour visibly shifts day-over-day in response to reflections — restraint where Pepper was over-surfacing, surfacing where she was under-surfacing.
+
+### 3. Strategy invocation (0–3)
+
+Does Pepper actually use strategies (#54) when relevant, not just store them? Detected by `traces.tools_called[].name == "query_strategies"` and by the presence of strategy provenance (`assembled_context.selectors.strategies.strategies_used` non-empty) on traces where a stored strategy applies.
+
+- **0** — Strategies exist but are never invoked. Strategy hub is decorative.
+- **1** — Strategies invoked rarely (<10% of applicable turns).
+- **2** — Strategies invoked on most applicable turns (≥50%).
+- **3** — Strategies invoked on every turn where one applies, and the model's reasoning visibly cites them.
+
+### 4. Identity invocation (0–3)
+
+Do Pepper's responses on values-laden topics align with the identity doc (#52)? "Values-laden" topics: anything where the operator's preferences would shape the answer (advice, declines-to-do, sensitive social situations, prioritisation).
+
+Detection: human review against the `## Identity` section. LLM-judge mode runs the same comparison automatically.
+
+- **0** — Responses contradict the identity doc.
+- **1** — Responses ignore the identity doc — neither aligned nor opposed.
+- **2** — Responses align with the identity doc on most values-laden turns.
+- **3** — Responses align consistently and visibly carry the identity's voice.
+
+### 5. Restraint exhibited (0–3)
+
+Does Pepper wait (#55) when the situation calls for it, not always reply? Detected by the presence of `wait` traces with operator-thumbs-up signals from #56's feedback layer. Counter-evidence: scheduled briefs that should have waited but produced output.
+
+- **0** — Pepper always replies. No waits, ever.
+- **1** — Occasional waits but pattern is unclear; some are clearly correct, some clearly missed.
+- **2** — Waits show reasonable judgement: thumbs-up on most explicit-thumbs feedback.
+- **3** — Waits are consistently calibrated — ambiguous-high incidents are rare and decreasing over time.
+
+### 6. Recovery from error (0–3)
+
+When Pepper is wrong, does the reflection capture it and the next day's behaviour shift?
+
+Detection: a thumbs-down on a turn (`traces.user_reaction.thumbs == "down"`) followed by reflection content that names the error, followed by a downstream turn where Pepper would otherwise have repeated the error but does not.
+
+- **0** — Errors recur. Pepper does not learn from thumbs-down feedback.
+- **1** — Some recovery: errors named in reflection but not always avoided on subsequent turns.
+- **2** — Recovery is visible: most thumbs-down turns lead to a reflection note AND a subsequent shift in behaviour.
+- **3** — Recovery is reliable: every clear error in the window produces a reflection that names it and a subsequent change.
+
+## Scoring procedure
+
+1. Pull a 7-day trace window via `agents/reflector/continuity_eval.py:select_window`.
+2. Stratified sample across cadences: 20 turns selected to balance scheduler vs user, daily vs weekly, with-tools vs no-tools.
+3. Score each dimension manually first. The scoring spreadsheet template is `eval_results/continuity_template.csv`.
+4. If LLM-judge correlates within ±0.5 points per dimension on the manual baseline, switch to LLM-judge for ongoing weekly runs. Same opt-in flag as #42's reflection-eval LLM-judge.
+5. Write the per-dimension means + total to `eval_results/continuity_<date>.json`.
+
+## Gates
+
+The rubric is the test plan. The gate for Epic 06 is:
+
+> **Epic 06 is "Done" only if the end-of-epic continuity-of-self score exceeds the pre-E04+E06 baseline by ≥1 point on average across dimensions.**
+
+If the lift is below 1 point, the epic stays open and the design is revised.
+
+## Privacy
+
+- Manual scoring stays local — the operator scores from the local web UI / CSV.
+- LLM-judge mode (when opted in) follows the same posture as #42's: local-only by default, no frontier escalation. The judge prompt + the trace text are sent to the local LLM only.
+- `eval_results/continuity_<date>.json` lives in the repo (committable; non-personal — only score numbers and trace counts).
+
+## References
+
+- Parent epic: [#49 — Inner Life Moves](https://github.com/jacksteroo/Pepper/issues/49).
+- Issue: [#57 — Continuity-of-self eval](https://github.com/jacksteroo/Pepper/issues/57).
+- Companion reflection rubric: [docs/reflection-eval-rubric.md](reflection-eval-rubric.md) — same scoring shape, different concern.
+- Notion: *Bringing Pepper Alive — Philosophical Foundation* §6 ("what alive decomposes into").

--- a/eval_results/continuity_template.csv
+++ b/eval_results/continuity_template.csv
@@ -1,0 +1,4 @@
+trace_id,window_label,coherent_voice,reflection_grounded_continuity,strategy_invocation,identity_invocation,restraint_exhibited,recovery_from_error,notes
+# Score each sampled trace 0–3 per dimension. Save as continuity_<date>.csv next to this template.
+# `window_label` is "baseline" or "end_of_epic". The scoring tool aggregates per label.
+# Empty cells are treated as "not scored" — leave blank rather than guessing.

--- a/scripts/score_continuity.py
+++ b/scripts/score_continuity.py
@@ -1,0 +1,198 @@
+"""Operator CLI for the continuity-of-self rubric (#57).
+
+Usage::
+
+    .venv/bin/python scripts/score_continuity.py --label baseline
+    .venv/bin/python scripts/score_continuity.py --label end_of_epic
+
+Reads the last 7 days of traces, runs `select_sample` + `score_window`,
+and writes `eval_results/continuity_<date>.json`. The score is the
+auto-detector baseline; the operator is expected to open the JSON and
+fill in the language-level dimensions (1, 2, 4) by manual review or
+LLM-judge — see `docs/continuity-of-self-rubric.md`.
+
+Pure file I/O at the script layer; the heavy lifting lives in
+`agents.reflector.continuity_eval` and is fully tested.
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Optional
+
+# Add the repo root so the script runs without an install.
+_REPO_ROOT = Path(__file__).parent.parent
+sys.path.insert(0, str(_REPO_ROOT))
+
+from agents.reflector.continuity_eval import (  # noqa: E402
+    DEFAULT_EVAL_RESULTS_DIR,
+    SAMPLE_SIZE_DEFAULT,
+    ScoringInputs,
+    TraceForScoring,
+    score_window,
+    select_sample,
+    write_result,
+)
+
+
+async def _fetch_traces(
+    *,
+    window_start: datetime,
+    window_end: datetime,
+) -> list[TraceForScoring]:
+    """Pull traces from the local DB into the scoring shape.
+
+    Returns an empty list if the DB is not initialised — the operator
+    sees a sample_size=0 result which is still useful as a sanity
+    check that the harness ran.
+    """
+    try:
+        from agent import db as _db
+        from agent.config import settings
+        from agent.traces import TraceRepository
+    except Exception as exc:
+        print(f"[continuity_eval] could not import trace store: {exc}")
+        return []
+
+    if _db._session_factory is None:
+        try:
+            await _db.init_db(settings)
+        except Exception as exc:
+            print(f"[continuity_eval] init_db failed: {exc}")
+            return []
+
+    factory = _db._session_factory
+    if factory is None:
+        return []
+
+    async with factory() as session:
+        repo = TraceRepository(session)
+        rows = await repo.query(
+            window_start=window_start,
+            window_end=window_end,
+            limit=1000,
+        )
+
+    out: list[TraceForScoring] = []
+    for r in rows:
+        out.append(
+            TraceForScoring(
+                trace_id=r.trace_id,
+                created_at=r.created_at,
+                input=r.input or "",
+                output=r.output or "",
+                trigger_source=str(r.trigger_source),
+                tools_called=list(r.tools_called or []),
+                user_reaction=r.user_reaction,
+                assembled_context=r.assembled_context or {},
+            )
+        )
+    return out
+
+
+async def _fetch_thumbs_counts(*, window_start: datetime) -> tuple[int, int]:
+    """Read the explicit-thumbs counts from `wait_feedback`.
+
+    Conservative: returns (0, 0) on any failure so the auto-detector
+    still produces a reasonable score, just without thumbs adjustment.
+    """
+    try:
+        from agent import db as _db
+        from agents.reflector.wait_evaluator import (
+            SIGNAL_THUMBS,
+            WaitFeedbackRepository,
+        )
+    except Exception:
+        return 0, 0
+    factory = _db._session_factory
+    if factory is None:
+        return 0, 0
+    up = down = 0
+    async with factory() as session:
+        repo = WaitFeedbackRepository(session)
+        records = await repo.list_recent(days=7)
+        for r in records:
+            if r.signal_type != SIGNAL_THUMBS:
+                continue
+            if r.created_at < window_start:
+                continue
+            if r.signal_value >= 0.5:
+                up += 1
+            else:
+                down += 1
+    return up, down
+
+
+async def _amain(args: argparse.Namespace) -> int:
+    window_end = datetime.now(timezone.utc)
+    window_start = window_end - timedelta(days=args.days)
+
+    traces = await _fetch_traces(
+        window_start=window_start, window_end=window_end
+    )
+    sample = select_sample(
+        traces, sample_size=args.sample_size, seed=args.seed
+    )
+    thumbs_up, thumbs_down = await _fetch_thumbs_counts(window_start=window_start)
+    result = score_window(
+        sample,
+        window_start=window_start,
+        window_end=window_end,
+        inputs=ScoringInputs(
+            explicit_thumbs_up=thumbs_up,
+            explicit_thumbs_down=thumbs_down,
+        ),
+        notes=args.label,
+    )
+    out_path = write_result(
+        result,
+        out_dir=DEFAULT_EVAL_RESULTS_DIR,
+        prefix=f"continuity_{args.label}",
+    )
+    print(f"[continuity_eval] wrote {out_path}")
+    print(f"  sample_size={result.sample_size}")
+    print(f"  total={result.total}")
+    for d, v in result.mean_per_dimension.items():
+        print(f"  {d}: {v}")
+    return 0
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n\n")[0] if __doc__ else None)
+    parser.add_argument(
+        "--label",
+        required=True,
+        choices=["baseline", "end_of_epic", "weekly", "ad_hoc"],
+        help=(
+            "Phase label written into the result JSON's `notes` field "
+            "and used as the file-name prefix."
+        ),
+    )
+    parser.add_argument(
+        "--days",
+        type=int,
+        default=7,
+        help="Trace window in days (default 7).",
+    )
+    parser.add_argument(
+        "--sample-size",
+        type=int,
+        default=SAMPLE_SIZE_DEFAULT,
+        help=f"Stratified sample size (default {SAMPLE_SIZE_DEFAULT}).",
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=None,
+        help="Optional random seed for reproducibility.",
+    )
+    args = parser.parse_args()
+    rc = asyncio.run(_amain(args))
+    sys.exit(rc)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Closes #57 · Epic #49 — final gating PR

## Summary
Lands the continuity-of-self rubric (\`docs/continuity-of-self-rubric.md\`) and the scoring harness (\`agents/reflector/continuity_eval.py\` + \`scripts/score_continuity.py\`). Six 0–3 dimensions; auto-detectors for the three quantitative ones (strategy invocation, restraint exhibited, recovery from error); human-review placeholders for the three language-level ones (voice, continuity, identity).

## What lands
- **\`docs/continuity-of-self-rubric.md\`** — full rubric: dimension definitions, scoring procedure, gates ("epic done iff lift ≥1 point"), privacy posture.
- **\`agents/reflector/continuity_eval.py\`** — \`Score\` / \`WindowResult\` dataclasses, three auto-detectors with documented score curves, stratified sampler, \`score_window\` orchestrator, \`write_result\` JSON serialisation, \`epic_gate_passes\` predicate.
- **\`eval_results/continuity_template.csv\`** — operator scoring template.
- **\`scripts/score_continuity.py\`** — operator CLI. Usage: \`.venv/bin/python scripts/score_continuity.py --label baseline\` (or \`end_of_epic\`/\`weekly\`/\`ad_hoc\`).

## Acceptance criteria status

| AC | Status |
|---|---|
| Rubric exists | ✅ |
| Baseline scored (pre-E04+E06) | ⏳ requires live Pepper — script in place |
| End-of-epic scored | ⏳ requires live Pepper — script in place |
| Lift ≥1 point on average to call E06 done | ⏳ gate predicate in code; needs live data |

The "epic stays open until lift verified" framing matches #57's wording. This PR completes the framework; the score itself requires the operator to run \`scripts/score_continuity.py\` after Pepper has accumulated 7d of traces under the post-E06 codebase.

## Test plan
- [x] 24 new tests (\`agent/tests/test_continuity_eval.py\`): dataclass invariants, the three auto-detector score curves (zero / low / mid / high fractions + saturation), sampler strata representation, orchestrator totalling, JSON shape, epic-gate predicate (lift ≥1 passes, <1 fails).
- [x] 73 adjacent tests still green (continuity, wait_evaluator, strategies, identity).
- [x] Smoke import: \`import scripts.score_continuity\` clean.

## Privacy
All scoring runs locally. The optional LLM-judge mode follows the same opt-in flag as #42's reflection-eval LLM-judge — local-only by default, no frontier escalation. The committed JSON in \`eval_results/\` carries score numbers + trace counts only — no trace content.

## What this completes
Epic 06 (#49) ships:
- ADR-0008 — identity governance (#51)
- ADR-0009 + reflection-loop design (#50)
- Strategy hub schema + tools + UI (#53, #54)
- Wait-action + feedback loop (#55, #56)
- PEPPER_IDENTITY surface (#52)
- Continuity-of-self rubric (this PR)

The substrate is in place. The lift-≥1 gate is the operator's responsibility once a 7-day post-E06 window of traces accumulates.