### PR TITLE
chore: Docker + WhatsApp bridge fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ RUN pip install --no-cache-dir -e ".[dev]"
 
 # Copy source
 COPY agent/ agent/
+COPY agents/ agents/
 COPY subsystems/ subsystems/
 COPY docs/ docs/
 

--- a/scripts/reconnect_whatsapp.sh
+++ b/scripts/reconnect_whatsapp.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+
+cd "$REPO_ROOT"
+
+echo "Clearing stale Chromium lock files..."
+docker run --rm -v pepper_whatsapp_session:/data alpine \
+    sh -c "rm -f /data/session/SingletonLock /data/session/SingletonSocket /data/session/SingletonCookie"
+
+echo "Restarting whatsapp-bridge..."
+docker-compose restart whatsapp-bridge
+
+echo "Waiting for bridge to start..."
+sleep 5
+
+echo "Tailing logs (Ctrl-C when done scanning QR code)..."
+docker-compose logs -f whatsapp-bridge


### PR DESCRIPTION
## Summary
- Add `COPY agents/ agents/` to Dockerfile — the `agents/` package was missing from the image, causing `ModuleNotFoundError: No module named 'agents'` on startup
- Add `scripts/reconnect_whatsapp.sh` — clears stale Chromium `SingletonLock` files from the `pepper_whatsapp_session` volume and restarts the bridge so WhatsApp can reconnect without manual Docker volume surgery